### PR TITLE
dht: fixes out of range container erase.

### DIFF
--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -864,7 +864,7 @@ Dht::Search::insertNode(std::shared_ptr<Node> node, time_point now, const Blob& 
                 [=](const SearchNode& n) { return n.node->isGood(now) or n.candidate; }
             );
             if (farthest_not_expired_node != nodes.rend()) {
-                nodes.erase(farthest_not_expired_node.base());
+                nodes.erase(std::prev(farthest_not_expired_node.base()));
             } // else, all nodes are expired.
         }
         expired = false;


### PR DESCRIPTION
This case would raise segmentation fault on some Mac OSX platforms when running with the compiled library (LLVM). However, there wasn't any runtime error when running a version compiled with gcc 5.3.0 on GNU/Linux.