### PR TITLE
Fix the autotool Makefile, missing pht include

### DIFF
--- a/include/opendht/indexation/pht.h
+++ b/include/opendht/indexation/pht.h
@@ -10,7 +10,9 @@
 #include <iostream>
 #include <sstream>
 
-#include "opendht.h"
+#include "../value.h"
+#include "../dhtrunner.h"
+#include "../infohash.h"
 
 namespace dht {
 namespace indexation {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,7 +12,8 @@ libopendht_la_SOURCES = \
         crypto.cpp \
         securedht.cpp \
         dhtrunner.cpp \
-        default_types.cpp
+        default_types.cpp \
+        indexation/pht.cpp
 
 if WIN32
 libopendht_la_SOURCES += rng.cpp
@@ -28,4 +29,5 @@ nobase_include_HEADERS = \
         ../include/opendht/securedht.h \
         ../include/opendht/dhtrunner.h \
         ../include/opendht/default_types.h \
-        ../include/opendht/rng.h
+        ../include/opendht/rng.h \
+        ../include/opendht/indexation/pht.h

--- a/src/indexation/pht.cpp
+++ b/src/indexation/pht.cpp
@@ -166,7 +166,6 @@ void Pht::insert(Key k, Value v, Dht::DoneCallbackSimple done_cb) {
     lookupStep(kp, lo, hi, vals,
         [=](std::vector<std::shared_ptr<Value>>& values, Prefix p) {
             *final_prefix = Prefix(p);
-            return true;
         },
         [=](bool ok){
             if (not ok) {


### PR DESCRIPTION
I fixe the Makefile.am from src, cause we were missing the pht file in it.
Now we can create the makefile using autotools again.

( cmake was already update )