### PR TITLE
[dht] cover bad cases in SearchNode::canGet

### DIFF
--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -223,13 +223,13 @@ struct Dht::SearchNode {
         /* Find request status for a query satisfying the initial query */
         const auto& sq_status = std::find_if(getStatus.cbegin(), getStatus.cend(),
             [&q](const SyncStatus::value_type& s) {
-                return s.first and q and s.first->isSatisfiedBy(*q);
+                return s.first and q and q->isSatisfiedBy(*s.first) and s.second and s.second->pending();
             }
         );
         return not node->isExpired() and (now > last_get_reply + Node::NODE_EXPIRE_TIME or update > last_get_reply)
             and not hasStartedPagination(q)
             and (get_status == getStatus.cend() or not get_status->second)
-            and (sq_status == getStatus.cend() or not sq_status->second or not sq_status->second->pending());
+            and sq_status == getStatus.cend();
     }
 
     /**

--- a/src/network_engine.cpp
+++ b/src/network_engine.cpp
@@ -182,9 +182,8 @@ NetworkEngine::sendRequest(std::shared_ptr<Request>& request)
 {
     request->start = scheduler.time();
     auto e = requests.emplace(request->tid, request);
-    if (!e.second) {
-        DHT_LOG.ERR("Request already existed !");
-    }
+    if (!e.second)
+        DHT_LOG.ERR("Request already existed (tid: %d)!", request->tid);
     request->node->requested(request);
     requestStep(request);
 }


### PR DESCRIPTION
Prior to this patch and since the queries, `SearchNode::getStatus` would accumulate entries that would not be deleted when `find_node` operation would complete. Therefor, this was memory leak and also creating inconsistency in `canGet` timings.
