### PR TITLE
dht: more accurate name for requested nodes count

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -292,8 +292,8 @@ private:
        the target 8 turn out to be dead. */
     static constexpr unsigned SEARCH_NODES {14};
 
-    /* Concurrent requests during a search */
-    static constexpr unsigned SEARCH_REQUESTS {4};
+    /* Concurrent search nodes requested count */
+    static constexpr unsigned MAX_REQUESTED_SEARCH_NODES {4};
 
     /* Number of listening nodes */
     static constexpr unsigned LISTEN_NODES {4};


### PR DESCRIPTION
The number of currently requested nodes, formerly named currentGetRequests, was renamed since it was not accurately describing the behavior. The number we are counting is not the number of 'get' requests, but rather the number of nodes being requested simultaneously.
