### PR TITLE
Search refill optimisation

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -604,6 +604,7 @@ private:
         sa_family_t af;
 
         uint16_t tid;
+        time_point refill_time {time_point::min()};
         time_point step_time {time_point::min()};           /* the time of the last search_step */
         time_point get_step_time {time_point::min()};       /* the time of the last get time */
 

--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -641,6 +641,11 @@ private:
         bool isListening(time_point now) const;
 
         /**
+         * @return The number of non-good search nodes.
+         */
+        unsigned getNumberOfCandidates(time_point now);
+
+        /**
          * ret = 0 : no announce required.
          * ret > 0 : (re-)announce required at time ret.
          */

--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -609,7 +609,6 @@ private:
 
         bool expired {false};              /* no node, or all nodes expired */
         bool done {false};                 /* search is over, cached for later */
-        bool refilled {false};
         std::vector<SearchNode> nodes {};
         std::vector<Announce> announce {};
         std::vector<Get> callbacks {};

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -942,8 +942,14 @@ Dht::searchStep(Search& sr)
     DHT_DEBUG("[search %s IPv%c] step", sr.id.toString().c_str(), sr.af == AF_INET ? '4' : '6');
     sr.step_time = now;
 
-    if (sr.nodes.size()-sr.getNumberOfCandidates(now) < SEARCH_NODES) {
+    /*
+     * The accurate delay between two refills has not been strongly determined.
+     * TODO: Emprical analysis over refill timeout.
+     */
+    if (sr.refill_time + Node::NODE_EXPIRE_TIME < now and sr.nodes.size()-sr.getNumberOfCandidates(now) < SEARCH_NODES) {
         auto added = sr.refill(sr.af == AF_INET ? buckets : buckets6, now);
+        if (added)
+            sr.refill_time = now;
         DHT_WARN("[search %s IPv%c] refilled with %u nodes", sr.id.toString().c_str(), (sr.af == AF_INET) ? '4' : '6', added);
     }
 

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -858,9 +858,16 @@ Dht::Search::insertNode(std::shared_ptr<Node> node, time_point now, const Blob& 
         }*//* else {
             std::cout << "Adding real node " << node->id << " to IPv" << (af==AF_INET?'4':'6') << " synced search " << id << std::endl;
         }*/
-        while (nodes.size()-num_candidates > SEARCH_NODES)
-            if (not removeExpiredNode(now))
-                nodes.pop_back();
+        if (nodes.size()-num_candidates > SEARCH_NODES) {
+            removeExpiredNode(now);
+
+            auto farthest_good_node = std::find_if(nodes.rbegin(), nodes.rend(),
+                    [=](std::shared_ptr<Node>& n) { return n->isGood(now); }
+                    );
+            if (farthest_good_node != nodes.rend()) {
+                nodes.erase(farthest_good_node.base());
+            }
+        }
         expired = false;
     }
     if (not token.empty()) {

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -944,6 +944,12 @@ Dht::searchStep(Search& sr)
 
     /* Check if the first TARGET_NODES (8) live nodes have replied. */
     if (sr.isSynced(now)) {
+
+        if (sr.nodes.size()-sr.getNumberOfCandidates(now) < SEARCH_NODES and not sr.refilled) {
+            auto added = sr.refill(sr.af == AF_INET ? buckets : buckets6, now);
+            DHT_WARN("[search %s IPv%c] refilled with %u nodes", sr.id.toString().c_str(), (sr.af == AF_INET) ? '4' : '6', added);
+        }
+
         if (not sr.callbacks.empty()) {
             // search is synced but some (newer) get operations are not complete
             // Call callbacks when done
@@ -1053,39 +1059,30 @@ Dht::searchStep(Search& sr)
                     return sn.candidate or sn.node->isExpired(now);
                 }) == sr.nodes.size())
         {
-            unsigned added = 0;
-            if (not sr.refilled) {
-                added = sr.refill(sr.af == AF_INET ? buckets : buckets6, now);
-                sr.refilled = true;
+            DHT_ERROR("[search %s IPv%c] expired", sr.id.toString().c_str(), sr.af == AF_INET ? '4' : '6');
+            // no nodes or all expired nodes
+            sr.expired = true;
+            // reset refilled since the search is now expired.
+            sr.refilled = false;
+            if (sr.announce.empty() && sr.listeners.empty()) {
+                // Listening or announcing requires keeping the cluster up to date.
+                sr.done = true;
             }
-            if (added) {
-                DHT_WARN("[search %s IPv%c] refilled with %u nodes", sr.id.toString().c_str(), (sr.af == AF_INET) ? '4' : '6', added);
-            } else {
-                DHT_ERROR("[search %s IPv%c] expired", sr.id.toString().c_str(), sr.af == AF_INET ? '4' : '6');
-                // no nodes or all expired nodes
-                sr.expired = true;
-                // reset refilled since the search is now expired.
-                sr.refilled = false;
-                if (sr.announce.empty() && sr.listeners.empty()) {
-                    // Listening or announcing requires keeping the cluster up to date.
-                    sr.done = true;
+            {
+                auto get_cbs = std::move(sr.callbacks);
+                for (const auto& g : get_cbs) {
+                    if (g.done_cb)
+                        g.done_cb(false, {});
                 }
-                {
-                    auto get_cbs = std::move(sr.callbacks);
-                    for (const auto& g : get_cbs) {
-                        if (g.done_cb)
-                            g.done_cb(false, {});
-                    }
-                }
-                {
-                    std::vector<DoneCallback> a_cbs;
-                    a_cbs.reserve(sr.announce.size());
-                    for (const auto& a : sr.announce)
-                        if (a.callback)
-                            a_cbs.emplace_back(std::move(a.callback));
-                    for (const auto& a : a_cbs)
-                        a(false, {});
-                }
+            }
+            {
+                std::vector<DoneCallback> a_cbs;
+                a_cbs.reserve(sr.announce.size());
+                for (const auto& a : sr.announce)
+                    if (a.callback)
+                        a_cbs.emplace_back(std::move(a.callback));
+                for (const auto& a : a_cbs)
+                    a(false, {});
             }
         }
     }
@@ -1355,7 +1352,7 @@ Dht::Search::refill(const RoutingTable& r, time_point now) {
     auto num_candidates = getNumberOfCandidates(now);
     auto b = r.findBucket(id);
     auto n = b;
-    while (added < SEARCH_NODES && (std::next(n) != r.end() || b != r.begin())) {
+    while (nodes.size()-num_candidates < SEARCH_NODES && (std::next(n) != r.end() || b != r.begin())) {
         if (std::next(n) != r.end()) {
             added += insertBucket(*std::next(n), now);
             n = std::next(n);
@@ -1365,7 +1362,8 @@ Dht::Search::refill(const RoutingTable& r, time_point now) {
             b = std::prev(b);
         }
     }
-    //DHT_WARN("[search %s IPv%c] refilled with %u nodes", id.toString().c_str(), (af == AF_INET) ? '4' : '6', added);
+    refilled = true;
+
     return added;
 }
 


### PR DESCRIPTION
 In order to optimize the refill of a search with good `SearchNode`, the refill is now done at each call of `searchStep()`. A refill will try to add more good nodes to the search until the search has reached `SEARCH_NODES` good nodes.

- [x] Include a notion of delay between two `Search::refill` calls to avoid network flood.


@aberaud: Please let know what you think. I'll squash some of the commits before you merge this when it is acceptable.
