### PR TITLE
Change ascii value to letter value in log

### DIFF
--- a/include/opendht/utils.h
+++ b/include/opendht/utils.h
@@ -90,7 +90,7 @@ struct LogMethod {
     void logPrintable(const uint8_t *buf, size_t buflen) const {
         std::string buf_clean(buflen, '\0');
         for (size_t i=0; i<buflen; i++)
-            buf_clean[i] = buf[i] >= 32 && buf[i] <= 126 ? buf[i] : '.';
+            buf_clean[i] = buf[i] >= ' ' && buf[i] <= '~' ? buf[i] : '.';
         (*this)("%s", buf_clean.c_str());
     }
 private:


### PR DESCRIPTION
As far as ASCII is concerned, using they decimal value of letter / symbol, should not be a problem.
However, some (linux?) distrubution do not base they char on ascii.

Even thought, ASCII is a standard, and may not evolved, that change will make the program more evolution-proof toward those change.

In fact, that's not a bug, but only an undesired futur. (If ASCII change then log may (try to) print unpritable caracter).