### PR TITLE
Fix building with Cygwin.

### DIFF
--- a/tools/dhtnode.cpp
+++ b/tools/dhtnode.cpp
@@ -153,8 +153,11 @@ main(int argc, char **argv)
             } else if (op == "b") {
                 try {
                     auto addr = splitPort(idstr);
-                    if (not addr.first.empty() and addr.second.empty())
-                        addr.second = std::to_string(DHT_DEFAULT_PORT);
+                    if (not addr.first.empty() and addr.second.empty()){
+                        std::stringstream ss;
+						ss << DHT_DEFAULT_PORT;
+						addr.second = ss.str();
+                    }
                     dht.bootstrap(addr.first.c_str(), addr.second.c_str());
                 } catch (const std::exception& e) {
                     std::cout << e.what() << std::endl;

--- a/tools/tools_common.h
+++ b/tools/tools_common.h
@@ -162,8 +162,11 @@ parseArgs(int argc, char **argv) {
         case 'b':
             if (optarg) {
                 params.bootstrap = splitPort((optarg[0] == '=') ? optarg+1 : optarg);
-                if (not params.bootstrap.first.empty() and params.bootstrap.second.empty())
-                    params.bootstrap.second = std::to_string(DHT_DEFAULT_PORT);
+                if (not params.bootstrap.first.empty() and params.bootstrap.second.empty()){
+                    std::stringstream ss;
+					ss << DHT_DEFAULT_PORT;
+					params.bootstrap.second = ss.str();
+                }
             }
             else
                 params.is_bootstrap_node = true;


### PR DESCRIPTION
I had some issues building the library with cygwin under windows, turns out the toolchain does not have great support for the std::to_string(); method hence using a stringstream is a quick alternative to ensure it builds.