### PR TITLE
dht: ensure to not copy Storage instances

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -723,6 +723,9 @@ private:
         Storage() {}
         Storage(InfoHash id, time_point now) : id(id), maintenance_time(now+MAX_STORAGE_MAINTENANCE_EXPIRE_TIME) {}
 
+        Storage(Storage&&) noexcept = default;
+        Storage& operator=(Storage&&) = default;
+
         bool empty() const {
             return values.empty();
         }
@@ -769,6 +772,9 @@ private:
         std::pair<ssize_t, ssize_t> expire(const std::map<ValueType::Id, ValueType>& types, time_point now);
 
     private:
+        Storage(const Storage&) = delete;
+        Storage& operator=(const Storage&) = delete;
+
         std::vector<ValueStorage> values {};
         size_t total_size {};
     };

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -195,7 +195,7 @@ Dht::shutdown(ShutdownCallback cb) {
         else DHT_WARN("Shuting down node: %u ops remaining.", *remaining);
     };
 
-    for (auto str : store) {
+    for (const auto& str : store) {
         *remaining += maintainStorage(str.id, true, str_donecb);
     }
     DHT_WARN("Shuting down node: %u ops remaining.", *remaining);
@@ -1527,7 +1527,7 @@ Dht::listen(const InfoHash& id, GetCallback cb, Value::Filter f)
     auto st = findStorage(id);
     size_t tokenlocal = 0;
     if (st == store.end() && store.size() < MAX_HASHES) {
-        store.push_back(Storage {id, now});
+        store.emplace_back(id, now);
         st = std::prev(store.end());
     }
     if (st != store.end()) {
@@ -1782,7 +1782,7 @@ Dht::storageStore(const InfoHash& id, const std::shared_ptr<Value>& value, time_
     if (st == store.end()) {
         if (store.size() >= MAX_HASHES)
             return false;
-        store.push_back(Storage {id, now});
+        store.emplace_back(id, now);
         st = std::prev(store.end());
     }
 
@@ -1838,7 +1838,7 @@ Dht::storageAddListener(const InfoHash& id, const InfoHash& node, const sockaddr
     if (st == store.end()) {
         if (store.size() >= MAX_HASHES)
             return;
-        store.push_back(Storage {id, now});
+        store.emplace_back(id, now);
         st = std::prev(store.end());
     }
     sa_family_t af = from->sa_family;


### PR DESCRIPTION
This path deletes copy-constructor and copy-assignement and
default defines move-contructor and move-assignement methods.
Also uses emplace_back than push_back on dht::store vector
to have a better efficiency.

Signed-off-by: Guillaume Roguez <guillaume.roguez@savoirfairelinux.com>