### PR TITLE
[dht] refresh operation for permanent put

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -532,30 +532,37 @@ private:
     /* when we receive a ping request */
     NetworkEngine::RequestAnswer onPing(std::shared_ptr<Node> node);
     /* when we receive a "find node" request */
-    NetworkEngine::RequestAnswer onFindNode(std::shared_ptr<Node> node, InfoHash& hash, want_t want);
+    NetworkEngine::RequestAnswer onFindNode(std::shared_ptr<Node> node, const InfoHash& hash, want_t want);
     void onFindNodeDone(const Request& status, NetworkEngine::RequestAnswer& a, std::shared_ptr<Search> sr);
     /* when we receive a "get values" request */
-    NetworkEngine::RequestAnswer onGetValues(std::shared_ptr<Node> node, InfoHash& hash, want_t want, const Query& q);
+    NetworkEngine::RequestAnswer onGetValues(std::shared_ptr<Node> node,
+            const InfoHash& hash,
+            want_t want,
+            const Query& q);
     void onGetValuesDone(const Request& status,
             NetworkEngine::RequestAnswer& a,
             std::shared_ptr<Search>& sr,
             const std::shared_ptr<Query>& orig_query);
     /* when we receive a listen request */
     NetworkEngine::RequestAnswer onListen(std::shared_ptr<Node> node,
-            InfoHash& hash,
-            Blob& token,
+            const InfoHash& hash,
+            const Blob& token,
             size_t rid,
-            Query&& query);
+            const Query& query);
     void onListenDone(const Request& status,
             NetworkEngine::RequestAnswer& a,
             std::shared_ptr<Search>& sr,
             const std::shared_ptr<Query>& orig_query);
     /* when we receive an announce request */
     NetworkEngine::RequestAnswer onAnnounce(std::shared_ptr<Node> node,
-            InfoHash& hash,
-            Blob& token,
-            std::vector<std::shared_ptr<Value>> v,
-            time_point created);
+            const InfoHash& hash,
+            const Blob& token,
+            const std::vector<std::shared_ptr<Value>>& v,
+            const time_point& created);
+    NetworkEngine::RequestAnswer onRefresh(std::shared_ptr<Node> node,
+            const InfoHash& hash,
+            const Blob& token,
+            const Value::Id& vid);
     void onAnnounceDone(const Request& status, NetworkEngine::RequestAnswer& a, std::shared_ptr<Search>& sr);
 };
 

--- a/include/opendht/network_engine.h
+++ b/include/opendht/network_engine.h
@@ -399,7 +399,7 @@ private:
     static const constexpr size_t NODE4_INFO_BUF_LEN {26};
     /* the length of a node info buffer in ipv6 format */
     static const constexpr size_t NODE6_INFO_BUF_LEN {38};
-    /* the maximum time we wait for an UDP reply before telling the link layer */
+    /* after a UDP reply, the period during which we tell the link layer about it */
     static constexpr std::chrono::seconds UDP_REPLY_TIME {15};
 
     /* Max. time to receive a full fragmented packet */

--- a/include/opendht/network_engine.h
+++ b/include/opendht/network_engine.h
@@ -399,7 +399,7 @@ private:
     static const constexpr size_t NODE4_INFO_BUF_LEN {26};
     /* the length of a node info buffer in ipv6 format */
     static const constexpr size_t NODE6_INFO_BUF_LEN {38};
-    /* the maximum time we wait for an UDP reply */
+    /* the maximum time we wait for an UDP reply before telling the link layer */
     static constexpr std::chrono::seconds UDP_REPLY_TIME {15};
 
     /* Max. time to receive a full fragmented packet */

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -3079,6 +3079,9 @@ Dht::onError(std::shared_ptr<Request> req, DhtProtocolException e) {
                 break;
             }
         }
+    } else if (e.getCode() == DhtProtocolException::NOT_FOUND) {
+        DHT_LOG.ERR("[node %s] returned error 404: storage not found", req->node->id.toString().c_str());
+        network_engine.cancelRequest(req);
     }
 }
 
@@ -3320,7 +3323,7 @@ NetworkEngine::RequestAnswer
 Dht::onRefresh(std::shared_ptr<Node> node, const InfoHash& hash, const Blob& token, const Value::Id& vid)
 {
     const auto& now = scheduler.time();
-    if (!tokenMatch(token, (sockaddr*)&node->addr.first)) {
+    if (not tokenMatch(token, (sockaddr*)&node->addr.first)) {
         DHT_LOG.WARN("[node %s] incorrect token %s for 'put'.", node->toString().c_str(), hash.toString().c_str());
         throw DhtProtocolException {DhtProtocolException::UNAUTHORIZED, DhtProtocolException::PUT_WRONG_TOKEN};
     }

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -1279,6 +1279,11 @@ void Dht::searchSendAnnounceValue(const std::shared_ptr<Search>& sr) {
                                                                     onDone,
                                                                     onExpired);
                                 } else if (hasValue and a.permanent) {
+                                    DHT_LOG.WARN("[search %s IPv%c] [node %s] sending 'refresh' (vid: %d)",
+                                            sr->id.toString().c_str(),
+                                            sr->af == AF_INET ? '4' : '6',
+                                            sn->node->toString().c_str(),
+                                            a.value->id);
                                     sn->acked[a.value->id] = network_engine.sendRefreshValue(sn->node,
                                                                     sr->id,
                                                                     a.value->id,

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -1278,7 +1278,15 @@ void Dht::searchSendAnnounceValue(const std::shared_ptr<Search>& sr) {
                                                                     sn->token,
                                                                     onDone,
                                                                     onExpired);
-                                } else {
+                                } else if (hasValue and a.permanent) {
+                                    sn->acked[a.value->id] = network_engine.sendRefreshValue(sn->node,
+                                                                    sr->id,
+                                                                    a.value->id,
+                                                                    sn->token,
+                                                                    onDone,
+                                                                    onExpired);
+                                }
+                                else {
                                     DHT_LOG.WARN("[search %s IPv%c] [node %s] already has value (vid: %d). Aborting.",
                                             sr->id.toString().c_str(),
                                             sr->af == AF_INET ? '4' : '6',

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -182,6 +182,20 @@ struct Dht::Storage {
     std::tuple<ValueStorage*, ssize_t, ssize_t>
     store(const std::shared_ptr<Value>& value, time_point created, ssize_t size_left);
 
+    /**
+     * Refreshes the time point of the value's lifetime begining.
+     *
+     * @param now  The reference to now;
+     * @param vid  The value id;
+     */
+    void refresh(const time_point& now, const Value::Id& vid) {
+        auto vs = std::find_if(values.begin(), values.end(), [&vid](const ValueStorage& vs) {
+            return vs.data->id == vid;
+        });
+        if (vs != values.end())
+            vs->time = now;
+    }
+
     std::pair<ssize_t, ssize_t> expire(const std::map<ValueType::Id, ValueType>& types, time_point now);
 
 private:
@@ -2640,7 +2654,8 @@ Dht::Dht(int s, int s6, Config config)
             std::bind(&Dht::onFindNode, this, _1, _2, _3),
             std::bind(&Dht::onGetValues, this, _1, _2, _3, _4),
             std::bind(&Dht::onListen, this, _1, _2, _3, _4, _5),
-            std::bind(&Dht::onAnnounce, this, _1, _2, _3, _4, _5))
+            std::bind(&Dht::onAnnounce, this, _1, _2, _3, _4, _5),
+            std::bind(&Dht::onRefresh, this, _1, _2, _3, _4))
 {
     scheduler.syncTime();
     if (s < 0 && s6 < 0)
@@ -3075,7 +3090,7 @@ Dht::onPing(std::shared_ptr<Node>)
 }
 
 NetworkEngine::RequestAnswer
-Dht::onFindNode(std::shared_ptr<Node> node, InfoHash& target, want_t want)
+Dht::onFindNode(std::shared_ptr<Node> node, const InfoHash& target, want_t want)
 {
     const auto& now = scheduler.time();
     NetworkEngine::RequestAnswer answer;
@@ -3088,7 +3103,7 @@ Dht::onFindNode(std::shared_ptr<Node> node, InfoHash& target, want_t want)
 }
 
 NetworkEngine::RequestAnswer
-Dht::onGetValues(std::shared_ptr<Node> node, InfoHash& hash, want_t, const Query& query)
+Dht::onGetValues(std::shared_ptr<Node> node, const InfoHash& hash, want_t, const Query& query)
 {
     if (hash == zeroes) {
         DHT_LOG.WARN("[node %s] Eek! Got get_values with no info_hash.", node->toString().c_str());
@@ -3185,7 +3200,7 @@ void Dht::onGetValuesDone(const Request& status,
 }
 
 NetworkEngine::RequestAnswer
-Dht::onListen(std::shared_ptr<Node> node, InfoHash& hash, Blob& token, size_t rid, Query&& query)
+Dht::onListen(std::shared_ptr<Node> node, const InfoHash& hash, const Blob& token, size_t rid, const Query& query)
 {
     if (hash == zeroes) {
         DHT_LOG.WARN("Listen with no info_hash.");
@@ -3198,7 +3213,8 @@ Dht::onListen(std::shared_ptr<Node> node, InfoHash& hash, Blob& token, size_t ri
         DHT_LOG.WARN("[node %s] incorrect token %s for 'listen'.", node->toString().c_str(), hash.toString().c_str());
         throw DhtProtocolException {DhtProtocolException::UNAUTHORIZED, DhtProtocolException::LISTEN_WRONG_TOKEN};
     }
-    storageAddListener(hash, node, rid, std::forward<Query>(query));
+    Query q = query;
+    storageAddListener(hash, node, rid, std::move(q));
     return {};
 }
 
@@ -3226,10 +3242,10 @@ Dht::onListenDone(const Request& status,
 
 NetworkEngine::RequestAnswer
 Dht::onAnnounce(std::shared_ptr<Node> node,
-        InfoHash& hash,
-        Blob& token,
-        std::vector<std::shared_ptr<Value>> values,
-        time_point created)
+        const InfoHash& hash,
+        const Blob& token,
+        const std::vector<std::shared_ptr<Value>>& values,
+        const time_point& created)
 {
     if (hash == zeroes) {
         DHT_LOG.WARN("Put with no info_hash.");
@@ -3288,6 +3304,28 @@ Dht::onAnnounce(std::shared_ptr<Node> node,
                         hash.toString().c_str(), vc->id, vc->toString().c_str());
             }
         }
+    }
+    return {};
+}
+
+NetworkEngine::RequestAnswer
+Dht::onRefresh(std::shared_ptr<Node> node, const InfoHash& hash, const Blob& token, const Value::Id& vid)
+{
+    const auto& now = scheduler.time();
+    if (!tokenMatch(token, (sockaddr*)&node->addr.first)) {
+        DHT_LOG.WARN("[node %s] incorrect token %s for 'put'.", node->toString().c_str(), hash.toString().c_str());
+        throw DhtProtocolException {DhtProtocolException::UNAUTHORIZED, DhtProtocolException::PUT_WRONG_TOKEN};
+    }
+
+    auto s = store.find(hash);
+    if (s != store.end()) {
+        DHT_LOG.DEBUG("[Storage %s] refreshed value (vid: %d).", hash.toString().c_str(), vid);
+        s->second.refresh(now, vid);
+    } else {
+        DHT_LOG.DEBUG("[node %s] got refresh value for unknown storage (id: %s).",
+                node->id.toString().c_str(),
+                hash.toString().c_str());
+        throw DhtProtocolException {DhtProtocolException::NOT_FOUND, DhtProtocolException::STORAGE_NOT_FOUND};
     }
     return {};
 }

--- a/src/network_engine.cpp
+++ b/src/network_engine.cpp
@@ -1102,7 +1102,7 @@ NetworkEngine::sendRefreshValue(std::shared_ptr<Node> n,
     msgpack::packer<msgpack::sbuffer> pk(&buffer);
     pk.pack_map(5+(network?1:0));
 
-    pk.pack(std::string("a")); pk.pack_map(3);
+    pk.pack(std::string("a")); pk.pack_map(4);
       pk.pack(std::string("id"));  pk.pack(myid);
       pk.pack(std::string("h"));  pk.pack(infohash);
       pk.pack(std::string("vid")); pk.pack(vid);

--- a/src/network_engine.cpp
+++ b/src/network_engine.cpp
@@ -467,14 +467,14 @@ NetworkEngine::process(std::unique_ptr<ParsedMessage>&& msg, const SockAddr& fro
 
         switch (msg->type) {
         case MessageType::Error: {
-            if (msg->error_code == DhtProtocolException::UNAUTHORIZED
-                    && msg->id != zeroes
-                    && (msg->tid.matches(TransPrefix::ANNOUNCE_VALUES)
-                     || msg->tid.matches(TransPrefix::LISTEN)))
+            if (msg->id != zeroes
+                    and (msg->tid.matches(TransPrefix::ANNOUNCE_VALUES)
+                     or msg->tid.matches(TransPrefix::REFRESH)
+                     or msg->tid.matches(TransPrefix::LISTEN)))
             {
                 req->last_try = TIME_INVALID;
                 req->reply_time = TIME_INVALID;
-                onError(req, DhtProtocolException {DhtProtocolException::UNAUTHORIZED});
+                onError(req, DhtProtocolException {msg->error_code});
             } else {
                 DHT_LOG.WARN("[node %s %s] received unknown error message %u",
                         msg->id.toString().c_str(), from.toString().c_str(), msg->error_code);

--- a/src/network_engine.cpp
+++ b/src/network_engine.cpp
@@ -33,6 +33,7 @@ const std::string DhtProtocolException::LISTEN_WRONG_TOKEN {"Listen with wrong t
 const std::string DhtProtocolException::PUT_NO_INFOHASH {"Put with no info_hash"};
 const std::string DhtProtocolException::PUT_WRONG_TOKEN {"Put with wrong token"};
 const std::string DhtProtocolException::PUT_INVALID_ID {"Put with invalid id"};
+const std::string DhtProtocolException::STORAGE_NOT_FOUND {"Access operation for unknown storage"};
 
 constexpr std::chrono::seconds NetworkEngine::UDP_REPLY_TIME;
 constexpr std::chrono::seconds NetworkEngine::RX_MAX_PACKET_TIME;
@@ -43,10 +44,11 @@ const constexpr uint16_t NetworkEngine::TransId::INVALID;
 std::mt19937 NetworkEngine::rd_device {dht::crypto::random_device{}()};
 
 const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::PING = {"pn"};
-const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::FIND_NODE  = {"fn"};
-const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::GET_VALUES  = {"gt"};
-const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::ANNOUNCE_VALUES  = {"pt"};
-const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::LISTEN  = {"lt"};
+const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::FIND_NODE = {"fn"};
+const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::GET_VALUES = {"gt"};
+const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::ANNOUNCE_VALUES = {"pt"};
+const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::REFRESH = {"rf"};
+const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::LISTEN = {"lt"};
 constexpr long unsigned NetworkEngine::MAX_REQUESTS_PER_SEC;
 
 static const uint8_t v4prefix[16] = {
@@ -62,6 +64,7 @@ enum class MessageType {
     FindNode,
     GetValues,
     AnnounceValue,
+    Refresh,
     Listen,
     ValueData
 };
@@ -88,7 +91,7 @@ struct ParsedMessage {
     Blob nodes4_raw, nodes6_raw;
     std::vector<std::shared_ptr<Node>> nodes4, nodes6;
     /* values to store or retreive request */
-    std::vector<std::shared_ptr<Value>> values;           
+    std::vector<std::shared_ptr<Value>> values;
     /* index for fields values */
     std::vector<std::shared_ptr<FieldValueIndex>> fields;
     /** When part of the message header: {index -> (total size, {})}
@@ -139,10 +142,11 @@ NetworkEngine::NetworkEngine(InfoHash& myid, NetId net, int s, int s6, Logger& l
         decltype(NetworkEngine::onFindNode) onFindNode,
         decltype(NetworkEngine::onGetValues) onGetValues,
         decltype(NetworkEngine::onListen) onListen,
-        decltype(NetworkEngine::onAnnounce) onAnnounce) :
+        decltype(NetworkEngine::onAnnounce) onAnnounce,
+        decltype(NetworkEngine::onRefresh) onRefresh) :
     onError(onError), onNewNode(onNewNode), onReportedAddr(onReportedAddr), onPing(onPing), onFindNode(onFindNode),
-    onGetValues(onGetValues), onListen(onListen), onAnnounce(onAnnounce), myid(myid), network(net),
-    dht_socket(s), dht_socket6(s6), DHT_LOG(log), scheduler(scheduler)
+    onGetValues(onGetValues), onListen(onListen), onAnnounce(onAnnounce), onRefresh(onRefresh), myid(myid),
+    network(net), dht_socket(s), dht_socket6(s6), DHT_LOG(log), scheduler(scheduler)
 {
     transaction_id = std::uniform_int_distribution<decltype(transaction_id)>{1}(rd_device);
 }
@@ -537,6 +541,14 @@ NetworkEngine::process(std::unique_ptr<ParsedMessage>&& msg, const SockAddr& fro
                 }
                 break;
             }
+            case MessageType::Refresh:
+                DHT_LOG.DEBUG("[node %s %s] got 'refresh value' request for %s.",
+                    msg->id.toString().c_str(), from.toString().c_str(),
+                    msg->info_hash.toString().c_str());
+                onRefresh(node, msg->info_hash, msg->token, msg->value_id);
+                /* Same note as above in MessageType::AnnounceValue applies. */
+                sendValueAnnounced(from, msg->tid, msg->value_id);
+                break;
             case MessageType::Listen: {
                 DHT_LOG.DEBUG("[node %s %s] got 'listen' request for %s.",
                         msg->id.toString().c_str(), from.toString().c_str(), msg->info_hash.toString().c_str());
@@ -1019,8 +1031,14 @@ NetworkEngine::sendListenConfirmation(const SockAddr& addr, TransId tid) {
 }
 
 std::shared_ptr<Request>
-NetworkEngine::sendAnnounceValue(std::shared_ptr<Node> n, const InfoHash& infohash, const std::shared_ptr<Value>& value, time_point created,
-        const Blob& token, RequestCb on_done, RequestExpiredCb on_expired) {
+NetworkEngine::sendAnnounceValue(std::shared_ptr<Node> n,
+        const InfoHash& infohash,
+        const std::shared_ptr<Value>& value,
+        time_point created,
+        const Blob& token,
+        RequestCb on_done,
+        RequestExpiredCb on_expired)
+{
     auto tid = TransId {TransPrefix::ANNOUNCE_VALUES, getNewTid()};
     msgpack::sbuffer buffer;
     msgpack::packer<msgpack::sbuffer> pk(&buffer);
@@ -1069,6 +1087,59 @@ NetworkEngine::sendAnnounceValue(std::shared_ptr<Node> n, const InfoHash& infoha
         sendValueParts(tid, v, n->addr);
     ++out_stats.put;
     return req;
+}
+
+std::shared_ptr<Request>
+NetworkEngine::sendRefreshValue(std::shared_ptr<Node> n,
+                const InfoHash& infohash,
+                const Value::Id& vid,
+                const Blob& token,
+                RequestCb on_done,
+                RequestExpiredCb on_expired)
+{
+    auto tid = TransId {TransPrefix::REFRESH, getNewTid()};
+    msgpack::sbuffer buffer;
+    msgpack::packer<msgpack::sbuffer> pk(&buffer);
+    pk.pack_map(5+(network?1:0));
+
+    pk.pack(std::string("a")); pk.pack_map(3);
+      pk.pack(std::string("id"));  pk.pack(myid);
+      pk.pack(std::string("h"));  pk.pack(infohash);
+      pk.pack(std::string("vid")); pk.pack(vid);
+      pk.pack(std::string("token"));  pk.pack(token);
+
+    pk.pack(std::string("q")); pk.pack(std::string("refresh"));
+    pk.pack(std::string("t")); pk.pack_bin(tid.size());
+                               pk.pack_bin_body((const char*)tid.data(), tid.size());
+    pk.pack(std::string("y")); pk.pack(std::string("q"));
+    pk.pack(std::string("v")); pk.pack(my_v);
+    if (network) {
+        pk.pack(std::string("n")); pk.pack(network);
+    }
+
+    Blob b {buffer.data(), buffer.data() + buffer.size()};
+    std::shared_ptr<Request> req(new Request {tid.getTid(), n, std::move(b),
+        [=](const Request& req_status, ParsedMessage&& msg) { /* on done */
+            if (msg.value_id == Value::INVALID_ID) {
+                DHT_LOG.DEBUG("Unknown search or announce!");
+            } else {
+                if (on_done) {
+                    RequestAnswer answer {};
+                    answer.vid = msg.value_id;
+                    on_done(req_status, std::move(answer));
+                }
+            }
+        },
+        [=](const Request& req_status, bool done) { /* on expired */
+            if (on_expired) {
+                on_expired(req_status, done);
+            }
+        }
+    });
+    sendRequest(req);
+    ++out_stats.refresh;
+    return req;
+
 }
 
 void
@@ -1165,6 +1236,8 @@ ParsedMessage::msgpack_unpack(msgpack::object msg)
         type = MessageType::Listen;
     else if (q == "put")
         type = MessageType::AnnounceValue;
+    else if (q == "refresh")
+        type = MessageType::Refresh;
     else
         throw msgpack::type_error();
 


### PR DESCRIPTION
Since the introduction of the new "put" operation's behavior in 8f2cc93, the permanent put feature was broken every 2*Value::type.expiration minutes following a successful announce. This was due to the behavior where we didn't send a value if it was already announced to some nodes. However, since we reannounce with a time margin before a value expires, the reannounce operation would fail one time out of two.