### PR TITLE
[Bug] Correction of function commonBits

### DIFF
--- a/include/opendht/indexation/pht.h
+++ b/include/opendht/indexation/pht.h
@@ -87,7 +87,7 @@ struct Prefix {
         auto longest_prefix_size = std::min(p1.size_, p2.size_);
 
         for (i = 0; i < longest_prefix_size; i++) {
-            if (p1.content_.data()[i] != p2.content_.data()[i])
+            if (p1.content_.data()[i] != p2.content_.data()[i] || i == longest_prefix_size)
                 break;
         }
 


### PR DESCRIPTION
Hi,

I was trying to make my cache working, and during my test i test the function commonBits.
According to this test : http://pastebin.com/6qBXp995
**Edit** : In my comment i invert the 2 size of the string.
`_p.size_ = 9` and `p.size_ = 16`

CommonBits should return only 9 as value ( since there is only 9 bits into _p which is a prefix of p).
But in this test it return 10.

It could be related to your bug @sim590. [ You told me about a [random ?] bug into pht]