### PR TITLE
dht: Dht::insertNode has to really insert

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -113,12 +113,12 @@ public:
      * The node is not pinged, so this should be
      * used to bootstrap efficiently from previously known nodes.
      */
-    bool insertNode(const InfoHash& id, const sockaddr*, socklen_t);
-    bool insertNode(const NodeExport& n) {
-        return insertNode(n.id, reinterpret_cast<const sockaddr*>(&n.ss), n.sslen);
+    void insertNode(const InfoHash& id, const sockaddr*, socklen_t);
+    void insertNode(const NodeExport& n) {
+        insertNode(n.id, reinterpret_cast<const sockaddr*>(&n.ss), n.sslen);
     }
 
-    int pingNode(const sockaddr*, socklen_t);
+    void pingNode(const sockaddr*, socklen_t);
 
     time_point periodic(const uint8_t *buf, size_t buflen, const sockaddr *from, socklen_t fromlen);
 

--- a/include/opendht/network_engine.h
+++ b/include/opendht/network_engine.h
@@ -350,7 +350,9 @@ public:
     void processMessage(const uint8_t *buf, size_t buflen, const sockaddr* from, socklen_t fromlen);
 
     std::shared_ptr<Node> insertNode(const InfoHash& myid, const sockaddr* from, socklen_t fromlen) {
-        return cache.getNode(myid, from, fromlen, scheduler.time(), 0);
+        auto n = cache.getNode(myid, from, fromlen, scheduler.time(), 0);
+        onNewNode(n, 0);
+        return n;
     }
 
     std::vector<unsigned> getNodeMessageStats(bool in) {

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -2844,30 +2844,28 @@ Dht::exportNodes()
     return nodes;
 }
 
-bool
+void
 Dht::insertNode(const InfoHash& id, const sockaddr* sa, socklen_t salen)
 {
     if (sa->sa_family != AF_INET && sa->sa_family != AF_INET6)
-        return false;
+        return;
     scheduler.syncTime();
-    auto n = network_engine.insertNode(id, sa, salen);
-    return !!n;
+    network_engine.insertNode(id, sa, salen);
 }
 
-int
+void
 Dht::pingNode(const sockaddr* sa, socklen_t salen)
 {
     scheduler.syncTime();
     DHT_LOG.DEBUG("Sending ping to %s", print_addr(sa, salen).c_str());
     auto& count = sa->sa_family == AF_INET ? pending_pings4 : pending_pings6;
     count++;
-    network_engine.sendPing(sa, salen, [&](const Request&, NetworkEngine::RequestAnswer&&){
+    network_engine.sendPing(sa, salen, [&](const Request&, NetworkEngine::RequestAnswer&&) {
         count--;
     }, [&](const Request&, bool last){
         if (last)
             count--;
     });
-    return -1;
 }
 
 void


### PR DESCRIPTION
When adding nodes from a `NodeExport` list in `DhtRunner`, the underlying `Dht` would not try to add the nodes to the routing table and/or searches. Since the entries in the node cache are not persistent (weak_ptr), the node would not stand a chance.