### PR TITLE
[autotools] pip to uninstall python files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,21 +16,27 @@ AM_PROG_AR
 dnl Check for Doxygen
 AC_ARG_ENABLE([doc], [AS_HELP_STRING([--disable-doc], [Disable documentation generation (doxygen)])])
 AS_IF([test "x$enable_doc" != "xno"], [
-  AC_CHECK_PROGS([DOXYGEN], [doxygen])
-  AS_IF([test -z "$DOXYGEN"],[AC_MSG_WARN([Doxygen not found - continuing without Doxygen support])])
-])
+       AC_CHECK_PROGS([DOXYGEN], [doxygen])
+       AS_IF([test -z "$DOXYGEN"],[AC_MSG_WARN([Doxygen not found - continuing without Doxygen support])])
+       ])
 AM_CONDITIONAL([HAVE_DOXYGEN], [test -n "$DOXYGEN"])
 
 dnl Check for Python
 AC_ARG_ENABLE([python], [AS_HELP_STRING([--disable-python], [Disble python binding])])
 AS_IF([test "x$enable_python" != "xno"], [
-  AM_PATH_PYTHON([3.3],, [:])
-  AS_IF([test -n "$PYTHON"],[
-    AC_CHECK_PROGS([CYTHON], [cython])
-    AS_IF([test -z "$CYTHON"],[AC_MSG_WARN([Cython not found - continuing without python support])])
-  ])
-])
+       AM_PATH_PYTHON([3.3],, [:])
+       AS_IF([test -n "$PYTHON"],[
+              AC_CHECK_PROGS([CYTHON], [cython])
+              AS_IF([test -z "$CYTHON"],[AC_MSG_WARN([Cython not found - continuing without python support])])
+              ])
+       ])
 AM_CONDITIONAL([USE_CYTHON], [test -n "$CYTHON"])
+dnl Check for pip support (uninstall)
+AS_IF([test -n "$PYTHON"],[
+       AC_CHECK_PROGS([PIP], [pip3])
+       AS_IF([test -z "$PIP"],[AC_MSG_WARN([pip not found - continuing without python uninstall support])])
+       AM_CONDITIONAL([HAVE_PIP], [test -n "$PIP"])
+       ])
 
 case "${host_os}" in
   "")

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -1,5 +1,7 @@
 if USE_CYTHON
 
+PYTHON_INSTALL_RECORD = $(builddir)/install_record.txt
+
 pybuild.stamp:
 	LDFLAGS="-L$(top_srcdir)/src/.libs" $(PYTHON) setup.py build_ext --inplace
 	echo stamp > pybuild.stamp
@@ -8,15 +10,18 @@ CLEANFILES = pybuild.stamp
 
 all-local: pybuild.stamp
 clean-local:
-	rm -rf $(builddir)/build $(builddir)/*.so
+	rm -rf $(builddir)/build $(builddir)/*.so $(PYTHON_INSTALL_RECORD)
 
 install-exec-local:
-	$(PYTHON) setup.py install
+	$(PYTHON) setup.py install --record $(PYTHON_INSTALL_RECORD)
 	rm -rf $(builddir)/build
 
 if HAVE_PIP
 uninstall-local:
 	/usr/bin/yes | $(PIP) uninstall $(PACKAGE)
+else
+uninstall-local:
+	while read -r file; do rm -rvf $$file ; done <$(PYTHON_INSTALL_RECORD)
 endif
 
 endif

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -10,8 +10,13 @@ all-local: pybuild.stamp
 clean-local:
 	rm -rf $(builddir)/build $(builddir)/*.so
 
-install:
+install-exec-local:
 	$(PYTHON) setup.py install
 	rm -rf $(builddir)/build
+
+if HAVE_PIP
+uninstall-local:
+	/usr/bin/yes | $(PIP) uninstall $(PACKAGE)
+endif
 
 endif

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -19,9 +19,7 @@ install-exec-local:
 if HAVE_PIP
 uninstall-local:
 	/usr/bin/yes | $(PIP) uninstall $(PACKAGE)
-else
-uninstall-local:
-	while read -r file; do rm -rvf $$file ; done <$(PYTHON_INSTALL_RECORD)
 endif
 
 endif
+


### PR DESCRIPTION
As highlighted in #45, autotools files didn't provide a way for uninstalling opendht python module. So I've written a solution for this using `pip`.

@aberaud: since python naming convention differ from platform to platform, I've chosen to check for the binary `pip3` for explicitely specifying the python version and since our python module is written in Python3. Tell me if this way is okay with you.