### PR TITLE
Prefix bug - A bit may remain in a prefix

### DIFF
--- a/include/opendht/indexation/pht.h
+++ b/include/opendht/indexation/pht.h
@@ -36,7 +36,7 @@ struct Prefix {
     {
         auto rem = size_ % 8;
         if (rem)
-            content_.push_back(p.content_[size_/8] & (0xFF << (7 - rem)));
+            content_.push_back(p.content_[size_/8] & (0xFF << (8 - rem)));
     }
 
     Prefix getPrefix(ssize_t len) const {


### PR DESCRIPTION
Hi,

There is a little bug in the Prefix code.
If you try to get a prefix that is not a multiple of 8, you will get some extra bits. (In fact you will get X % 8 extra bit), even if they are not print they are here.

Here is an example that illustrate that problem, and confirm it
http://pastebin.com/92q0ie6u

For the simplicity of my test i've change the `auto n=size_ / 8` by auto n=2.
Here is the output before patch :
`./test`
`01010101110000000` 
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`^ extra bit here`
Here is the output after recompile all things :
`./test`
`01010101100000000` 

Btw there is an extra bit on the ouput cause i don't change the bn var.

So here is this pull request.
