### PR TITLE
dht: Value pagination using queries

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -531,16 +531,26 @@ private:
     void onFindNodeDone(const Request& status, NetworkEngine::RequestAnswer& a, std::shared_ptr<Search> sr);
     /* when we receive a "get values" request */
     NetworkEngine::RequestAnswer onGetValues(std::shared_ptr<Node> node, InfoHash& hash, want_t want, const Query& q);
-    void onGetValuesDone(const Request& status, NetworkEngine::RequestAnswer& a, std::shared_ptr<Search> sr,
+    void onGetValuesDone(const Request& status,
+            NetworkEngine::RequestAnswer& a,
+            std::shared_ptr<Search>& sr,
             const std::shared_ptr<Query>& orig_query);
     /* when we receive a listen request */
-    NetworkEngine::RequestAnswer onListen(std::shared_ptr<Node> node, InfoHash& hash, Blob& token, size_t rid,
+    NetworkEngine::RequestAnswer onListen(std::shared_ptr<Node> node,
+            InfoHash& hash,
+            Blob& token,
+            size_t rid,
             Query&& query);
-    void onListenDone(const Request& status, NetworkEngine::RequestAnswer& a,
-            std::shared_ptr<Search>& sr, const std::shared_ptr<Query>& orig_query);
+    void onListenDone(const Request& status,
+            NetworkEngine::RequestAnswer& a,
+            std::shared_ptr<Search>& sr,
+            const std::shared_ptr<Query>& orig_query);
     /* when we receive an announce request */
     NetworkEngine::RequestAnswer onAnnounce(std::shared_ptr<Node> node,
-            InfoHash& hash, Blob& token, std::vector<std::shared_ptr<Value>> v, time_point created);
+            InfoHash& hash,
+            Blob& token,
+            std::vector<std::shared_ptr<Value>> v,
+            time_point created);
     void onAnnounceDone(const Request& status, NetworkEngine::RequestAnswer& a, std::shared_ptr<Search>& sr);
 };
 

--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -328,6 +328,7 @@ private:
         time_point start;
         Value::Filter filter;
         std::shared_ptr<Query> query;
+        std::set<std::shared_ptr<Query>> pagination_queries;
         QueryCallback query_cb;
         GetCallback get_cb;
         DoneCallback done_cb;
@@ -508,6 +509,20 @@ private:
 
     void confirmNodes();
     void expire();
+
+    void searchNodeGetDone(const Request& status,
+            NetworkEngine::RequestAnswer&& answer,
+            std::weak_ptr<Search> ws,
+            std::shared_ptr<Query> query);
+    void searchNodeGetExpired(const Request& status, bool over, std::weak_ptr<Search> ws, std::shared_ptr<Query> query);
+    /**
+     * This method recovers sends individual request for values per id.
+     *
+     * @param ws     A weak pointer to the Search.
+     * @param query  The initial query passed through the API.
+     * @param n      The node to which send the requests.
+     */
+    void paginate(std::weak_ptr<Search> ws, std::shared_ptr<Query> query, SearchNode* n);
 
     /**
      * If update is true, this method will also send message to synced but non-updated search nodes.

--- a/include/opendht/value.h
+++ b/include/opendht/value.h
@@ -827,6 +827,12 @@ struct Query
 
     void msgpack_unpack(const msgpack::object& o);
 
+    std::string toString() {
+        std::stringstream ss;
+        ss << *this;
+        return ss.str();
+    }
+
     friend std::ostream& operator<<(std::ostream& s, const dht::Query& q) {
         return s << "Query[" << q.select << " " << q.where << "]";
     }

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -219,6 +219,21 @@ struct Dht::SearchNode {
     }
 
     /**
+     * Tells if pagination is pending for a given 'get' request.
+     *
+     * @param get  The 'get' request data structure.
+     *
+     * @return true if pagination is pending, else false.
+     */
+    bool paginationPending(const Get& get) const {
+        return std::find_if(get.pagination_queries.cbegin(), get.pagination_queries.cend(),
+            [this](const std::shared_ptr<Query>& query) {
+                const auto& req = getStatus.find(query);
+                return req != getStatus.cend() and req->second and req->second->pending();
+            }) != get.pagination_queries.cend();
+    }
+
+    /**
      * Tell if the node has finished responding to a given 'get' request.
      *
      * A 'get' request can be divided in multiple requests called "pagination
@@ -230,8 +245,12 @@ struct Dht::SearchNode {
      * @return true if it has finished, else false.
      */
     bool isDone(const Get& get) const {
-        const auto& gs = get.query ? getStatus.find(get.query) : getStatus.cend();
-        return gs != getStatus.end() and gs->second and not gs->second->pending();
+        if (not get.pagination_queries.empty())
+            return not paginationPending(get);
+        else {
+            const auto& gs = get.query ? getStatus.find(get.query) : getStatus.cend();
+            return gs != getStatus.end() and gs->second and not gs->second->pending();
+        }
     }
 
     /**
@@ -791,6 +810,104 @@ Dht::expireSearches()
     erase_if(searches6, expired);
 }
 
+void
+Dht::searchNodeGetDone(const Request& status,
+        NetworkEngine::RequestAnswer&& answer,
+        std::weak_ptr<Search> ws,
+        std::shared_ptr<Query> query)
+{
+    if (auto sr = ws.lock()) {
+        sr->insertNode(status.node, scheduler.time(), answer.ntoken);
+        onGetValuesDone(status, answer, sr, query);
+    }
+}
+
+void
+Dht::searchNodeGetExpired(const Request& status,
+        bool over,
+        std::weak_ptr<Search> ws,
+        std::shared_ptr<Query> query)
+{
+    if (auto sr = ws.lock()) {
+        if (auto srn = sr->getNode(status.node)) {
+            srn->getStatus[query]->setExpired();
+            srn->candidate = not over;
+            if (over)
+                srn->getStatus.erase(query);
+        }
+        scheduler.edit(sr->nextSearchStep, scheduler.time());
+    }
+}
+
+void Dht::paginate(std::weak_ptr<Search> ws, std::shared_ptr<Query> query, SearchNode* n) {
+    if (auto sr = ws.lock()) {
+        auto find_cb = [query](std::shared_ptr<Search> sr) {
+            return std::find_if(sr->callbacks.begin(), sr->callbacks.end(),
+                [&query](const std::pair<time_point, Get>& g) {
+                    return g.second.query == query;
+                }
+            );
+        };
+        auto select_q = std::make_shared<Query>(Select {}.field(Value::Field::Id), query ? query->where : Where {});
+        auto onSelectDone =
+            [this,ws,query,find_cb](const Request& status, NetworkEngine::RequestAnswer&& answer) mutable
+            {
+                if (auto sr = ws.lock()) {
+                    auto cb = find_cb(sr);
+                    if (cb == sr->callbacks.end())
+                        return;
+                    if (auto sn = sr->getNode(status.node)) {
+                        if (answer.fields.empty()) {
+                            searchNodeGetDone(status, std::move(answer), ws, query);
+                            return;
+                        } else {
+                            for (const auto& fvi : answer.fields) {
+                                try {
+                                    auto vid = fvi->index.at(Value::Field::Id).getInt();
+                                    if (vid == Value::INVALID_ID) continue;
+                                    auto query_for_vid = std::make_shared<Query>(Select {}, Where {}.id(vid));
+                                    cb->second.pagination_queries.insert(query_for_vid);
+                                    DHT_LOG.WARN("[search %s IPv%c] [node %s] sending %s",
+                                            sr->id.toString().c_str(), sr->af == AF_INET ? '4' : '6',
+                                            sn->node->toString().c_str(), query_for_vid->toString().c_str());
+                                    sn->getStatus[query_for_vid] = network_engine.sendGetValues(status.node,
+                                            sr->id,
+                                            *query_for_vid,
+                                            -1,
+                                            std::bind(&Dht::searchNodeGetDone, this, _1, _2, ws, query),
+                                            std::bind(&Dht::searchNodeGetExpired, this, _1, _2, ws, query_for_vid)
+                                            );
+                                } catch (std::out_of_range&) {
+                                    DHT_LOG.ERR("[search %s IPv%c] [node %s] received non-id field in response to "\
+                                            "'SELECT id' request...",
+                                            sr->id.toString().c_str(), sr->af == AF_INET ? '4' : '6',
+                                            sn->node->toString().c_str());
+                                }
+                            }
+                        }
+
+                    }
+                }
+            };
+        auto cb = find_cb(sr);
+        if (cb != sr->callbacks.end()) {
+            /* add pagination query key for tracking ongoing requests. */
+            cb->second.pagination_queries.insert(select_q);
+
+            DHT_LOG.WARN("[search %s IPv%c] [node %s] sending %s",
+                    sr->id.toString().c_str(), sr->af == AF_INET ? '4' : '6',
+                    n->node->toString().c_str(), select_q->toString().c_str());
+            n->getStatus[select_q] = network_engine.sendGetValues(n->node,
+                    sr->id,
+                    *select_q,
+                    -1,
+                    onSelectDone,
+                    std::bind(&Dht::searchNodeGetExpired, this, _1, _2, ws, select_q)
+            );
+        }
+    }
+}
+
 Dht::SearchNode*
 Dht::searchSendGetValues(std::shared_ptr<Search> sr, SearchNode* pn, bool update)
 {
@@ -800,6 +917,7 @@ Dht::searchSendGetValues(std::shared_ptr<Search> sr, SearchNode* pn, bool update
     const auto& now = scheduler.time();
     const time_point up = update ? sr->getLastGetTime() : time_point::min();
 
+    std::weak_ptr<Search> ws = sr;
     SearchNode* n = nullptr;
     auto cb = sr->callbacks.begin();
     do { /* for all queries to send */
@@ -821,38 +939,34 @@ Dht::searchSendGetValues(std::shared_ptr<Search> sr, SearchNode* pn, bool update
                 return nullptr;
         }
 
-        std::weak_ptr<Search> ws = sr;
-        auto onDone =
-            [this,ws,query](const Request& status, NetworkEngine::RequestAnswer&& answer) mutable {
-                if (auto sr = ws.lock()) {
-                    sr->insertNode(status.node, scheduler.time(), answer.ntoken);
-                    onGetValuesDone(status, answer, sr, query);
-                }
-            };
-        auto onExpired =
-            [this,ws,query](const Request& status, bool over) mutable {
-                if (auto sr = ws.lock()) {
-                    if (auto srn = sr->getNode(status.node)) {
-                        srn->candidate = not over;
-                        if (over)
-                            srn->getStatus.erase(query);
-                    }
-                    scheduler.edit(sr->nextSearchStep, scheduler.time());
-                }
-            };
-        std::shared_ptr<Request> rstatus;
         if (sr->callbacks.empty() and sr->listeners.empty()) {
             DHT_LOG.WARN("[search %s IPv%c] [node %s] sending 'find_node'",
                     sr->id.toString().c_str(), sr->af == AF_INET ? '4' : '6',
                     n->node->toString().c_str());
-            rstatus = network_engine.sendFindNode(n->node, sr->id, -1, onDone, onExpired);
+            n->getStatus[query] = network_engine.sendFindNode(n->node,
+                    sr->id,
+                    -1,
+                    std::bind(&Dht::searchNodeGetDone, this, _1, _2, ws, query),
+                    std::bind(&Dht::searchNodeGetExpired, this, _1, _2, ws, query));
         } else {
-            DHT_LOG.WARN("[search %s IPv%c] [node %s] sending 'get'",
-                    sr->id.toString().c_str(), sr->af == AF_INET ? '4' : '6',
-                    n->node->toString().c_str());
-            rstatus = network_engine.sendGetValues(n->node, sr->id, query ? *query : Query {}, -1, onDone, onExpired);
+            if (query and not query->select.getSelection().empty()) {
+                /* The request contains a select. No need to paginate... */
+                DHT_LOG.WARN("[search %s IPv%c] [node %s] sending 'get'",
+                        sr->id.toString().c_str(), sr->af == AF_INET ? '4' : '6',
+                        n->node->toString().c_str());
+                n->getStatus[query] = network_engine.sendGetValues(n->node,
+                        sr->id,
+                        *query,
+                        -1,
+                        std::bind(&Dht::searchNodeGetDone, this, _1, _2, ws, query),
+                        std::bind(&Dht::searchNodeGetExpired, this, _1, _2, ws, query));
+            } else {
+                if (n->paginationPending(cb->second))
+                    n = nullptr;
+                else
+                    paginate(ws, query, n);
+            }
         }
-        n->getStatus[query] = rstatus;
 
         if (not sr->isSynced(now) or cb == sr->callbacks.end())
             break; /* only trying to find nodes, only send the oldest query */
@@ -1314,7 +1428,7 @@ Dht::search(const InfoHash& id, sa_family_t af, GetCallback gcb, QueryCallback q
         auto now = scheduler.time();
         sr->callbacks.insert(std::make_pair<time_point, Get>(
             std::move(now),
-            Get { scheduler.time(), f, std::make_shared<Query>(q),
+            Get { scheduler.time(), f, std::make_shared<Query>(q), {},
                 qcb ? qcb : QueryCallback {}, gcb ? gcb : GetCallback {}, dcb
             }
         ));


### PR DESCRIPTION
This is addressing #71. The first iteration on this was a bit diffrent and this final version is much better. See the log of a test made in network of 2 nodes.

```
>> p d0758565fd06c37aa66b071160d156f5628cd518
>> put: adding d0758565fd06c37aa66b071160d156f5628cd518 -> Value[id:d5d4cbbe3bb21832 Data (type: 0 ): ]
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] new search
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv6] new search
No node found from cache
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] step (0 requests)
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] [node 86ee09f761ed07740bce30700cdeac6d8a76d139 192.168.49.47:47110] sending 'find_node'
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv6] step (0 requests)
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv6] expired
Announce done IPv6 0
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] got reply to 'get' from 86ee09f761ed07740bce30700cdeac6d8a76d139 192.168.49.47:47110 with 0 nodes
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] step (0 requests)
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] synced, in
[Storage d0758565fd06c37aa66b071160d156f5628cd518] changed.
[Storage d0758565fd06c37aa66b071160d156f5628cd518] 0 remote listeners.
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] [node 86ee09f761ed07740bce30700cdeac6d8a76d139 192.168.49.47:47110] sending 'put' (vid: 1001527346)
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] got reply to put!
Announce done IPv4 1
Put: success (took 0.00540097s)
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] step (0 requests)
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] synced, in
>>
>> p d0758565fd06c37aa66b071160d156f5628cd518
>> put: adding d0758565fd06c37aa66b071160d156f5628cd518 -> Value[id:ace45cabe03a6824 Data (type: 0 ): ]
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] step (0 requests)
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] synced, in
[Storage d0758565fd06c37aa66b071160d156f5628cd518] changed.
[Storage d0758565fd06c37aa66b071160d156f5628cd518] 0 remote listeners.
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] [node 86ee09f761ed07740bce30700cdeac6d8a76d139 192.168.49.47:47110] sending 'put' (vid: -533043164)
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv6] step (0 requests)
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv6] expired
Announce done IPv6 0
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] got reply to put!
Announce done IPv4 1
Put: success (took 0.00258689s)
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] step (0 requests)
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] synced, in
[find 9e6d3c83daff456c2e40094a635fc7f7935753fc IPv4] sending find for neighborhood maintenance.
>>
>> g d0758565fd06c37aa66b071160d156f5628cd518
>> Get: found value (after 0.000574573s)
	Value[id:d5d4cbbe3bb21832 Data (type: 0 ): ]
Get: found value (after 0.000630142s)
	Value[id:ace45cabe03a6824 Data (type: 0 ): ]
No node found from cache
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] step (0 requests)
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] synced, in
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] [node 86ee09f761ed07740bce30700cdeac6d8a76d139 192.168.49.47:47110] sending Query[SELECT id ]
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv6] step (0 requests)
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv6] expired
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] [node 86ee09f761ed07740bce30700cdeac6d8a76d139 192.168.49.47:47110] sending Query[SELECT * WHERE id=15408164243047061554]
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] [node 86ee09f761ed07740bce30700cdeac6d8a76d139 192.168.49.47:47110] sending Query[SELECT * WHERE id=12458184362484721700]
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] got reply to 'get' from 86ee09f761ed07740bce30700cdeac6d8a76d139 192.168.49.47:47110 with 0 nodes
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] found 1 values
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] step (1 requests)
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] synced, in
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] got reply to 'get' from 86ee09f761ed07740bce30700cdeac6d8a76d139 192.168.49.47:47110 with 0 nodes
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] found 1 values
[search d0758565fd06c37aa66b071160d156f5628cd518 IPv4] step (0 requests)
Get: completed (took 0.00546089s)
```
You can observe that a single get operation now first asks for a list of value ids before individually requesting for each of those ids.
