### PR TITLE
autoconf: robustly check for cython3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,8 +45,8 @@ AC_ARG_ENABLE([python], [AS_HELP_STRING([--disable-python], [Disble python bindi
 AS_IF([test "x$enable_python" != "xno"], [
        AM_PATH_PYTHON([3.3],, [:])
        AS_IF([test -n "$PYTHON"],[
-              AC_CHECK_PROGS([CYTHON], [cython3])
-              AS_IF([test -z "$CYTHON"],[AC_MSG_WARN([Cython not found - continuing without python support])])
+              echo 'import Cython' | $PYTHON
+              AS_IF([test $? == 0],[CYTHON=yes],[AC_MSG_WARN([Cython not found - continuing without python support])])
               AC_CHECK_PROGS([PIP], [pip3])
               AS_IF([test -z "$PIP"],[AC_MSG_WARN([pip not found - continuing without python uninstall support])])
               ])


### PR DESCRIPTION
On some platforms, cython3 binary is called `cython` and on others, it's called `cython3`. The usual way to check if a python module is by doing the following:
```sh
echo 'import module' | $PYTHON
# $? -eq 0: module is installed
# $? -neq 0: module isn't installed
```
where `$PYTHON` is the Python binary you wish to check. Cython is a module.

CQFD
