### PR TITLE
[PHT] Key consistency

### DIFF
--- a/include/opendht/indexation/pht.h
+++ b/include/opendht/indexation/pht.h
@@ -150,7 +150,7 @@ public:
      */
     static constexpr const size_t MAX_NODE_ENTRY_COUNT {16};
 
-    using Key = std::map<std::string, Prefix>;
+    using Key = std::map<std::string, Blob>;
 
     using LookupCallback = std::function<void(std::vector<std::shared_ptr<Value>>& values, Prefix p)>;
     typedef void (*LookupCallbackRaw)(std::vector<std::shared_ptr<Value>>* values, Prefix* p, void *user_data);

--- a/include/opendht/indexation/pht.h
+++ b/include/opendht/indexation/pht.h
@@ -246,7 +246,7 @@ private:
         return k.size() == keySpec_.size() and
             std::equal(k.begin(), k.end(), keySpec_.begin(),
                 [&](const Key::value_type& key, const KeySpec::value_type& key_spec) {
-                    return key.first == key_spec.first;
+                    return key.first == key_spec.first and key.second.size() <= key_spec.second;
                 }
             );
     }

--- a/include/opendht/indexation/pht.h
+++ b/include/opendht/indexation/pht.h
@@ -52,8 +52,12 @@ struct Prefix {
      * @param pos : Pos of the needed bit
      * @return : true if the bit is at 1
      *           false otherwise
+     * @throw out_of_range Throw out of range if the bit at 'pos' does not exist
      */
     bool isActiveBit(size_t pos) const {
+        if ( pos >= size_ )
+            throw std::out_of_range("Can't detect active bit at pos, pos larger than prefix size or empty prefix");
+
         return ((this->content_[pos / 8] >> (7 - (pos % 8)) ) & 1) == 1;
     }
 

--- a/include/opendht/indexation/pht.h
+++ b/include/opendht/indexation/pht.h
@@ -148,6 +148,15 @@ public:
             raw_cb((std::vector<std::shared_ptr<Value>>*) &values, (Prefix*) &p, user_data);
         };
     }
+    using LookupCallbackSimple = std::function<void(std::vector<std::shared_ptr<Value>>& values)>;
+    typedef void (*LookupCallbackSimpleRaw)(std::vector<std::shared_ptr<Value>>* values, void *user_data);
+    static LookupCallbackSimple
+    bindLookupCbSimple(LookupCallbackSimpleRaw raw_cb, void* user_data) {
+        if (not raw_cb) return {};
+        return [=](std::vector<std::shared_ptr<Value>>& values) {
+            raw_cb((std::vector<std::shared_ptr<Value>>*) &values, user_data);
+        };
+    }
 
     Pht(std::string name, KeySpec k_spec, std::shared_ptr<DhtRunner> dht)
         : name_(INDEX_PREFIX + name), canary_(name_ + ".canary"), keySpec_(k_spec), dht_(dht)
@@ -160,7 +169,11 @@ public:
     /**
      * Lookup a key for a value.
      */
-    void lookup(Key k, LookupCallback cb = {}, DoneCallbackSimple doneCb = {}, bool exact_match = true);
+    void lookup(Key k, LookupCallback cb = {}, DoneCallbackSimple done_cb = {}, bool exact_match = true);
+    void lookup(Key k, LookupCallbackSimple cb = {}, DoneCallbackSimple done_cb = {}, bool exact_match = true)
+    {
+        lookup(k, [=](std::vector<std::shared_ptr<Value>>& values, Prefix) { cb(values); }, done_cb, exact_match);
+    }
     /**
      * Adds an entry into the index.
      */

--- a/python/opendht.pyx
+++ b/python/opendht.pyx
@@ -406,8 +406,11 @@ cdef class IndexValue(object):
 
 cdef class Pht(object):
     cdef cpp.Pht* thisptr
-    def __cinit__(self, bytes name, DhtRunner dht):
-        self.thisptr = new cpp.Pht(name, dht.thisptr)
+    def __cinit__(self, bytes name, key_spec, DhtRunner dht):
+        cdef cpp.IndexKeySpec cpp_key_spec
+        for kk, size in key_spec.items():
+            cpp_key_spec[bytes(kk, 'utf-8')] = size
+        self.thisptr = new cpp.Pht(name, cpp_key_spec, dht.thisptr)
     property MAX_NODE_ENTRY_COUNT:
         def __get__(self):
             return cpp.PHT_MAX_NODE_ENTRY_COUNT
@@ -424,7 +427,7 @@ cdef class Pht(object):
         ref.Py_INCREF(cb_obj)
         cdef cpp.IndexKey cppk
         for kk, v in key.items():
-            cppk[bytes(kk, 'utf-8')] = cpp.Prefix(bytes(v))
+            cppk[bytes(kk, 'utf-8')] = bytes(v)
         self.thisptr.lookup(
                 cppk,
                 cpp.Pht.bindLookupCb(lookup_callback, <void*>cb_obj),
@@ -441,7 +444,7 @@ cdef class Pht(object):
         ref.Py_INCREF(cb_obj)
         cdef cpp.IndexKey cppk
         for kk, v in key.items():
-            cppk[bytes(kk, 'utf-8')] = cpp.Prefix(bytes(v))
+            cppk[bytes(kk, 'utf-8')] = bytes(v)
         cdef cpp.IndexValue val
         val.first = (<InfoHash>value.getKey())._infohash
         val.second = value.getValueId()

--- a/python/opendht_cpp.pxd
+++ b/python/opendht_cpp.pxd
@@ -167,12 +167,13 @@ cdef extern from "opendht/indexation/pht.h" namespace "dht::indexation":
         Prefix(vector[uint8_t]) except +
         string toString() const
     ctypedef pair[InfoHash, uint64_t] IndexValue "dht::indexation::Value"
-    ctypedef map[string, Prefix] IndexKey "dht::indexation::Pht::Key"
+    ctypedef map[string, vector[uint8_t]] IndexKey "dht::indexation::Pht::Key"
+    ctypedef map[string, uint32_t] IndexKeySpec "dht::indexation::Pht::KeySpec"
     ctypedef void (*LookupCallbackRaw)(vector[shared_ptr[IndexValue]]* values, Prefix* p, void* user_data);
     cdef cppclass Pht:
         cppclass LookupCallback:
             LookupCallback() except +
-        Pht(string, shared_ptr[DhtRunner]) except +
+        Pht(string, IndexKeySpec, shared_ptr[DhtRunner]) except +
         void lookup(IndexKey k, LookupCallback cb, DoneCallbackSimple doneCb);
         void insert(IndexKey k, IndexValue v, DoneCallbackSimple cb)
         @staticmethod

--- a/python/tools/dht/tests.py
+++ b/python/tools/dht/tests.py
@@ -10,6 +10,7 @@ import string
 import time
 import subprocess
 import re
+import collections
 
 from matplotlib.ticker import FuncFormatter
 import math
@@ -276,17 +277,18 @@ class PhtTest(FeatureTest):
         """
         bootstrap = self._bootstrap
         bootstrap.resize(2)
-
         dht = bootstrap.get(1)
-        pht = Pht(b'foo_index', dht)
+
+        NUM_DIG  = max(math.log(self._num_keys, 2)/4, 5) # at least 5 digit keys.
+        keyspec = collections.OrderedDict([('foo', NUM_DIG)])
+        pht = Pht(b'foo_index', keyspec, dht)
 
         DhtNetwork.log('PHT has',
                        pht.MAX_NODE_ENTRY_COUNT,
                        'node'+ ('s' if pht.MAX_NODE_ENTRY_COUNT > 1 else ''),
                        'per leaf bucket.')
-        NUM_DIG  = max(math.log(self._num_keys, 2)/4, 5) # at least 5 digit keys.
         keys = [{
-            'foo' :
+            [_ for _ in keyspec.keys()][0] :
             ''.join(random.SystemRandom().choice(string.hexdigits)
                 for _ in range(NUM_DIG)).encode()
             } for n in range(self._num_keys)]

--- a/tools/dhtnode.cpp
+++ b/tools/dhtnode.cpp
@@ -264,7 +264,6 @@ void cmd_loop(std::shared_ptr<DhtRunner>& dht, std::map<std::string, indexation:
             iss >> exact_match;
             try {
                 auto key = createPhtKey(parseStringMap(keystr));
-                std::cout << "Pht::lookup(key=\"" << indexes.at(index).linearize(key).toString() << "\")" << std::endl;
                 indexes.at(index).lookup(key,
                     [=](std::vector<std::shared_ptr<indexation::Value>>& vals, indexation::Prefix p) {
                         if (vals.empty())
@@ -296,8 +295,6 @@ void cmd_loop(std::shared_ptr<DhtRunner>& dht, std::map<std::string, indexation:
             indexation::Value v {h, 0};
             try {
                 auto key = createPhtKey(parseStringMap(keystr));
-                std::cout << "Pht::insert(key=\"" << indexes.at(index).linearize(key).toString()
-                          << "\", " << h.toString() << ")" << std::endl;
                 indexes.at(index).insert(key, v,
                     [=](bool success) {
                         if (not success) {

--- a/tools/dhtnode.cpp
+++ b/tools/dhtnode.cpp
@@ -296,12 +296,8 @@ void cmd_loop(std::shared_ptr<DhtRunner>& dht, std::map<std::string, indexation:
             try {
                 auto key = createPhtKey(parseStringMap(keystr));
                 indexes.at(index).insert(key, v,
-                    [=](bool success) {
-                        if (not success) {
-                            std::cout << "Pht::insert: failed." << std::endl;
-                            return;
-                        }
-                        std::cout << "Pht::insert: done." << std::endl;
+                    [=](bool ok) {
+                        std::cout << "Pht::insert: " << (ok ? "done." : "failed.") << std::endl;
                     }
                 );
             }

--- a/tools/tools_common.h
+++ b/tools/tools_common.h
@@ -161,7 +161,7 @@ dht::indexation::Pht::Key createPhtKey(std::map<std::string, std::string> pht_ke
     dht::indexation::Pht::Key pht_key;
     for (auto f : pht_key_str_map) {
         dht::Blob prefix {f.second.begin(), f.second.end()};
-        pht_key.emplace(f.first, prefix);
+        pht_key.emplace(f.first, std::move(prefix));
     }
     return pht_key;
 }


### PR DESCRIPTION
This PR enhances the `Pht` API:

- A `Key` is now `std::map<std::string, Blob>` rather than `std::map<std::string, Prefix>`.
- The `Pht` now depends on a key specification

        using KeySpec = std::map<std::string, size_t>

  This key specification sets the order, the number and the length of the fields in the key.

Other minor changes:

- `dhtnode` will handle the key spec by setting the keyspec for the pht with the first key entered by the user;
- the benchmark has been updated accordingly.
