### PR TITLE
Refactoring Dht::sendClosestNodes

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -452,7 +452,7 @@ private:
 
         InfoHash middle(const RoutingTable::const_iterator&) const;
 
-        std::vector<std::shared_ptr<Node>> findClosestNodes(const InfoHash id, size_t count = TARGET_NODES) const;
+        std::vector<std::shared_ptr<Node>> findClosestNodes(const InfoHash id, time_point now, size_t count = TARGET_NODES) const;
 
         RoutingTable::iterator findBucket(const InfoHash& id);
         RoutingTable::const_iterator findBucket(const InfoHash& id) const;
@@ -914,7 +914,7 @@ private:
     int sendCachedPing(Bucket& b);
     bool bucketMaintenance(RoutingTable&);
     static unsigned insertClosestNode(uint8_t *nodes, unsigned numnodes, const InfoHash& id, const Node& n);
-    unsigned bufferClosestNodes(uint8_t *nodes, unsigned numnodes, const InfoHash& id, const Bucket& b) const;
+    void bufferClosestNodes(uint8_t *nodes, const InfoHash& id, const std::vector<std::shared_ptr<Node>>& closest_nodes) const;
     void dumpBucket(const Bucket& b, std::ostream& out) const;
 
     // Nodes

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -303,7 +303,8 @@ Dht::RoutingTable::depth(const RoutingTable::const_iterator& it) const
 }
 
 std::vector<std::shared_ptr<Node>>
-Dht::RoutingTable::findClosestNodes(const InfoHash id, size_t count) const {
+Dht::RoutingTable::findClosestNodes(const InfoHash id, time_point now, size_t count) const
+{
     std::vector<std::shared_ptr<Node>> nodes {};
     auto bucket = findBucket(id);
 
@@ -311,6 +312,9 @@ Dht::RoutingTable::findClosestNodes(const InfoHash id, size_t count) const {
 
     auto sortedBucketInsert = [&](const Bucket &b) {
         for (auto n : b.nodes) {
+            if (not n->isGood(now))
+                continue;
+
             auto here = std::find_if(nodes.begin(), nodes.end(),
                 [&id,&n](std::shared_ptr<Node> &node) {
                     return id.xorCmp(n->id, node->id) < 0;
@@ -2298,7 +2302,7 @@ Dht::maintainStorage(InfoHash id, bool force, DoneCallback donecb) {
 
     bool want4 = true, want6 = true;
 
-    auto nodes = buckets.findClosestNodes(id);
+    auto nodes = buckets.findClosestNodes(id, now);
     if (!nodes.empty()) {
         if (force || id.xorCmp(nodes.back()->id, myid) < 0) {
             for (auto &value : local_storage->values) {
@@ -2314,7 +2318,7 @@ Dht::maintainStorage(InfoHash id, bool force, DoneCallback donecb) {
     }
     else { want4 = false; }
 
-    auto nodes6 = buckets6.findClosestNodes(id);
+    auto nodes6 = buckets6.findClosestNodes(id, now);
     if (!nodes6.empty()) {
         if (force || id.xorCmp(nodes6.back()->id, myid) < 0) {
             for (auto &value : local_storage->values) {
@@ -2623,7 +2627,7 @@ Dht::processMessage(const uint8_t *buf, size_t buflen, const sockaddr *from, soc
         {
             // We store a value only if we think we're part of the
             // SEARCH_NODES nodes around the target id.
-            auto closest_nodes = (from->sa_family == AF_INET ? buckets : buckets6).findClosestNodes(msg.info_hash, SEARCH_NODES);
+            auto closest_nodes = (from->sa_family == AF_INET ? buckets : buckets6).findClosestNodes(msg.info_hash, now, SEARCH_NODES);
             if (msg.info_hash.xorCmp(closest_nodes.back()->id, myid) < 0) {
                 DHT_WARN("[node %s %s] announce too far from the target id. Dropping value.",
                         msg.id.toString().c_str(), print_addr(from, fromlen).c_str());
@@ -3094,14 +3098,14 @@ Dht::insertClosestNode(uint8_t *nodes, unsigned numnodes, const InfoHash& id, co
     return numnodes;
 }
 
-unsigned
-Dht::bufferClosestNodes(uint8_t* nodes, unsigned numnodes, const InfoHash& id, const Bucket& b) const
+void
+Dht::bufferClosestNodes(uint8_t* nodes, const InfoHash& id,
+                        const std::vector<std::shared_ptr<Node>>& closest_nodes) const
 {
-    for (const auto& n : b.nodes) {
-        if (n->isGood(now))
-            numnodes = insertClosestNode(nodes, numnodes, id, *n);
+    size_t numnodes = 0;
+    for (const auto& n : closest_nodes) {
+        numnodes = insertClosestNode(nodes, numnodes, id, *n);
     }
-    return numnodes;
 }
 
 int
@@ -3116,25 +3120,15 @@ Dht::sendClosestNodes(const sockaddr *sa, socklen_t salen, TransId tid,
         want = sa->sa_family == AF_INET ? WANT4 : WANT6;
 
     if ((want & WANT4)) {
-        auto b = buckets.findBucket(id);
-        if (b != buckets.end()) {
-            numnodes = bufferClosestNodes(nodes, numnodes, id, *b);
-            if (std::next(b) != buckets.end())
-                numnodes = bufferClosestNodes(nodes, numnodes, id, *std::next(b));
-            if (b != buckets.begin())
-                numnodes = bufferClosestNodes(nodes, numnodes, id, *std::prev(b));
-        }
+        auto closest_nodes = buckets.findClosestNodes(id, now, TARGET_NODES);
+        bufferClosestNodes(nodes, id, closest_nodes);
+        numnodes = closest_nodes.size();
     }
 
     if ((want & WANT6)) {
-        auto b = buckets6.findBucket(id);
-        if (b != buckets6.end()) {
-            numnodes6 = bufferClosestNodes(nodes6, numnodes6, id, *b);
-            if (std::next(b) != buckets6.end())
-                numnodes6 = bufferClosestNodes(nodes6, numnodes6, id, *std::next(b));
-            if (b != buckets6.begin())
-                numnodes6 = bufferClosestNodes(nodes6, numnodes6, id, *std::prev(b));
-        }
+        auto closest_nodes = buckets6.findClosestNodes(id, now, TARGET_NODES);
+        bufferClosestNodes(nodes6, id, closest_nodes);
+        numnodes6 = closest_nodes.size();
     }
     //DHT_DEBUG("sending closest nodes (%d+%d nodes.)", numnodes, numnodes6);
 


### PR DESCRIPTION
Since 4bee6274, there was some duplication of code around finding the set of closest nodes of an id, I've refactored Dht::sendClosestNodes to use Dht::RoutingTable::findClosestNodes.