### PR TITLE
Listen consistency

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -558,13 +558,15 @@ private:
     net::NetworkEngine::RequestAnswer onPing(std::shared_ptr<Node> node);
     /* when we receive a "find node" request */
     net::NetworkEngine::RequestAnswer onFindNode(std::shared_ptr<Node> node, const InfoHash& hash, want_t want);
-    void onFindNodeDone(const Request& status, net::NetworkEngine::RequestAnswer& a, std::shared_ptr<Search> sr);
+    void onFindNodeDone(const std::shared_ptr<Node>& status,
+            net::NetworkEngine::RequestAnswer& a,
+            std::shared_ptr<Search> sr);
     /* when we receive a "get values" request */
     net::NetworkEngine::RequestAnswer onGetValues(std::shared_ptr<Node> node,
             const InfoHash& hash,
             want_t want,
             const Query& q);
-    void onGetValuesDone(const Request& status,
+    void onGetValuesDone(const std::shared_ptr<Node>& status,
             net::NetworkEngine::RequestAnswer& a,
             std::shared_ptr<Search>& sr,
             const std::shared_ptr<Query>& orig_query);
@@ -572,12 +574,11 @@ private:
     net::NetworkEngine::RequestAnswer onListen(std::shared_ptr<Node> node,
             const InfoHash& hash,
             const Blob& token,
-            size_t rid,
+            size_t socket_id,
             const Query& query);
-    void onListenDone(const Request& status,
+    void onListenDone(const std::shared_ptr<Node>& status,
             net::NetworkEngine::RequestAnswer& a,
-            std::shared_ptr<Search>& sr,
-            const std::shared_ptr<Query>& orig_query);
+            std::shared_ptr<Search>& sr);
     /* when we receive an announce request */
     net::NetworkEngine::RequestAnswer onAnnounce(std::shared_ptr<Node> node,
             const InfoHash& hash,
@@ -588,7 +589,9 @@ private:
             const InfoHash& hash,
             const Blob& token,
             const Value::Id& vid);
-    void onAnnounceDone(const Request& status, net::NetworkEngine::RequestAnswer& a, std::shared_ptr<Search>& sr);
+    void onAnnounceDone(const std::shared_ptr<Node>& status,
+            net::NetworkEngine::RequestAnswer& a,
+            std::shared_ptr<Search>& sr);
 };
 
 }

--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -41,7 +41,9 @@
 
 namespace dht {
 
+namespace net {
 struct Request;
+} /* namespace net */
 
 /**
  * Main Dht class.
@@ -402,7 +404,7 @@ private:
     std::shared_ptr<Scheduler::Job> nextStorageMaintenance {};
     time_point mybucket_grow_time {time_point::min()}, mybucket6_grow_time {time_point::min()};
 
-    NetworkEngine network_engine;
+    net::NetworkEngine network_engine;
     unsigned pending_pings4 {0};
     unsigned pending_pings6 {0};
 
@@ -497,8 +499,8 @@ private:
      * @param ws      A weak pointer to the search concerned by the request.
      * @param query   The query sent to the node.
      */
-    void searchNodeGetDone(const Request& status,
-            NetworkEngine::RequestAnswer&& answer,
+    void searchNodeGetDone(const net::Request& status,
+            net::NetworkEngine::RequestAnswer&& answer,
             std::weak_ptr<Search> ws,
             std::shared_ptr<Query> query);
 
@@ -511,7 +513,7 @@ private:
      * @param ws      A weak pointer to the search concerned by the request.
      * @param query   The query sent to the node.
      */
-    void searchNodeGetExpired(const Request& status, bool over, std::weak_ptr<Search> ws, std::shared_ptr<Query> query);
+    void searchNodeGetExpired(const net::Request& status, bool over, std::weak_ptr<Search> ws, std::shared_ptr<Query> query);
 
     /**
      * This method recovers sends individual request for values per id.
@@ -549,44 +551,44 @@ private:
 
     void processMessage(const uint8_t *buf, size_t buflen, const SockAddr&);
 
-    void onError(std::shared_ptr<Request> node, DhtProtocolException e);
+    void onError(std::shared_ptr<net::Request> node, net::DhtProtocolException e);
     /* when our address is reported by a distant peer. */
     void onReportedAddr(const InfoHash& id, const SockAddr&);
     /* when we receive a ping request */
-    NetworkEngine::RequestAnswer onPing(std::shared_ptr<Node> node);
+    net::NetworkEngine::RequestAnswer onPing(std::shared_ptr<Node> node);
     /* when we receive a "find node" request */
-    NetworkEngine::RequestAnswer onFindNode(std::shared_ptr<Node> node, const InfoHash& hash, want_t want);
-    void onFindNodeDone(const Request& status, NetworkEngine::RequestAnswer& a, std::shared_ptr<Search> sr);
+    net::NetworkEngine::RequestAnswer onFindNode(std::shared_ptr<Node> node, const InfoHash& hash, want_t want);
+    void onFindNodeDone(const Request& status, net::NetworkEngine::RequestAnswer& a, std::shared_ptr<Search> sr);
     /* when we receive a "get values" request */
-    NetworkEngine::RequestAnswer onGetValues(std::shared_ptr<Node> node,
+    net::NetworkEngine::RequestAnswer onGetValues(std::shared_ptr<Node> node,
             const InfoHash& hash,
             want_t want,
             const Query& q);
     void onGetValuesDone(const Request& status,
-            NetworkEngine::RequestAnswer& a,
+            net::NetworkEngine::RequestAnswer& a,
             std::shared_ptr<Search>& sr,
             const std::shared_ptr<Query>& orig_query);
     /* when we receive a listen request */
-    NetworkEngine::RequestAnswer onListen(std::shared_ptr<Node> node,
+    net::NetworkEngine::RequestAnswer onListen(std::shared_ptr<Node> node,
             const InfoHash& hash,
             const Blob& token,
             size_t rid,
             const Query& query);
     void onListenDone(const Request& status,
-            NetworkEngine::RequestAnswer& a,
+            net::NetworkEngine::RequestAnswer& a,
             std::shared_ptr<Search>& sr,
             const std::shared_ptr<Query>& orig_query);
     /* when we receive an announce request */
-    NetworkEngine::RequestAnswer onAnnounce(std::shared_ptr<Node> node,
+    net::NetworkEngine::RequestAnswer onAnnounce(std::shared_ptr<Node> node,
             const InfoHash& hash,
             const Blob& token,
             const std::vector<std::shared_ptr<Value>>& v,
             const time_point& created);
-    NetworkEngine::RequestAnswer onRefresh(std::shared_ptr<Node> node,
+    net::NetworkEngine::RequestAnswer onRefresh(std::shared_ptr<Node> node,
             const InfoHash& hash,
             const Blob& token,
             const Value::Id& vid);
-    void onAnnounceDone(const Request& status, NetworkEngine::RequestAnswer& a, std::shared_ptr<Search>& sr);
+    void onAnnounceDone(const Request& status, net::NetworkEngine::RequestAnswer& a, std::shared_ptr<Search>& sr);
 };
 
 }

--- a/include/opendht/network_engine.h
+++ b/include/opendht/network_engine.h
@@ -41,6 +41,7 @@ namespace dht {
 namespace net {
 
 struct Request;
+struct Socket;
 
 #ifndef MSG_CONFIRM
 #define MSG_CONFIRM 0
@@ -120,16 +121,7 @@ public:
     };
 
 
-    /**
-     * Cancel a request. Setting req->cancelled = true is not enough in the case
-     * a request is "persistent".
-     */
-    void cancelRequest(std::shared_ptr<Request>& req);
-
-    void connectivityChanged(sa_family_t);
-
 private:
-
     /**
      * @brief when we receive an error message.
      *
@@ -196,7 +188,7 @@ private:
     std::function<RequestAnswer(std::shared_ptr<Node>,
             const InfoHash&,
             const Blob&,
-            uint16_t,
+            uint32_t,
             const Query&)> onListen {};
     /**
      * @brief on announce request callback.
@@ -226,6 +218,7 @@ private:
             const Value::Id&)> onRefresh {};
 
 public:
+    using SocketCb = std::function<void(const std::shared_ptr<Node>&, RequestAnswer&&)>;
     using RequestCb = std::function<void(const Request&, RequestAnswer&&)>;
     using RequestExpiredCb = std::function<void(const Request&, bool)>;
 
@@ -248,67 +241,186 @@ public:
     /**
      * Sends values (with closest nodes) to a listenner.
      *
-     * @param sa  The address of the listenner.
-     * @param sslen  The length of the sockaddr structure.
-     * @param rid  The request id of the initial listen request.
-     * @param hash  The hash key of the value.
-     * @param want  Wether to send ipv4 and/or ipv6 nodes.
-     * @param ntoken  Listen security token.
-     * @param nodes  The ipv4 closest nodes.
-     * @param nodes6  The ipv6 closest nodes.
-     * @param values  The values to send.
+     * @param sa          The address of the listenner.
+     * @param sslen       The length of the sockaddr structure.
+     * @param socket_id  The tid to use to write to the request socket.
+     * @param hash        The hash key of the value.
+     * @param want        Wether to send ipv4 and/or ipv6 nodes.
+     * @param ntoken      Listen security token.
+     * @param nodes       The ipv4 closest nodes.
+     * @param nodes6      The ipv6 closest nodes.
+     * @param values      The values to send.
      */
-    void tellListener(std::shared_ptr<Node> n, uint16_t rid, const InfoHash& hash, want_t want, const Blob& ntoken,
+    void tellListener(std::shared_ptr<Node> n, uint32_t socket_id, const InfoHash& hash, want_t want, const Blob& ntoken,
             std::vector<std::shared_ptr<Node>>&& nodes, std::vector<std::shared_ptr<Node>>&& nodes6,
             std::vector<std::shared_ptr<Value>>&& values, const Query& q);
 
     bool isRunning(sa_family_t af) const;
     inline want_t want () const { return dht_socket >= 0 && dht_socket6 >= 0 ? (WANT4 | WANT6) : -1; }
 
+    /**
+     * Cancel a request. Setting req->cancelled = true is not enough in the case
+     * a request is "persistent".
+     */
+    void cancelRequest(std::shared_ptr<Request>& req);
+
+    void connectivityChanged(sa_family_t);
+
     /**************
      *  Requests  *
      **************/
+
+    /**
+     * Send a "ping" request to a given node.
+     *
+     * @param n           The node.
+     * @param on_done     Request callback when the request is completed.
+     * @param on_expired  Request callback when the request expires.
+     *
+     * @return the request with information concerning its success.
+     */
     std::shared_ptr<Request>
-        sendPing(std::shared_ptr<Node> n, RequestCb on_done, RequestExpiredCb on_expired);
+        sendPing(std::shared_ptr<Node> n, RequestCb&& on_done, RequestExpiredCb&& on_expired);
+    /**
+     * Send a "ping" request to a given node.
+     *
+     * @param sa          The node's ip sockaddr info.
+     * @param salen       The associated sockaddr struct length.
+     * @param on_done     Request callback when the request is completed.
+     * @param on_expired  Request callback when the request expires.
+     *
+     * @return the request with information concerning its success.
+     */
     std::shared_ptr<Request>
-        sendPing(const sockaddr* sa, socklen_t salen, RequestCb on_done, RequestExpiredCb on_expired) {
-            return sendPing(std::make_shared<Node>(zeroes, sa, salen), on_done, on_expired);
+        sendPing(const sockaddr* sa, socklen_t salen, RequestCb&& on_done, RequestExpiredCb&& on_expired) {
+            return sendPing(std::make_shared<Node>(zeroes, sa, salen),
+                    std::forward<RequestCb>(on_done),
+                    std::forward<RequestExpiredCb>(on_expired));
         }
-    std::shared_ptr<Request>
-        sendFindNode(std::shared_ptr<Node> n,
-                const InfoHash& target,
-                want_t want,
-                RequestCb on_done,
-                RequestExpiredCb on_expired);
-    std::shared_ptr<Request>
-        sendGetValues(std::shared_ptr<Node> n,
-                const InfoHash& info_hash,
-                const Query& query,
-                want_t want,
-                RequestCb on_done,
-                RequestExpiredCb on_expired);
-    std::shared_ptr<Request>
-        sendListen(std::shared_ptr<Node> n,
-                const InfoHash& infohash,
-                const Query& query,
-                const Blob& token,
-                RequestCb on_done,
-                RequestExpiredCb on_expired);
-    std::shared_ptr<Request>
-        sendAnnounceValue(std::shared_ptr<Node> n,
-                const InfoHash& infohash,
-                const std::shared_ptr<Value>& v,
-                time_point created,
-                const Blob& token,
-                RequestCb on_done,
-                RequestExpiredCb on_expired);
-    std::shared_ptr<Request>
-        sendRefreshValue(std::shared_ptr<Node> n,
-                const InfoHash& infohash,
-                const Value::Id& vid,
-                const Blob& token,
-                RequestCb on_done,
-                RequestExpiredCb on_expired);
+    /**
+     * Send a "find node" request to a given node.
+     *
+     * @param n           The node.
+     * @param target      The target hash.
+     * @param want        Indicating wether IPv4 or IPv6 are wanted in response.
+     *                    Use NetworkEngine::want()
+     * @param on_done     Request callback when the request is completed.
+     * @param on_expired  Request callback when the request expires.
+     *
+     * @return the request with information concerning its success.
+     */
+    std::shared_ptr<Request> sendFindNode(std::shared_ptr<Node> n,
+                                          const InfoHash& hash,
+                                          want_t want,
+                                          RequestCb&& on_done,
+                                          RequestExpiredCb&& on_expired);
+    /**
+     * Send a "get" request to a given node.
+     *
+     * @param n           The node.
+     * @param hash        The target hash.
+     * @param query       The query describing filters.
+     * @param token       A security token.
+     * @param want        Indicating wether IPv4 or IPv6 are wanted in response.
+     *                    Use NetworkEngine::want()
+     * @param on_done     Request callback when the request is completed.
+     * @param on_expired  Request callback when the request expires.
+     *
+     * @return the request with information concerning its success.
+     */
+    std::shared_ptr<Request> sendGetValues(std::shared_ptr<Node> n,
+                                           const InfoHash& hash,
+                                           const Query& query,
+                                           want_t want,
+                                           RequestCb&& on_done,
+                                           RequestExpiredCb&& on_expired);
+    /**
+     * Send a "listen" request to a given node.
+     *
+     * @param n           The node.
+     * @param hash        The storage's hash.
+     * @param query       The query describing filters.
+     * @param token       A security token.
+     * @param previous    The previous request "listen" sent to this node.
+     * @param socket      **UNUSED** The socket for further response.
+     *
+     *                    For backward compatibility purpose, sendListen has to
+     *                    handle creation of the socket. Therefor, you cannot
+     *                    use openSocket yourself. TODO: Once we don't support
+     *                    the old "listen" negociation, sendListen shall not
+     *                    create the socket itself.
+     *
+     * @param on_done     Request callback when the request is completed.
+     * @param on_expired  Request callback when the request expires.
+     * @param socket_cb   Callback to execute each time new updates arrive on
+     *                    the socket.
+     *
+     * @return the request with information concerning its success.
+     */
+    std::shared_ptr<Request> sendListen(std::shared_ptr<Node> n,
+                                        const InfoHash& hash,
+                                        const Query& query,
+                                        const Blob& token,
+                                        std::shared_ptr<Request> previous,
+                                        RequestCb&& on_done,
+                                        RequestExpiredCb&& on_expired,
+                                        SocketCb&& socket_cb);
+    /**
+     * Send a "announce" request to a given node.
+     *
+     * @param n           The node.
+     * @param hash        The target hash.
+     * @param created     The time when the value was created (avoiding extended
+     *                    value lifetime)
+     * @param token       A security token.
+     * @param on_done     Request callback when the request is completed.
+     * @param on_expired  Request callback when the request expires.
+     *
+     * @return the request with information concerning its success.
+     */
+    std::shared_ptr<Request> sendAnnounceValue(std::shared_ptr<Node> n,
+                                               const InfoHash& hash,
+                                               const std::shared_ptr<Value>& v,
+                                               time_point created,
+                                               const Blob& token,
+                                               RequestCb&& on_done,
+                                               RequestExpiredCb&& on_expired);
+    /**
+     * Send a "refresh" request to a given node. Asks a node to keep the
+     * associated value Value.type.expiration more minutes in its storage.
+     *
+     * @param n           The node.
+     * @param hash        The target hash.
+     * @param vid         The value id.
+     * @param token       A security token.
+     * @param on_done     Request callback when the request is completed.
+     * @param on_expired  Request callback when the request expires.
+     *
+     * @return the request with information concerning its success.
+     */
+    std::shared_ptr<Request> sendRefreshValue(std::shared_ptr<Node> n,
+                                              const InfoHash& hash,
+                                              const Value::Id& vid,
+                                              const Blob& token,
+                                              RequestCb&& on_done,
+                                              RequestExpiredCb&& on_expired);
+    /**
+     * Opens a socket on which a node will be able allowed to write for further
+     * additionnal updates following the response to a previous request.
+     *
+     * @param node  The node which will be allowed to write on this socket.
+     * @param cb    The callback to execute once updates arrive on the socket.
+     *
+     * @return the socket.
+     */
+    std::shared_ptr<Socket> openSocket(const std::shared_ptr<Node>& node, TransPrefix tp, SocketCb&& cb);
+
+    /**
+     * Closes a socket so that no further data will be red on that socket.
+     *
+     * @param socket  The socket to close.
+     */
+    void closeSocket(std::shared_ptr<Socket> socket);
 
     /**
      * Parses a message and calls appropriate callbacks.
@@ -489,8 +601,10 @@ private:
 
     // requests handling
     uint16_t transaction_id {1};
-    std::map<uint16_t, std::shared_ptr<Request>> requests {};
+    std::map<TransId, std::shared_ptr<Request>> requests {};
     std::map<TransId, PartialMessage> partial_messages;
+    std::map<TransId, std::shared_ptr<Socket>> opened_sockets {};
+
     MessageStats in_stats {}, out_stats {};
     std::set<SockAddr> blacklist {};
 

--- a/include/opendht/node.h
+++ b/include/opendht/node.h
@@ -28,7 +28,9 @@
 
 namespace dht {
 
+namespace net {
 struct Request;
+} /* namespace net */
 
 struct Node {
     InfoHash id;
@@ -72,8 +74,8 @@ struct Node {
 
     void update(const SockAddr&);
 
-    void requested(std::shared_ptr<Request>& req);
-    void received(time_point now, std::shared_ptr<Request> req);
+    void requested(std::shared_ptr<net::Request>& req);
+    void received(time_point now, std::shared_ptr<net::Request> req);
 
     void setExpired();
 
@@ -98,12 +100,12 @@ private:
     /* Number of times we accept authentication errors from this node. */
     static const constexpr unsigned MAX_AUTH_ERRORS {3};
 
-    std::list<std::weak_ptr<Request>> requests_ {};
+    std::list<std::weak_ptr<net::Request>> requests_ {};
     unsigned auth_errors {0};
     bool expired_ {false};
 
     void clearPendingQueue() {
-        requests_.remove_if([](std::weak_ptr<Request>& w) {
+        requests_.remove_if([](std::weak_ptr<net::Request>& w) {
             return w.expired();
         });
     }

--- a/include/opendht/request.h
+++ b/include/opendht/request.h
@@ -29,6 +29,27 @@ class NetworkEngine;
 struct ParsedMessage;
 
 /*!
+ * @class   Socket
+ * @brief   Open route to a node for continous incoming packets.
+ * @details
+ * A socket lets a remote node send us continuous packets treated using a
+ * given callback. This is intended to provide an easy management of
+ * specific updates nodes can send. For e.g, this is used in the case of the
+ * "listen" operation for treating updates a node has for a given storage.
+ */
+struct Socket {
+    Socket() {}
+    Socket(std::shared_ptr<Node> node,
+           TransId id,
+           std::function<void(const std::shared_ptr<Node>&, ParsedMessage&&)> on_receive) :
+        node(node), id(id), on_receive(on_receive) {}
+
+    std::shared_ptr<Node> node;
+    TransId id;
+    std::function<void(const std::shared_ptr<Node>&, ParsedMessage&&)> on_receive {};
+};
+
+/*!
  * @class   Request
  * @brief   An atomic request destined to a node.
  * @details
@@ -58,13 +79,13 @@ struct Request {
     State getState() const { return state_; }
 
     Request() {}
-    Request(uint16_t tid,
+    Request(TransId tid,
             std::shared_ptr<Node> node,
             Blob&& msg,
-            std::function<void(const Request& req_status, ParsedMessage&&)> on_done,
-            std::function<void(const Request& req_status, bool)> on_expired,
-            bool persistent = false) :
-        node(node), on_done(on_done), on_expired(on_expired), tid(tid), msg(std::move(msg)), persistent(persistent) { }
+            std::function<void(const Request&, ParsedMessage&&)> on_done,
+            std::function<void(const Request&, bool)> on_expired,
+            std::shared_ptr<Socket> socket = {}) :
+        node(node), on_done(on_done), on_expired(on_expired), tid(tid), msg(std::move(msg)), socket(socket) { }
 
     void setExpired() {
         if (pending()) {
@@ -74,11 +95,10 @@ struct Request {
         }
     }
     void setDone(ParsedMessage&& msg) {
-        if (pending() or persistent) {
+        if (pending()) {
             state_ = Request::State::COMPLETED;
             on_done(*this, std::forward<ParsedMessage>(msg));
-            if (not persistent)
-                clear();
+            clear();
         }
     }
 
@@ -108,12 +128,12 @@ private:
     time_point start {time_point::min()};      /* time when the request is created. */
     time_point last_try {time_point::min()};   /* time of the last attempt to process the request. */
 
-    std::function<void(const Request& req_status, ParsedMessage&&)> on_done {};
-    std::function<void(const Request& req_status, bool)> on_expired {};
+    std::function<void(const Request&, ParsedMessage&&)> on_done {};
+    std::function<void(const Request&, bool)> on_expired {};
 
-    const uint16_t tid {0};                   /* the request id. */
-    Blob msg {};                              /* the serialized message. */
-    const bool persistent {false};            /* the request is not erased upon completion. */
+    const TransId tid; /* the request id. */
+    Blob msg {};                      /* the serialized message. */
+    std::shared_ptr<Socket> socket;   /* the socket used for further reponses. */
 };
 
 } /* namespace net  */

--- a/include/opendht/request.h
+++ b/include/opendht/request.h
@@ -18,7 +18,12 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.
  */
 
+#pragma once
+
+#include "net.h"
+
 namespace dht {
+namespace net {
 
 class NetworkEngine;
 struct ParsedMessage;
@@ -32,7 +37,8 @@ struct ParsedMessage;
  * request is done.
  */
 struct Request {
-    friend class dht::NetworkEngine;
+    friend class dht::net::NetworkEngine;
+
     std::shared_ptr<Node> node {};             /* the node to whom the request is destined. */
     time_point reply_time {time_point::min()}; /* time when we received the response to the request. */
 
@@ -110,4 +116,5 @@ private:
     const bool persistent {false};            /* the request is not erased upon completion. */
 };
 
+} /* namespace net  */
 }

--- a/net.h
+++ b/net.h
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (C) 2014-2016 Savoir-faire Linux Inc.
+ *  Author(s) : Adrien Béraud <adrien.beraud@savoirfairelinux.com>
+ *              Simon Désaulniers <sim.desaulniers@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+namespace dht {
+namespace net {
+
+struct TransPrefix : public std::array<uint8_t, 2> {
+    TransPrefix(const std::string& str) : std::array<uint8_t, 2>({{(uint8_t)str[0], (uint8_t)str[1]}}) {}
+    static const TransPrefix PING;
+    static const TransPrefix FIND_NODE;
+    static const TransPrefix GET_VALUES;
+    static const TransPrefix ANNOUNCE_VALUES;
+    static const TransPrefix REFRESH;
+    static const TransPrefix LISTEN;
+};
+
+/* Transaction-ids are 4-bytes long, with the first two bytes identifying
+ * the kind of request, and the remaining two a sequence number in
+ * host order.
+ */
+struct TransId final : public std::array<uint8_t, 4> {
+    static const constexpr uint16_t INVALID {0};
+
+    TransId() { std::fill_n(begin(), 4, 0); }
+    TransId(const std::array<char, 4>& o) { std::copy(o.begin(), o.end(), begin()); }
+    TransId(const TransPrefix prefix, uint16_t seqno = 0) {
+        std::copy_n(prefix.begin(), prefix.size(), begin());
+        *reinterpret_cast<uint16_t*>(data()+prefix.size()) = seqno;
+    }
+
+    TransId(const char* q, size_t l) : array<uint8_t, 4>() {
+        if (l > 4) {
+            length = 0;
+        } else {
+            std::copy_n(q, l, begin());
+            length = l;
+        }
+    }
+
+    uint16_t getTid() const {
+        return *reinterpret_cast<const uint16_t*>(&(*this)[2]);
+    }
+
+    uint32_t toInt() const {
+        return *reinterpret_cast<const uint32_t*>(&(*this)[0]);
+    }
+
+    bool matches(const TransPrefix prefix, uint16_t* tid = nullptr) const {
+        if (std::equal(begin(), begin()+2, prefix.begin())) {
+            if (tid)
+                *tid = getTid();
+            return true;
+        } else
+            return false;
+    }
+
+    unsigned length {4};
+};
+
+} /* namespace net */
+} /* dht */

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -94,15 +94,16 @@ constexpr std::chrono::seconds Dht::REANNOUNCE_MARGIN;
  * Foreign nodes asking for updates about an InfoHash.
  */
 struct Dht::Listener {
-    size_t rid {};
+    size_t sid {};
     time_point time {};
     Query query {};
 
-    /*constexpr*/ Listener(size_t rid, time_point t, Query&& q) : rid(rid), time(t), query(q) {}
+    Listener(size_t sid, time_point t, Query&& q) : sid(sid), time(t), query(q) {}
 
-    void refresh(size_t tid, time_point t) {
-        rid = tid;
-        time = t;
+    void refresh(size_t sid, time_point time, Query query) {
+        this->sid = sid;
+        this->time = time;
+        this->query = query;
     }
 };
 
@@ -116,7 +117,7 @@ struct Dht::ValueStorage {
 
 struct Dht::Storage {
     time_point maintenance_time {};
-    std::map<std::shared_ptr<Node>, Listener> listeners {};
+    std::map<std::shared_ptr<Node>, std::map<size_t, Listener>> listeners;
     std::map<size_t, LocalListener> local_listeners {};
     size_t listener_token {1};
 
@@ -445,7 +446,7 @@ struct Dht::SearchNode {
      */
     time_point getListenTime(const std::shared_ptr<Query>& q) const {
         auto listen_status = listenStatus.find(q);
-        if (listen_status == listenStatus.end())
+        if (listen_status == listenStatus.end() or not listen_status->second)
             return time_point::min();
         return listen_status->second->pending() ? time_point::max() :
             listen_status->second->reply_time + LISTEN_EXPIRE_TIME - REANNOUNCE_MARGIN;
@@ -1392,26 +1393,31 @@ Dht::searchStep(std::shared_ptr<Search> sr)
                                 sr->id.toString().c_str(), n.node->toString().c_str());
 
                         const auto& r = n.listenStatus.find(query);
-                        auto last_req = r != n.listenStatus.end() ? r->second : std::shared_ptr<Request> {};
+                        auto prev_req = r != n.listenStatus.end() ? r->second : nullptr;
 
                         std::weak_ptr<Search> ws = sr;
-                        n.listenStatus[query] = network_engine.sendListen(n.node, sr->id, *query, n.token,
-                            [this,ws,last_req,query](const net::Request& req, net::NetworkEngine::RequestAnswer&& answer) mutable
+                        n.listenStatus[query] = network_engine.sendListen(n.node, sr->id, *query, n.token, prev_req,
+                            [this,ws,query](const net::Request& req, net::NetworkEngine::RequestAnswer&& answer) mutable
                             { /* on done */
-                                network_engine.cancelRequest(last_req);
                                 if (auto sr = ws.lock()) {
-                                    onListenDone(req, answer, sr, query);
+                                    onListenDone(req.node, answer, sr);
                                     scheduler.edit(sr->nextSearchStep, scheduler.time());
                                 }
                             },
-                            [this,ws,last_req,query](const net::Request& req, bool over) mutable
+                            [this,ws,query](const net::Request& req, bool over) mutable
                             { /* on expired */
-                                network_engine.cancelRequest(last_req);
                                 if (auto sr = ws.lock()) {
                                     scheduler.edit(sr->nextSearchStep, scheduler.time());
                                     if (over)
                                         if (auto sn = sr->getNode(req.node))
                                             sn->listenStatus.erase(query);
+                                }
+                            },
+                            [this,ws,query](const std::shared_ptr<Node>& node, net::NetworkEngine::RequestAnswer&& answer) mutable
+                            { /* on new values */
+                                if (auto sr = ws.lock()) {
+                                    onGetValuesDone(node, answer, sr, query);
+                                    scheduler.edit(sr->nextSearchStep, scheduler.time());
                                 }
                             }
                         );
@@ -2201,16 +2207,23 @@ Dht::storageChanged(const InfoHash& id, Storage& st, ValueStorage& v)
     }
 
     DHT_LOG.d(id, "[store %s] %lu remote listeners", id.toString().c_str(), st.listeners.size());
-    for (const auto& l : st.listeners) {
-        auto f = l.second.query.where.getFilter();
-        if (f and not f(*v.data))
-            continue;
-        DHT_LOG.w(id, l.first->id, "[store %s] [node %s] sending update", id.toString().c_str(), l.first->toString().c_str());
-        std::vector<std::shared_ptr<Value>> vals {};
-        vals.push_back(v.data);
-        Blob ntoken = makeToken((const sockaddr*)&l.first->addr.first, false);
-        network_engine.tellListener(l.first, l.second.rid, id, 0, ntoken, {}, {},
-                std::move(vals), l.second.query);
+    for (const auto& node_listeners : st.listeners) {
+        for (const auto& l : node_listeners.second) {
+            auto f = l.second.query.where.getFilter();
+            if (f and not f(*v.data))
+                continue;
+            DHT_LOG.w(id, node_listeners.first->id, "[store %s] [node %s] sending update",
+                    id.toString().c_str(),
+                    node_listeners.first->toString().c_str());
+            std::vector<std::shared_ptr<Value>> vals {};
+            vals.push_back(v.data);
+            Blob ntoken = makeToken((const sockaddr*)&node_listeners.first->addr.first, false);
+            network_engine.tellListener(node_listeners.first, l.second.sid, id, 0, ntoken, {}, {},
+                    std::move(vals), l.second.query);
+            /* The node will distribute a copy of the value for each listener on
+             * that node himself. */
+            break;
+        }
     }
 }
 
@@ -2287,7 +2300,7 @@ Dht::Storage::clear()
 }
 
 void
-Dht::storageAddListener(const InfoHash& id, const std::shared_ptr<Node>& node, size_t rid, Query&& query)
+Dht::storageAddListener(const InfoHash& id, const std::shared_ptr<Node>& node, size_t socket_id, Query&& query)
 {
     const auto& now = scheduler.time();
     auto st = store.find(id);
@@ -2296,18 +2309,19 @@ Dht::storageAddListener(const InfoHash& id, const std::shared_ptr<Node>& node, s
             return;
         st = store.emplace(id, Storage(now)).first;
     }
-    auto l = st->second.listeners.find(node);
-    if (l == st->second.listeners.end()) {
+    auto node_listeners = st->second.listeners.emplace(node, std::map<size_t, Listener> {}).first;
+    auto l = node_listeners->second.find(socket_id);
+    if (l == node_listeners->second.end()) {
         auto vals = st->second.get(query.where.getFilter());
         if (not vals.empty()) {
-            network_engine.tellListener(node, rid, id, WANT4 | WANT6, makeToken((sockaddr*)&node->addr.first, false),
+            network_engine.tellListener(node, socket_id, id, WANT4 | WANT6, makeToken((sockaddr*)&node->addr.first, false),
                     buckets4.findClosestNodes(id, now, TARGET_NODES), buckets6.findClosestNodes(id, now, TARGET_NODES),
                     std::move(vals), query);
         }
-        st->second.listeners.emplace(node, Listener {rid, now, std::forward<Query>(query)});
+        node_listeners->second.emplace(socket_id, Listener {socket_id, now, std::forward<Query>(query)});
     }
     else
-        l->second.refresh(rid, now);
+        l->second.refresh(socket_id, now, query);
 }
 
 void
@@ -2316,13 +2330,20 @@ Dht::expireStorage()
     const auto& now = scheduler.time();
     auto i = store.begin();
     while (i != store.end()) {
-        for (auto l = i->second.listeners.cbegin(); l != i->second.listeners.cend();){
-            bool expired = l->second.time + Node::NODE_EXPIRE_TIME < now;
-            if (expired) {
-                DHT_LOG.d(i->first, l->first->id, "[store %s] [node %s] discarding expired listener", i->first.toString().c_str(), l->first->toString().c_str());
-                i->second.listeners.erase(l++);
-            } else
-                ++l;
+        for (auto nl_it = i->second.listeners.begin(); nl_it != i->second.listeners.end();){
+            auto& node_listeners = nl_it->second;
+            for (auto l = node_listeners.cbegin(); l != node_listeners.cend();) {
+                bool expired = l->second.time + Node::NODE_EXPIRE_TIME < now;
+                if (expired) {
+                    DHT_LOG.d(i->first, nl_it->first->id, "[store %s] [node %s] discarding expired listener",
+                            i->first.toString().c_str(),
+                            nl_it->first->toString().c_str());
+                    l = node_listeners.erase(l);
+                } else
+                    ++l;
+            }
+            if (node_listeners.empty())
+                nl_it = i->second.listeners.erase(nl_it);
         }
 
         auto stats = i->second.expire(types, now);
@@ -2648,11 +2669,14 @@ Dht::printStorageLog(const decltype(store)::value_type& s) const
     if (not st.local_listeners.empty())
         out << "   " << st.local_listeners.size() << " local listeners" << std::endl;
     const auto& now = scheduler.time();
-    for (const auto& l : st.listeners) {
-        out << "   " << "Listener " << l.first->toString();
-        auto since = duration_cast<seconds>(now - l.second.time);
-        auto expires = duration_cast<seconds>(l.second.time + Node::NODE_EXPIRE_TIME - now);
-        out << " (since " << since.count() << "s, exp in " << expires.count() << "s)" << std::endl;
+    for (const auto& node_listeners : st.listeners) {
+        const auto& node = node_listeners.first;
+        for (const auto& l : node_listeners.second) {
+            out << "   " << "Listener " << node->toString();
+            auto since = duration_cast<seconds>(now - l.second.time);
+            auto expires = duration_cast<seconds>(l.second.time + Node::NODE_EXPIRE_TIME - now);
+            out << " (since " << since.count() << "s, exp in " << expires.count() << "s)" << std::endl;
+        }
     }
     return out.str();
 }
@@ -3201,7 +3225,7 @@ Dht::onGetValues(std::shared_ptr<Node> node, const InfoHash& hash, want_t, const
     return answer;
 }
 
-void Dht::onGetValuesDone(const Request& status,
+void Dht::onGetValuesDone(const std::shared_ptr<Node>& node,
         net::NetworkEngine::RequestAnswer& a,
         std::shared_ptr<Search>& sr,
         const std::shared_ptr<Query>& orig_query)
@@ -3212,7 +3236,7 @@ void Dht::onGetValuesDone(const Request& status,
     }
 
     DHT_LOG.d(sr->id, "[search %s] [node %s] got reply to 'get' with %u nodes",
-            sr->id.toString().c_str(), status.node->toString().c_str(), a.nodes4.size());
+            sr->id.toString().c_str(), node->toString().c_str(), a.nodes4.size());
 
     if (not a.ntoken.empty()) {
         if (not a.values.empty() or not a.fields.empty()) {
@@ -3261,8 +3285,8 @@ void Dht::onGetValuesDone(const Request& status,
                 l.first(l.second);
         }
     } else {
-        DHT_LOG.w(sr->id, "[node %s] no token provided. Ignoring response content.", status.node->toString().c_str());
-        network_engine.blacklistNode(status.node);
+        DHT_LOG.w(sr->id, "[node %s] no token provided. Ignoring response content.", node->toString().c_str());
+        network_engine.blacklistNode(node);
     }
 
     if (not sr->done) {
@@ -3274,7 +3298,7 @@ void Dht::onGetValuesDone(const Request& status,
 }
 
 net::NetworkEngine::RequestAnswer
-Dht::onListen(std::shared_ptr<Node> node, const InfoHash& hash, const Blob& token, size_t rid, const Query& query)
+Dht::onListen(std::shared_ptr<Node> node, const InfoHash& hash, const Blob& token, size_t socket_id, const Query& query)
 {
     if (hash == zeroes) {
         DHT_LOG.w(node->id, "[node %s] listen with no info_hash", node->toString().c_str());
@@ -3288,21 +3312,17 @@ Dht::onListen(std::shared_ptr<Node> node, const InfoHash& hash, const Blob& toke
         throw net::DhtProtocolException {net::DhtProtocolException::UNAUTHORIZED, net::DhtProtocolException::LISTEN_WRONG_TOKEN};
     }
     Query q = query;
-    storageAddListener(hash, node, rid, std::move(q));
+    storageAddListener(hash, node, socket_id, std::move(q));
     return {};
 }
 
 void
-Dht::onListenDone(const Request& status,
+Dht::onListenDone(const std::shared_ptr<Node>& node,
         net::NetworkEngine::RequestAnswer& answer,
-        std::shared_ptr<Search>& sr,
-        const std::shared_ptr<Query>& orig_query)
+        std::shared_ptr<Search>& sr)
 {
-    DHT_LOG.d(sr->id, status.node->id, "[search %s] [node %s] got reply to listen (%llu values)",
-                sr->id.toString().c_str(), status.node->toString().c_str(), answer.values.size());
-    if (not answer.values.empty()) { /* got new values from listen request */
-        onGetValuesDone(status, answer, sr, orig_query);
-    }
+    DHT_LOG.d(sr->id, node->id, "[search %s] [node %s] got listen confirmation",
+                sr->id.toString().c_str(), node->toString().c_str(), answer.values.size());
 
     if (not sr->done) {
         const auto& now = scheduler.time();
@@ -3402,11 +3422,11 @@ Dht::onRefresh(std::shared_ptr<Node> node, const InfoHash& hash, const Blob& tok
 }
 
 void
-Dht::onAnnounceDone(const Request& req, net::NetworkEngine::RequestAnswer& answer, std::shared_ptr<Search>& sr)
+Dht::onAnnounceDone(const std::shared_ptr<Node>& node, net::NetworkEngine::RequestAnswer& answer, std::shared_ptr<Search>& sr)
 {
     const auto& now = scheduler.time();
-    DHT_LOG.d(sr->id, req.node->id, "[search %s] [node %s] got reply to put!",
-            sr->id.toString().c_str(), req.node->toString().c_str());
+    DHT_LOG.d(sr->id, node->id, "[search %s] [node %s] got reply to put!",
+            sr->id.toString().c_str(), node->toString().c_str());
     searchSendGetValues(sr);
     /* if (auto sn = sr->getNode(req->node)) { */
     /*     sn->setRefreshTime(answer.vid, now + answer) */

--- a/src/network_engine.cpp
+++ b/src/network_engine.cpp
@@ -26,6 +26,7 @@
 #include <msgpack.hpp>
 
 namespace dht {
+namespace net {
 
 const std::string DhtProtocolException::GET_NO_INFOHASH {"Get_values with no info_hash"};
 const std::string DhtProtocolException::LISTEN_NO_INFOHASH {"Listen with no info_hash"};
@@ -40,15 +41,15 @@ constexpr std::chrono::seconds NetworkEngine::RX_MAX_PACKET_TIME;
 constexpr std::chrono::seconds NetworkEngine::RX_TIMEOUT;
 
 const std::string NetworkEngine::my_v {"RNG1"};
-const constexpr uint16_t NetworkEngine::TransId::INVALID;
+const constexpr uint16_t TransId::INVALID;
 std::mt19937 NetworkEngine::rd_device {dht::crypto::random_device{}()};
 
-const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::PING = {"pn"};
-const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::FIND_NODE = {"fn"};
-const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::GET_VALUES = {"gt"};
-const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::ANNOUNCE_VALUES = {"pt"};
-const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::REFRESH = {"rf"};
-const NetworkEngine::TransPrefix NetworkEngine::TransPrefix::LISTEN = {"lt"};
+const TransPrefix TransPrefix::PING = {"pn"};
+const TransPrefix TransPrefix::FIND_NODE = {"fn"};
+const TransPrefix TransPrefix::GET_VALUES = {"gt"};
+const TransPrefix TransPrefix::ANNOUNCE_VALUES = {"pt"};
+const TransPrefix TransPrefix::REFRESH = {"rf"};
+const TransPrefix TransPrefix::LISTEN = {"lt"};
 constexpr long unsigned NetworkEngine::MAX_REQUESTS_PER_SEC;
 
 static const uint8_t v4prefix[16] = {
@@ -1419,4 +1420,5 @@ ParsedMessage::complete()
 }
 
 
-}
+} /* namespace net  */
+} /* namespace dht */

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -72,7 +72,7 @@ Node::update(const SockAddr& new_addr)
 
 /** To be called when a message was sent to the node */
 void
-Node::requested(std::shared_ptr<Request>& req)
+Node::requested(std::shared_ptr<net::Request>& req)
 {
     requests_.emplace_back(req);
 }
@@ -80,7 +80,7 @@ Node::requested(std::shared_ptr<Request>& req)
 /** To be called when a message was received from the node.
  Req should be true if the message was an aswer to a request we made*/
 void
-Node::received(time_point now, std::shared_ptr<Request> req)
+Node::received(time_point now, std::shared_ptr<net::Request> req)
 {
     time = now;
     if (req) {


### PR DESCRIPTION
Since the initial implementation of listen operation, multiple listen requests from a single node on a same hash was not possible without singular inconsistencies. The flaw was coming from the fact that nodes receiving listen request could not differentiate between listen refresh request and a new independent listen request.

This patch introduces the new `net::Socket` structure which in time will enable remote nodes to send update for a storage while differentiating between concurrent listen requests. A socket has a unique identifier which consists of a transaction id as defined in the OpenDHT protocol
