### PR TITLE
dht: uniformly sync SearchNodes reannouncing

### DIFF
--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -2827,7 +2827,6 @@ Dht::maintainStorage(InfoHash id, bool force, DoneCallback donecb) {
             want4 = false;
         }
     }
-    else { want4 = false; }
 
     auto nodes6 = buckets6.findClosestNodes(id, now);
     if (!nodes6.empty()) {
@@ -2843,7 +2842,6 @@ Dht::maintainStorage(InfoHash id, bool force, DoneCallback donecb) {
             want6 = false;
         }
     }
-    else { want6 = false; }
 
     if (not want4 and not want6) {
         DHT_LOG_DEBUG("Discarding storage values %s", id.toString().c_str());


### PR DESCRIPTION
Historically, the next announce timing was based on the last acknowledgement received from a SearchNode. This behavior was invalid since the 'refresh' operation. In fact, for a given value that was "refreshed", its creation time would differ from the announcer's info. Therefor, all search node's reannouncing timings would differ, hence causing inconsistency on the network.
