### PR TITLE
dht: consider IPv4 or IPv6 disconnected on operation done

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -167,16 +167,35 @@ public:
      * reannounced on a regular basis.
      * User can call #cancelPut(InfoHash, Value::Id) to cancel a put operation.
      */
-    void put(const InfoHash& key, std::shared_ptr<Value>, DoneCallback cb=nullptr, time_point created=time_point::max());
-    void put(const InfoHash& key, const std::shared_ptr<Value>& v, DoneCallbackSimple cb, time_point created=time_point::max()) {
-        put(key, v, bindDoneCb(cb), created);
+    void put(const InfoHash& key,
+            std::shared_ptr<Value>,
+            DoneCallback cb=nullptr,
+            time_point created=time_point::max(),
+            bool permanent = false);
+    void put(const InfoHash& key,
+            const std::shared_ptr<Value>& v,
+            DoneCallbackSimple cb,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        put(key, v, bindDoneCb(cb), created, permanent);
     }
 
-    void put(const InfoHash& key, Value&& v, DoneCallback cb=nullptr, time_point created=time_point::max()) {
-        put(key, std::make_shared<Value>(std::move(v)), cb, created);
+    void put(const InfoHash& key,
+            Value&& v,
+            DoneCallback cb=nullptr,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        put(key, std::make_shared<Value>(std::move(v)), cb, created, permanent);
     }
-    void put(const InfoHash& key, Value&& v, DoneCallbackSimple cb, time_point created=time_point::max()) {
-        put(key, std::forward<Value>(v), bindDoneCb(cb), created);
+    void put(const InfoHash& key,
+            Value&& v,
+            DoneCallbackSimple cb,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        put(key, std::forward<Value>(v), bindDoneCb(cb), created, permanent);
     }
 
     /**
@@ -306,6 +325,7 @@ private:
      * A single "put" operation data
      */
     struct Announce {
+        bool permanent;
         std::shared_ptr<Value> value;
         time_point created;
         DoneCallback callback;
@@ -457,7 +477,7 @@ private:
      * The values can be filtered by an arbitrary provided filter.
      */
     std::shared_ptr<Search> search(const InfoHash& id, sa_family_t af, GetCallback = nullptr, DoneCallback = nullptr, Value::Filter = Value::AllFilter());
-    void announce(const InfoHash& id, sa_family_t af, std::shared_ptr<Value> value, DoneCallback callback, time_point created=time_point::max());
+    void announce(const InfoHash& id, sa_family_t af, std::shared_ptr<Value> value, DoneCallback callback, time_point created=time_point::max(), bool permanent = false);
     size_t listenTo(const InfoHash& id, sa_family_t af, GetCallback cb, Value::Filter f = Value::AllFilter());
 
     void bootstrapSearch(Search& sr);

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -156,16 +156,16 @@ public:
     void cancelListen(InfoHash h, size_t token);
     void cancelListen(InfoHash h, std::shared_future<size_t> token);
 
-    void put(InfoHash hash, std::shared_ptr<Value> value, DoneCallback cb={});
-    void put(InfoHash hash, std::shared_ptr<Value> value, DoneCallbackSimple cb) {
-        put(hash, value, bindDoneCb(cb));
+    void put(InfoHash hash, std::shared_ptr<Value> value, DoneCallback cb={}, bool permanent = false);
+    void put(InfoHash hash, std::shared_ptr<Value> value, DoneCallbackSimple cb, bool permanent = false) {
+        put(hash, value, bindDoneCb(cb), permanent);
     }
 
-    void put(InfoHash hash, Value&& value, DoneCallback cb={});
-    void put(InfoHash hash, Value&& value, DoneCallbackSimple cb) {
-        put(hash, std::forward<Value>(value), bindDoneCb(cb));
+    void put(InfoHash hash, Value&& value, DoneCallback cb={}, bool permanent = false);
+    void put(InfoHash hash, Value&& value, DoneCallbackSimple cb, bool permanent = false) {
+        put(hash, std::forward<Value>(value), bindDoneCb(cb), permanent);
     }
-    void put(const std::string& key, Value&& value, DoneCallbackSimple cb={});
+    void put(const std::string& key, Value&& value, DoneCallbackSimple cb={}, bool permanent = false);
 
     void cancelPut(const InfoHash& h, const Value::Id& id);
 

--- a/include/opendht/securedht.h
+++ b/include/opendht/securedht.h
@@ -101,9 +101,9 @@ public:
     /**
      * Will take ownership of the value, sign it using our private key and put it in the DHT.
      */
-    void putSigned(const InfoHash& hash, std::shared_ptr<Value> val, DoneCallback callback);
-    void putSigned(const InfoHash& hash, Value&& v, DoneCallback callback) {
-        putSigned(hash, std::make_shared<Value>(std::move(v)), callback);
+    void putSigned(const InfoHash& hash, std::shared_ptr<Value> val, DoneCallback callback, bool permanent = false);
+    void putSigned(const InfoHash& hash, Value&& v, DoneCallback callback, bool permanent = false) {
+        putSigned(hash, std::make_shared<Value>(std::move(v)), callback, permanent);
     }
 
     /**
@@ -111,9 +111,9 @@ public:
      * and put it in the DHT.
      * The operation will be immediate if the recipient' public key is known (otherwise it will be retrived first).
      */
-    void putEncrypted(const InfoHash& hash, const InfoHash& to, std::shared_ptr<Value> val, DoneCallback callback);
-    void putEncrypted(const InfoHash& hash, const InfoHash& to, Value&& v, DoneCallback callback) {
-        putEncrypted(hash, to, std::make_shared<Value>(std::move(v)), callback);
+    void putEncrypted(const InfoHash& hash, const InfoHash& to, std::shared_ptr<Value> val, DoneCallback callback, bool permanent = false);
+    void putEncrypted(const InfoHash& hash, const InfoHash& to, Value&& v, DoneCallback callback, bool permanent = false) {
+        putEncrypted(hash, to, std::make_shared<Value>(std::move(v)), callback, permanent);
     }
 
     /**

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -731,8 +731,6 @@ void
 Dht::searchStep(std::shared_ptr<Search> sr)
 {
     if (not sr or sr->expired or sr->done) return;
-    if (sr->nodes.empty() and (sr->af == AF_INET ? buckets : buckets6).isEmpty())
-        return; // wait for connection
 
     const auto& now = scheduler.time();
     DHT_LOG.DEBUG("[search %s IPv%c] step (%d requests)", sr->id.toString().c_str(), sr->af == AF_INET ? '4' : '6', sr->currentGetRequests());

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -579,9 +579,6 @@ Dht::Search::removeExpiredNode(time_point now)
 bool
 Dht::Search::insertNode(const std::shared_ptr<Node>& snode, time_point now, const Blob& token)
 {
-    if (expired and nodes.empty())
-        return false;
-
     auto& node = *snode;
     const auto& nid = node.id;
 
@@ -895,10 +892,14 @@ Dht::searchStep(std::shared_ptr<Search> sr)
             {
                 std::vector<DoneCallback> a_cbs;
                 a_cbs.reserve(sr->announce.size());
-                for (const auto& a : sr->announce)
-                    if (a.callback)
-                        a_cbs.emplace_back(std::move(a.callback));
-                sr->announce.clear();
+                for (auto ait = sr->announce.begin() ; ait != sr->announce.end(); ) {
+                    if (ait->callback)
+                        a_cbs.emplace_back(std::move(ait->callback));
+                    if (not ait->permanent)
+                        ait = sr->announce.erase(ait);
+                    else
+                        ait++;
+                }
                 for (const auto& a : a_cbs)
                     a(false, {});
             }

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -890,7 +890,7 @@ Dht::searchStep(std::shared_ptr<Search> sr)
                         g.done_cb(false, {});
                 }
             }
-            if (not sr->nodes.empty()) {
+            {
                 std::vector<DoneCallback> a_cbs;
                 a_cbs.reserve(sr->announce.size());
                 for (const auto& a : sr->announce)

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -484,30 +484,30 @@ DhtRunner::cancelListen(InfoHash h, std::shared_future<size_t> token)
 }
 
 void
-DhtRunner::put(InfoHash hash, Value&& value, DoneCallback cb)
+DhtRunner::put(InfoHash hash, Value&& value, DoneCallback cb, bool permanent)
 {
     std::lock_guard<std::mutex> lck(storage_mtx);
     auto sv = std::make_shared<Value>(std::move(value));
     pending_ops.emplace([=](SecureDht& dht) {
-        dht.put(hash, sv, cb);
+        dht.put(hash, sv, cb, {}, permanent);
     });
     cv.notify_all();
 }
 
 void
-DhtRunner::put(InfoHash hash, std::shared_ptr<Value> value, DoneCallback cb)
+DhtRunner::put(InfoHash hash, std::shared_ptr<Value> value, DoneCallback cb, bool permanent)
 {
     std::lock_guard<std::mutex> lck(storage_mtx);
     pending_ops.emplace([=](SecureDht& dht) {
-        dht.put(hash, value, cb);
+        dht.put(hash, value, cb, {}, permanent);
     });
     cv.notify_all();
 }
 
 void
-DhtRunner::put(const std::string& key, Value&& value, DoneCallbackSimple cb)
+DhtRunner::put(const std::string& key, Value&& value, DoneCallbackSimple cb, bool permanent)
 {
-    put(InfoHash::get(key), std::forward<Value>(value), cb);
+    put(InfoHash::get(key), std::forward<Value>(value), cb, permanent);
 }
 
 void

--- a/src/securedht.cpp
+++ b/src/securedht.cpp
@@ -78,7 +78,7 @@ SecureDht::SecureDht(int s, int s6, SecureDht::Config conf)
                 DHT_LOG.DEBUG("SecureDht: public key announced successfully");
             else
                 DHT_LOG.ERR("SecureDht: error while announcing public key!");
-        });
+        }, {}, true);
     }
 }
 


### PR DESCRIPTION
Put and Get wrapped done callbacks need to consider the case only ipv4 **or** ipv6 connection is available. In that case, don't block waiting for the disconnected network and call done callbacks if the operation succeeded on one of the networks.

This bug was introduced by both d44c590 ('put' donecb wouldn't be called) and bd08506 ('get' donecb wouldn't be called)