### PR TITLE
tools: fix dhtchat compile, include random

### DIFF
--- a/tools/dhtchat.cpp
+++ b/tools/dhtchat.cpp
@@ -38,6 +38,7 @@ extern "C" {
 #include <iostream>
 #include <string>
 #include <chrono>
+#include <random>
 
 #include <ctime>
 


### PR DESCRIPTION
`tools/dhtchat.cpp` needs `random` to compile for me (LLVM/OS X) and I suspect would elsewhere as well.