### PR TITLE
dht: prevent bad function call in Value::Filter::chain

### DIFF
--- a/include/opendht/value.h
+++ b/include/opendht/value.h
@@ -131,8 +131,15 @@ struct Value
         using std::function<bool(const Value&)>::function;
     public:
         static Filter chain(Filter&& f1, Filter&& f2) {
-            return [f1,f2](const Value& v){
-                return (f1 ? f1(v) : true) && (f2 ? f2(v) : true);
+            if (not f1 and f2)
+                return f2;
+            else if (f1 and not f2)
+                return f1;
+            else if (not f1 and not f2)
+                return {};
+            else
+                return [f1,f2](const Value& v){
+                    return f1(v) && f2(v);
             };
         }
         static Filter chain(std::initializer_list<Filter> l) {
@@ -146,8 +153,15 @@ struct Value
         }
         Filter chain(Filter&& f2) {
             Filter f1 = std::move(*this);
-            return [f1,f2](const Value& v){
-                return (f1 ? f1(v) : true) && (f2 ? f2(v) : true);
+            if (not f1 and f2)
+                return f2;
+            else if (f1 and not f2)
+                return f1;
+            else if (not f1 and not f2)
+                return {};
+            else
+                return [f1,f2](const Value& v){
+                    return f1(v) && f2(v);
             };
         }
     };

--- a/include/opendht/value.h
+++ b/include/opendht/value.h
@@ -132,7 +132,7 @@ struct Value
     public:
         static Filter chain(Filter&& f1, Filter&& f2) {
             return [f1,f2](const Value& v){
-                return f1(v) && f2(v);
+                return (f1 ? f1(v) : true) && (f2 ? f2(v) : true);
             };
         }
         static Filter chain(std::initializer_list<Filter> l) {
@@ -147,7 +147,7 @@ struct Value
         Filter chain(Filter&& f2) {
             Filter f1 = std::move(*this);
             return [f1,f2](const Value& v){
-                return f1(v) && f2(v);
+                return (f1 ? f1(v) : true) && (f2 ? f2(v) : true);
             };
         }
     };


### PR DESCRIPTION
The following code snippet shows how you can use `Value::Filter::chain` in an unsafe way:
```cpp
#include <opendht.h>
int main(int argc, char *argv[]) {
    auto f = dht::Value::Filter::chain({}, {});
    if (f)
        f({});
    return 0;
}
```
Running this code will cause `bad_function_call` exception. Requiring to check both parameters of `Value::Filter::chain` before calling it is nuisance. Making the check in `chain` methods is better. The new behavior of the `chain` methods are logical in the sense that if a filter is not callable, then it doesn't filter anything, so this is equivalent of returning `true`.
