### PR TITLE
Update FindMsgpack.cmake fixing "not found" error

### DIFF
--- a/cmake/FindMsgpack.cmake
+++ b/cmake/FindMsgpack.cmake
@@ -7,7 +7,9 @@
 if(NOT MSGPACK_USE_BUNDLED)
   find_package(PkgConfig)
   if (PKG_CONFIG_FOUND)
-    pkg_check_modules(PC_MSGPACK QUIET msgpack)
+    pkg_search_module(PC_MSGPACK QUIET
+      msgpackc>=${Msgpack_FIND_VERSION}
+      msgpack>=${Msgpack_FIND_VERSION})
   endif()
 else()
   set(PC_MSGPACK_INCLUDEDIR)
@@ -19,19 +21,33 @@ endif()
 
 set(MSGPACK_DEFINITIONS ${PC_MSGPACK_CFLAGS_OTHER})
 
-find_path(MSGPACK_INCLUDE_DIR msgpack.h
+find_path(MSGPACK_INCLUDE_DIR msgpack/version_master.h
   HINTS ${PC_MSGPACK_INCLUDEDIR} ${PC_MSGPACK_INCLUDE_DIRS}
   ${LIMIT_SEARCH})
 
-# If we're asked to use static linkage, add libmsgpack.a as a preferred library name.
+if(MSGPACK_INCLUDE_DIR)
+  file(READ ${MSGPACK_INCLUDE_DIR}/msgpack/version_master.h msgpack_version_h)
+  string(REGEX REPLACE ".*MSGPACK_VERSION_MAJOR +([0-9]+).*" "\\1" MSGPACK_VERSION_MAJOR "${msgpack_version_h}")
+  string(REGEX REPLACE ".*MSGPACK_VERSION_MINOR +([0-9]+).*" "\\1" MSGPACK_VERSION_MINOR "${msgpack_version_h}")
+  string(REGEX REPLACE ".*MSGPACK_VERSION_REVISION +([0-9]+).*" "\\1" MSGPACK_VERSION_REVISION "${msgpack_version_h}")
+  set(MSGPACK_VERSION_STRING "${MSGPACK_VERSION_MAJOR}.${MSGPACK_VERSION_MINOR}.${MSGPACK_VERSION_REVISION}")
+else()
+  set(MSGPACK_VERSION_STRING)
+endif()
+
+# If we're asked to use static linkage, add libmsgpack{,c}.a as a preferred library name.
 if(MSGPACK_USE_STATIC)
   list(APPEND MSGPACK_NAMES
+    "${CMAKE_STATIC_LIBRARY_PREFIX}msgpackc${CMAKE_STATIC_LIBRARY_SUFFIX}"
     "${CMAKE_STATIC_LIBRARY_PREFIX}msgpack${CMAKE_STATIC_LIBRARY_SUFFIX}")
 endif()
 
-list(APPEND MSGPACK_NAMES msgpack)
+list(APPEND MSGPACK_NAMES msgpackc msgpack)
 
 find_library(MSGPACK_LIBRARY NAMES ${MSGPACK_NAMES}
+  # Check each directory for all names to avoid using headers/libraries from
+  # different places.
+  NAMES_PER_DIR
   HINTS ${PC_MSGPACK_LIBDIR} ${PC_MSGPACK_LIBRARY_DIRS}
   ${LIMIT_SEARCH})
 
@@ -43,6 +59,6 @@ set(MSGPACK_INCLUDE_DIRS ${MSGPACK_INCLUDE_DIR})
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set MSGPACK_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args(Msgpack DEFAULT_MSG
-                                  MSGPACK_LIBRARY MSGPACK_INCLUDE_DIR)
-
+find_package_handle_standard_args(Msgpack
+  REQUIRED_VARS MSGPACK_LIBRARY MSGPACK_INCLUDE_DIR
+  VERSION_VAR MSGPACK_VERSION_STRING)


### PR DESCRIPTION
This error appeared not long ago after some changes in the msgpack-c project:
```
CMake Error at /usr/share/cmake-3.4/Modules/FindPackageHandleStandardArgs.cmake:148 (message):
  Could NOT find Msgpack (missing: MSGPACK_LIBRARY) (Required is at least
  version "1.2")
Call Stack (most recent call first):
  /usr/share/cmake-3.4/Modules/FindPackageHandleStandardArgs.cmake:388 (_FPHSA_FAILURE_MESSAGE)
  cmake/FindMsgpack.cmake:46 (find_package_handle_standard_args)
  CMakeLists.txt:22 (find_package)
```
The error, and a fix provided by the neovim project, is explained [here](https://github.com/neovim/neovim/pull/4075).