### PR TITLE
Specifying linking libraries in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,9 @@ if (NOT DEFINED CMAKE_INSTALL_LIBDIR)
 	set(CMAKE_INSTALL_LIBDIR lib)
 endif ()
 
+target_link_libraries(opendht-static gnutls nettle)
+target_link_libraries(opendht gnutls nettle)
+
 if (OPENDHT_TOOLS)
 	add_subdirectory(tools)
 endif ()


### PR DESCRIPTION
As #47 made it clear, it appears that when cmake runs on some platforms, it can't figure out the linking flags itself. This patch adds this.