### PR TITLE
search: detect connectivity changes

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -294,6 +294,16 @@ private:
        the target 8 turn out to be dead. */
     static constexpr unsigned SEARCH_NODES {14};
 
+    /* The number of bad nodes is limited in order to help determine
+     * presence of connectivity changes. See
+     * https://github.com/savoirfairelinux/opendht/issues/137 for details.
+     *
+     * According to the tables, 25 is a good average value for big networks. If
+     * the network is small, normal search expiration process will handle the
+     * situation.
+     * */
+    static constexpr unsigned SEARCH_MAX_BAD_NODES {25};
+
     /* Concurrent search nodes requested count */
     static constexpr unsigned MAX_REQUESTED_SEARCH_NODES {4};
 


### PR DESCRIPTION
The number of bad nodes is limited in order to help determine presence of connectivity changes. This is intended to address #137.

According to the tables, 25 is a good average value for big networks. If the network is small, normal search expiration process will handle the situation.

I have made the choice of merging the events of an expired search and connectivity change event. I think this is clear that those two are strongly linked together if not actually the same case. @aberaud what do you think? Take a look at [this line](https://github.com/savoirfairelinux/opendht/pull/138/files#diff-96c057f80526cd0b3abd165dedb9f8cfR613)