### PR TITLE
Change ascii value to std::isprint() function

### DIFF
--- a/include/opendht/utils.h
+++ b/include/opendht/utils.h
@@ -90,7 +90,7 @@ struct LogMethod {
     void logPrintable(const uint8_t *buf, size_t buflen) const {
         std::string buf_clean(buflen, '\0');
         for (size_t i=0; i<buflen; i++)
-            buf_clean[i] = buf[i] >= 32 && buf[i] <= 126 ? buf[i] : '.';
+            buf_clean[i] = std::isprint(buf[i]) ? buf[i] : '.';
         (*this)("%s", buf_clean.c_str());
     }
 private:


### PR DESCRIPTION
This pull request refere to #34. 

I change the ascii comparaison by the std::ctype::isprint() function, which one is more accurate to the problem.