### PR TITLE
infohash: add helper to C string format conversion

### DIFF
--- a/include/opendht/infohash.h
+++ b/include/opendht/infohash.h
@@ -197,6 +197,10 @@ public:
 
     std::string toString() const;
 
+    const char* toCString() const {
+        return toString().c_str();
+    }
+
     template <typename Packer>
     void msgpack_pack(Packer& pk) const
     {


### PR DESCRIPTION
This const void* convertion method helps a lot with programs
that need to print the hash with a printf() like function.