### PR TITLE
Fix #26: add duration cast

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -26,8 +26,9 @@ time_point from_time_t(std::time_t t) {
 }
 
 std::time_t to_time_t(time_point t) {
-    return std::chrono::system_clock::to_time_t(std::chrono::system_clock::now() + 
-            (t - clock::now()));
+    return std::chrono::system_clock::to_time_t(
+            std::chrono::system_clock::now() +
+            std::chrono::duration_cast<std::chrono::system_clock::duration>(t - clock::now()));
 }
 
 Blob


### PR DESCRIPTION
This fixes #26. This is due to an incompatibility between c++11 and llvm. Since I cannot reproduce the bug easily, I'll let Travis do that for me...