### PR TITLE
dht: Fix, get does not include the put value if its performed just after it.

### DIFF
--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -939,7 +939,7 @@ Dht::searchStep(std::shared_ptr<Search> sr)
                     continue;
                 }
             }
-            if (in) storageStore(sr->id, a.value, a.created);
+
             unsigned i = 0;
             for (auto& n : sr->nodes) {
                 if (not n.isSynced(now))
@@ -1343,6 +1343,9 @@ Dht::announce(const InfoHash& id, sa_family_t af, std::shared_ptr<Value> value, 
             callback(false, {});
         return;
     }
+
+    storageStore(id, value, created);
+
     auto& srs = af == AF_INET ? searches4 : searches6;
     auto srp = srs.find(id);
     auto sr = srp == srs.end() ? search(id, af) : srp->second;


### PR DESCRIPTION
When the put is performed just after a get, then the get will not include the value which was in the put.

This bug was found when using the new complete node splitting algorithm (after some hour of searching ).

