### PR TITLE
dht: make reannounce margin bigger, safer

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -331,7 +331,7 @@ private:
     /* Timeout for listen */
     static constexpr std::chrono::seconds LISTEN_EXPIRE_TIME {30};
 
-    static constexpr std::chrono::seconds REANNOUNCE_MARGIN {5};
+    static constexpr std::chrono::seconds REANNOUNCE_MARGIN {10};
 
     static constexpr size_t TOKEN_SIZE {64};
 


### PR DESCRIPTION
Reannouncing margin going from 5 seconds to ~~30~~10 seconds.

In the case of a "permanent put", refreshing values need to be done sooner than 5 seconds before the expiration time of the value. It is common for a "put" operation to take up to 5 seconds when a search is not synced. A search can easily become unsynced after 10 minutes.