### PR TITLE
dht: data persistence 2.0

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -512,11 +512,30 @@ private:
     void confirmNodes();
     void expire();
 
+    /**
+     * Generic function to execute when a 'get' request has completed.
+     *
+     * @param status  The request passed by the network engine.
+     * @param answer  The answer from the network engine.
+     * @param ws      A weak pointer to the search concerned by the request.
+     * @param query   The query sent to the node.
+     */
     void searchNodeGetDone(const Request& status,
             NetworkEngine::RequestAnswer&& answer,
             std::weak_ptr<Search> ws,
             std::shared_ptr<Query> query);
+
+    /**
+     * Generic function to execute when a 'get' request expires.
+     *
+     * @param status  The request passed by the network engine.
+     * @param over    Whether we're done to try sending the request to the node
+     *                or not. This lets us mark a node as candidate.
+     * @param ws      A weak pointer to the search concerned by the request.
+     * @param query   The query sent to the node.
+     */
     void searchNodeGetExpired(const Request& status, bool over, std::weak_ptr<Search> ws, std::shared_ptr<Query> query);
+
     /**
      * This method recovers sends individual request for values per id.
      *
@@ -531,6 +550,21 @@ private:
      */
     SearchNode* searchSendGetValues(std::shared_ptr<Search> sr, SearchNode *n = nullptr, bool update = true);
 
+    /**
+     * Forwards an 'announce' request for a list of nodes to the network engine.
+     *
+     * @param sr  The search for which we want to announce a value.
+     * @param announce  The 'announce' structure.
+     */
+    void searchSendAnnounceValue(const std::shared_ptr<Search>& sr);
+
+    /**
+     * Main process of a Search's operations. This function will demand the
+     * network engine to send requests packets for all pending operations
+     * ('get', 'put' and 'listen').
+     *
+     * @param sr  The search to execute its operations.
+     */
     void searchStep(std::shared_ptr<Search> sr);
     void dumpSearch(const Search& sr, std::ostream& out) const;
 

--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -424,6 +424,7 @@ private:
     // timing
     Scheduler scheduler {};
     std::shared_ptr<Scheduler::Job> nextNodesConfirmation {};
+    std::shared_ptr<Scheduler::Job> nextStorageMaintenance {};
     time_point mybucket_grow_time {time_point::min()}, mybucket6_grow_time {time_point::min()};
 
     NetworkEngine network_engine;

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -2072,6 +2072,12 @@ Dht::storageStore(const InfoHash& id, const std::shared_ptr<Value>& value, time_
         total_values += std::get<2>(store);
         storageChanged(*(*st), *std::get<0>(store));
     }
+
+    if (not nextStorageMaintenance)
+        /* activate storage maintenance for the first time */
+        nextStorageMaintenance = scheduler.add(now + MAX_STORAGE_MAINTENANCE_EXPIRE_TIME,
+                                               std::bind(&Dht::dataPersistence, this));
+
     return std::get<0>(store);
 }
 
@@ -2634,12 +2640,18 @@ Dht::dataPersistence() {
     auto storage_maintenance_time = time_point::max();
     for (auto &str : store) {
         if (now > str->maintenance_time) {
+            DHT_LOG.WARN("[storage %s] maintenance (%u values, %u bytes)",
+                    str->id.toString().c_str(), str->valueCount(), str->totalSize());
             maintainStorage(str->id);
             str->maintenance_time = now + MAX_STORAGE_MAINTENANCE_EXPIRE_TIME;
         }
         storage_maintenance_time = std::min(storage_maintenance_time, str->maintenance_time);
     }
-    scheduler.add(storage_maintenance_time, std::bind(&Dht::dataPersistence, this));
+    DHT_LOG.WARN("[store] next maintenance in %u minutes",
+            std::chrono::duration_cast<std::chrono::minutes>(storage_maintenance_time-now));
+    nextStorageMaintenance = storage_maintenance_time != time_point::max() ?
+                                scheduler.add(storage_maintenance_time, std::bind(&Dht::dataPersistence, this)) :
+                                nullptr;
 }
 
 size_t

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -347,9 +347,10 @@ struct Dht::SearchNode {
         if ((ack == acked.cend() or not ack->second) and (gs == getStatus.cend()
                                                           or not gs->second or not gs->second->pending()))
             return time_point::min();
-        return (ack == acked.cend() or not ack->second or ack->second->pending()) ?
-                time_point::max() :
-                ack->second->reply_time + type.expiration - REANNOUNCE_MARGIN;
+        return ((gs != getStatus.cend() and gs->second and gs->second->pending())
+                or ack == acked.cend() or not ack->second or ack->second->pending()) ?
+                    time_point::max() :
+                    ack->second->reply_time + type.expiration - REANNOUNCE_MARGIN;
     }
 
     /**

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -1110,9 +1110,6 @@ void Dht::searchSendAnnounceValue(const std::shared_ptr<Search>& sr) {
                             ++ait;
                         }
                     }
-
-                    if (sr->callbacks.empty() && sr->announce.empty() && sr->listeners.empty())
-                        sr->done = true;
                 }
             };
         DHT_LOG.WARN("[search %s IPv%c] [node %s] sending %s",
@@ -1218,6 +1215,9 @@ Dht::searchStep(std::shared_ptr<Search> sr)
 
         // Announce requests
         searchSendAnnounceValue(sr);
+
+        if (sr->callbacks.empty() && sr->announce.empty() && sr->listeners.empty())
+            sr->done = true;
     }
 
     if (sr->currentlySolicitedNodeCount() < MAX_REQUESTED_SEARCH_NODES) {

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -347,7 +347,9 @@ struct Dht::SearchNode {
         if ((ack == acked.cend() or not ack->second) and (gs == getStatus.cend()
                                                           or not gs->second or not gs->second->pending()))
             return time_point::min();
-        return gs->second->pending() ? time_point::max() : gs->second->reply_time + type.expiration - REANNOUNCE_MARGIN;
+        return (ack == acked.cend() or not ack->second or ack->second->pending()) ?
+                time_point::max() :
+                ack->second->reply_time + type.expiration - REANNOUNCE_MARGIN;
     }
 
     /**


### PR DESCRIPTION
This is a rework of #7 using queries (#43) and the network engine atomic requests (#52). Now, the data persistence behavior will be to first probe for a value ID before sending it, therefor reducing the overall traffic substantially.

Here you can see a graph with the following properties:

- 1024 nodes
- 17.5 put operations per sec (1Ko)
- 8.5 node shutdowns per sec
- 8.5 node joins per sec
- *y axis*: Traffic of the whole network in Kb/s
- *x axis*: Time in seconds

<div style="text-align:center">
<img src="https://cloud.githubusercontent.com/assets/4147254/18146537/49677a02-6f9e-11e6-9383-6b5623297529.png"/>
</div>