### PR TITLE
Data persistence: only store relevant values

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -609,6 +609,7 @@ private:
 
         bool expired {false};              /* no node, or all nodes expired */
         bool done {false};                 /* search is over, cached for later */
+        bool refilled {false};
         std::vector<SearchNode> nodes {};
         std::vector<Announce> announce {};
         std::vector<Get> callbacks {};

--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -452,7 +452,7 @@ private:
 
         InfoHash middle(const RoutingTable::const_iterator&) const;
 
-        std::vector<std::shared_ptr<Node>> findClosestNodes(const InfoHash id) const;
+        std::vector<std::shared_ptr<Node>> findClosestNodes(const InfoHash id, size_t count = TARGET_NODES) const;
 
         RoutingTable::iterator findBucket(const InfoHash& id);
         RoutingTable::const_iterator findBucket(const InfoHash& id) const;

--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -243,13 +243,6 @@ public:
 
     int pingNode(const sockaddr*, socklen_t);
 
-    /**
-     * Maintains the store. For each storage, if values don't belong there
-     * anymore because this node is too far from the target, values are sent to
-     * the appropriate nodes.
-     */
-    void maintainStore(bool force=false);
-
     time_point periodic(const uint8_t *buf, size_t buflen, const sockaddr *from, socklen_t fromlen);
 
     /**
@@ -886,6 +879,11 @@ private:
     void expireStorage();
     void storageChanged(Storage& st, ValueStorage&);
 
+    /**
+     * For a given storage, if values don't belong there anymore because this
+     * node is too far from the target, values are sent to the appropriate
+     * nodes.
+     */
     size_t maintainStorage(InfoHash id, bool force=false, DoneCallback donecb=nullptr);
 
     // Buckets

--- a/python/tools/benchmark.py
+++ b/python/tools/benchmark.py
@@ -134,7 +134,7 @@ class DhtNetworkSubProcess(NSPopen):
     SHUTDOWN_CLUSTER_REQ      = b"sdc"
     DUMP_STORAGE_REQ          = b"strl"
     MESSAGE_STATS             = b"gms"
-    
+
 
     # tokens
     NOTIFY_TOKEN     = 'notify'
@@ -515,13 +515,13 @@ class PersistenceTest(FeatureTest):
                         DhtNetwork.log("Waiting 15 seconds for packets to work their way effectively.")
                         time.sleep(15)
                     ops_count.append(cluster_ops_count/self.wb.node_num)
-                    
+
                     # checking if values were transfered to new nodes
                     foreign_nodes_before_delete = PersistenceTest.foreign_nodes
                     DhtNetwork.log('[GET]: trying to fetch persistent values')
                     self._dhtGet(consumer, myhash)
                     new_nodes = set(PersistenceTest.foreign_nodes) - set(foreign_nodes_before_delete)
-                    
+
                     self._result(local_values, new_nodes)
 
                 if self._plot:
@@ -602,7 +602,7 @@ class PersistenceTest(FeatureTest):
         nodes = set([])
 
         # prevents garbage collecting of unused flood nodes during the test.
-        flood_nodes = [] 
+        flood_nodes = []
 
         def gottaGetThemAllPokeNodes(nodes=None):
             nonlocal consumer, hashes

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -313,7 +313,7 @@ Dht::RoutingTable::findClosestNodes(const InfoHash id, size_t count) const {
         for (auto n : b.nodes) {
             auto here = std::find_if(nodes.begin(), nodes.end(),
                 [&id,&n](std::shared_ptr<Node> &node) {
-                    return id.xorCmp(node->id, n->id) < 0;
+                    return id.xorCmp(n->id, node->id) < 0;
                 }
             );
             nodes.insert(here, n);
@@ -338,7 +338,9 @@ Dht::RoutingTable::findClosestNodes(const InfoHash id, size_t count) const {
     }
 
     // shrink to the count closest nodes.
-    nodes.resize(count);
+    if (nodes.size() > count) {
+        nodes.resize(count);
+    }
     return nodes;
 }
 
@@ -2381,8 +2383,6 @@ Dht::processMessage(const uint8_t *buf, size_t buflen, const sockaddr *from, soc
     uint16_t ttid = 0;
 
     switch (msg.type) {
-    //TODO: handle case where put was made to node claiming to be outside of a
-    // valid range.
     case MessageType::Error:
         if (msg.tid.length != 4) return;
         if (msg.error_code == 401 && msg.id != zeroes && (msg.tid.matches(TransPrefix::ANNOUNCE_VALUES, &ttid) || msg.tid.matches(TransPrefix::LISTEN, &ttid))) {


### PR DESCRIPTION
We have noticed that nodes could begin transferring values to other nodes that wouldn't appear in other nodes' search cache. So, the process could repeat itself indefinitely.

So, in order to prevent all of this, the nodes now limit themselves to send and receive values only if they think they should store it. Additionally, a major function of the data persistence feature had to be fixed (findClosestNodes).