### PR TITLE
pht : Filter of duplicate values

### DIFF
--- a/src/indexation/pht.cpp
+++ b/src/indexation/pht.cpp
@@ -28,13 +28,13 @@ static std::string blobToString(const Blob &bl) {
 std::string Prefix::toString() const {
     std::stringstream ss;
 
-    ss << "Prefix : " << std::endl << "\tContent_ : ";
+    ss << "Prefix : " << std::endl << "\tContent_ : \"";
     ss << blobToString(content_);
-    ss << std::endl;
+    ss << "\"" << std::endl;
 
-    ss << "\tFlags_ :   ";
+    ss << "\tFlags_   : \"";
     ss << blobToString(flags_);
-    ss << std::endl;
+    ss << "\"" << std::endl;
 
     return ss.str();
 }
@@ -192,6 +192,14 @@ void Pht::lookupStep(Prefix p, std::shared_ptr<int> lo, std::shared_ptr<int> hi,
             else {
                 IndexEntry entry;
                 entry.unpackValue(*value);
+
+                auto it = std::find_if(vals->cbegin(), vals->cend(), [&](const std::shared_ptr<IndexEntry>& ie) {
+                    return ie->value == entry.value;
+                });
+
+                /* If we already got the value then get the next one */
+                if (it != vals->cend())
+                    return true;
 
                 if (max_common_prefix_len) { /* inexact match case */
                     auto common_bits = Prefix::commonBits(p, entry.prefix);


### PR DESCRIPTION
I add a filter that filter duplicated value : 

Here is a pastebin of what append with the modification 
http://pastebin.com/ZGL1MPew

First i insert 11 same value, then the lookup and there is only one value found (but 11 in storage)
Then i re-add 10 values (we are now above the maximum value in a node that should create a splitting).
Line 56 show that it does not since all values are the same (it also show only one of the 21 values in the storage table)
Finally : 
Line 68 to 72 show that there is 42 values in the storage (21 Canary + 21 values). 

This will be the new behaviour.
