### PR TITLE
dhtrunner: recover from network changes

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -121,7 +121,7 @@ public:
         insertNode(n.id, SockAddr(n.ss, n.sslen));
     }
 
-    void pingNode(const sockaddr*, socklen_t);
+    void pingNode(const sockaddr*, socklen_t, DoneCallbackSimple&& cb={});
 
     time_point periodic(const uint8_t *buf, size_t buflen, const SockAddr&);
     time_point periodic(const uint8_t *buf, size_t buflen, const sockaddr* from, socklen_t fromlen) {

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -197,8 +197,8 @@ public:
     }
     void putEncrypted(const std::string& key, InfoHash to, Value&& value, DoneCallback cb={});
 
-    void bootstrap(const char* host, const char* service);
-    void bootstrap(const std::vector<std::pair<sockaddr_storage, socklen_t>>& nodes);
+    void bootstrap(const char* host, const char* service, DoneCallbackSimple&& cb={});
+    void bootstrap(const std::vector<std::pair<sockaddr_storage, socklen_t>>& nodes, DoneCallbackSimple&& cb={});
     void bootstrap(const std::vector<NodeExport>& nodes);
 
     /**

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -197,7 +197,7 @@ public:
     }
     void putEncrypted(const std::string& key, InfoHash to, Value&& value, DoneCallback cb={});
 
-    void bootstrap(const char* host, const char* service, DoneCallbackSimple&& cb={});
+    void bootstrap(const std::string& host, const std::string& service, DoneCallbackSimple&& cb={});
     void bootstrap(const std::vector<std::pair<sockaddr_storage, socklen_t>>& nodes, DoneCallbackSimple&& cb={});
     void bootstrap(const std::vector<NodeExport>& nodes);
 
@@ -331,11 +331,20 @@ public:
     void join();
 
 private:
+    static constexpr std::chrono::seconds BOOTSTRAP_PERIOD {10};
+
+    /**
+     * Will try to resolve the list of hostnames `bootstrap_nodes` on seperate
+     * thread and then queue ping requests. This list should contain reliable
+     * nodes so that the DHT node can recover quickly from losing connection
+     * with the network.
+     */
+    void tryBootstrapCoutinuously();
 
     void doRun(const sockaddr_in* sin4, const sockaddr_in6* sin6, SecureDhtConfig config);
     time_point loop_();
 
-    static std::vector<std::pair<sockaddr_storage, socklen_t>> getAddrInfo(const char* host, const char* service);
+    static std::vector<std::pair<sockaddr_storage, socklen_t>> getAddrInfo(const std::string& host, const std::string& service);
 
     NodeStatus getStatus() const {
         return std::max(status4, status6);
@@ -350,6 +359,11 @@ private:
     std::mutex sock_mtx {};
     std::vector<std::pair<Blob, SockAddr>> rcv {};
 
+    std::vector<std::pair<std::string,std::string>> bootstrap_nodes {}; /* bootstrap nodes given with info "host",
+                                                                           "service" */
+    std::mutex bootstrap_mtx {};
+    std::thread bootstrap_thread {};
+
     std::queue<std::function<void(SecureDht&)>> pending_ops_prio {};
     std::queue<std::function<void(SecureDht&)>> pending_ops {};
     std::mutex storage_mtx {};
@@ -359,6 +373,7 @@ private:
     NodeStatus status4 {NodeStatus::Disconnected},
                status6 {NodeStatus::Disconnected};
     StatusCallback statusCb {nullptr};
+
 
     SockAddr bound4 {};
     SockAddr bound6 {};

--- a/include/opendht/network_engine.h
+++ b/include/opendht/network_engine.h
@@ -47,12 +47,12 @@ namespace dht {
 class DhtProtocolException : public DhtException {
 public:
     // sent to another peer (http-like).
-    static const constexpr uint16_t NON_AUTHORITATIVE_INFORMATION {203}; /* incomplete request packet. */
-    static const constexpr uint16_t UNAUTHORIZED {401};                  /* wrong tokens. */
+    static constexpr uint16_t NON_AUTHORITATIVE_INFORMATION {203}; /* incomplete request packet. */
+    static constexpr uint16_t UNAUTHORIZED {401};                  /* wrong tokens. */
     // for internal use (custom).
-    static const constexpr uint16_t INVALID_TID_SIZE {421};              /* id was truncated. */
-    static const constexpr uint16_t UNKNOWN_TID {422};                   /* unknown tid */
-    static const constexpr uint16_t WRONG_NODE_INFO_BUF_LEN {423};       /* node info length is wrong */
+    static constexpr uint16_t INVALID_TID_SIZE {421};              /* id was truncated. */
+    static constexpr uint16_t UNKNOWN_TID {422};                   /* unknown tid */
+    static constexpr uint16_t WRONG_NODE_INFO_BUF_LEN {423};       /* node info length is wrong */
 
     static const std::string GET_NO_INFOHASH;    /* received "get" request with no infohash */
     static const std::string LISTEN_NO_INFOHASH; /* got "listen" request without infohash */
@@ -109,7 +109,7 @@ public:
      * host order.
      */
     struct TransId final : public std::array<uint8_t, 4> {
-        static const constexpr uint16_t INVALID {0};
+        static constexpr uint16_t INVALID {0};
 
         TransId() {}
         TransId(const std::array<char, 4>& o) { std::copy(o.begin(), o.end(), begin()); }
@@ -375,9 +375,9 @@ private:
      ***************/
     static constexpr long unsigned MAX_REQUESTS_PER_SEC {1600};
     /* the length of a node info buffer in ipv4 format */
-    static const constexpr size_t NODE4_INFO_BUF_LEN {26};
+    static constexpr size_t NODE4_INFO_BUF_LEN {26};
     /* the length of a node info buffer in ipv6 format */
-    static const constexpr size_t NODE6_INFO_BUF_LEN {38};
+    static constexpr size_t NODE6_INFO_BUF_LEN {38};
     /* TODO */
     static constexpr std::chrono::seconds UDP_REPLY_TIME {15};
     /* The maximum number of nodes that we snub.  There is probably little

--- a/include/opendht/request.h
+++ b/include/opendht/request.h
@@ -32,6 +32,8 @@ struct ParsedMessage;
  * request is done.
  */
 struct Request {
+    static constexpr size_t MAX_ATTEMPT_COUNT {3};
+
     friend class dht::NetworkEngine;
     std::shared_ptr<Node> node {};             /* the node to whom the request is destined. */
     time_point reply_time {time_point::min()}; /* time when we received the response to the request. */
@@ -84,7 +86,6 @@ struct Request {
     }
 
 private:
-    static const constexpr size_t MAX_ATTEMPT_COUNT {3};
 
     bool isExpired(time_point now) const {
         return pending() and now > last_try + Node::MAX_RESPONSE_TIME and attempt_count >= Request::MAX_ATTEMPT_COUNT;

--- a/include/opendht/value.h
+++ b/include/opendht/value.h
@@ -126,7 +126,7 @@ struct Value
     };
 
     typedef uint64_t Id;
-    static const constexpr Id INVALID_ID {0};
+    static constexpr Id INVALID_ID {0};
 
     class Filter : public std::function<bool(const Value&)> {
         using std::function<bool(const Value&)>::function;

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -2389,9 +2389,8 @@ Dht::getNodesStats(sa_family_t af, unsigned *good_return, unsigned *dubious_retu
                 good++;
                 if (n->time > n->reply_time)
                     incoming++;
-            } else {
+            } else if (not n->isExpired())
                 dubious++;
-            }
         }
         if (b.cached)
             cached++;
@@ -2673,11 +2672,12 @@ Dht::neighbourhoodMaintenance(RoutingTable& list)
             q = r;
     }
 
-    /* Since our node-id is the same in both DHTs, it's probably
-       profitable to query both families. */
     auto n = q->randomNode();
     if (n) {
-        DHT_LOG.DEBUG("[find %s IPv%c] sending find for neighborhood maintenance.", id.toString().c_str(), q->af == AF_INET6 ? '6' : '4');
+        DHT_LOG.DEBUG("[find %s IPv%c] sending find for neighborhood maintenance.",
+                id.toString().c_str(), q->af == AF_INET6 ? '6' : '4');
+        /* Since our node-id is the same in both DHTs, it's probably
+           profitable to query both families. */
         network_engine.sendFindNode(n, id, network_engine.want(), nullptr, nullptr);
     }
 
@@ -2878,9 +2878,9 @@ Dht::confirmNodes()
        case is roughly 27 seconds, assuming the table is 22 bits deep.
        We want to keep a margin for neighborhood maintenance, so keep
        this within 25 seconds. */
-    auto time_dis = soon ?
-        uniform_duration_distribution<> {seconds(5) , seconds(25)}
-    : uniform_duration_distribution<> {seconds(60), seconds(180)};
+    auto time_dis = soon
+        ? uniform_duration_distribution<> {seconds(5) , seconds(25)}
+        : uniform_duration_distribution<> {seconds(60), seconds(180)};
     auto confirm_nodes_time = now + time_dis(rd);
 
     nextNodesConfirmation = scheduler.add(confirm_nodes_time, std::bind(&Dht::confirmNodes, this));

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -597,18 +597,18 @@ DhtRunner::getAddrInfo(const char* host, const char* service)
 }
 
 void
-DhtRunner::bootstrap(const char* host, const char* service)
+DhtRunner::bootstrap(const char* host, const char* service, DoneCallbackSimple&& cb)
 {
-    bootstrap(getAddrInfo(host, service));
+    bootstrap(getAddrInfo(host, service), std::forward<DoneCallbackSimple>(cb));
 }
 
 void
-DhtRunner::bootstrap(const std::vector<std::pair<sockaddr_storage, socklen_t>>& nodes)
+DhtRunner::bootstrap(const std::vector<std::pair<sockaddr_storage, socklen_t>>& nodes, DoneCallbackSimple&& cb)
 {
     std::lock_guard<std::mutex> lck(storage_mtx);
-    pending_ops_prio.emplace([=](SecureDht& dht) {
+    pending_ops_prio.emplace([=,&cb](SecureDht& dht) {
         for (auto& node : nodes)
-            dht.pingNode((sockaddr*)&node.first, node.second);
+            dht.pingNode((sockaddr*)&node.first, node.second, std::move(cb));
     });
     cv.notify_all();
 }

--- a/src/network_engine.cpp
+++ b/src/network_engine.cpp
@@ -131,7 +131,7 @@ void
 NetworkEngine::clear()
 {
     for (auto& req : requests)
-        req.second->cancel();
+        req.second->setExpired();
     requests.clear();
 }
 


### PR DESCRIPTION
Using a list of bootstrap nodes, we recover from network loss by pinging those nodes continuously until connected.