### PR TITLE
storage: update listener after value refresh

### DIFF
--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -189,13 +189,13 @@ struct Dht::Storage {
      * @param vid  The value id
      * @return true if a value storage was updated, false otherwise
      */
-    bool refresh(const time_point& now, const Value::Id& vid) {
+    ValueStorage* refresh(const time_point& now, const Value::Id& vid) {
         for (auto& vs : values)
             if (vs.data->id == vid) {
                 vs.created = now;
-                return true;
+                return &vs;
             }
-        return false;
+        return nullptr;
     }
 
     std::pair<ssize_t, ssize_t> expire(const std::map<ValueType::Id, ValueType>& types, time_point now);
@@ -3410,9 +3410,16 @@ Dht::onRefresh(std::shared_ptr<Node> node, const InfoHash& hash, const Blob& tok
     }
 
     auto s = store.find(hash);
-    if (s != store.end() and s->second.refresh(now, vid)) {
-        DHT_LOG.d(hash, node->id, "[store %s] [node %s] refreshed value %s", hash.toString().c_str(), node->toString().c_str(), std::to_string(vid).c_str());
-    } else {
+    ValueStorage* vs;
+    if (s != store.end()) {
+        vs = s->second.refresh(now, vid);
+        if (vs) {
+            DHT_LOG.d(hash, node->id, "[store %s] [node %s] refreshed value %s", hash.toString().c_str(), node->toString().c_str(), std::to_string(vid).c_str());
+            storageChanged(hash, s->second, *vs);
+        }
+    }
+
+    if (not vs) {
         DHT_LOG.d(hash, node->id, "[store %s] [node %s] got refresh for unknown value",
                 hash.toString().c_str(), node->toString().c_str());
         throw DhtProtocolException {DhtProtocolException::NOT_FOUND, DhtProtocolException::STORAGE_NOT_FOUND};


### PR DESCRIPTION
All values on OpenDHT live for a given period of time. If a value is put on a hash on which a node listens, the listener should be notified.

If one implements "permanent" put manually, listeners for that hash would be updated each 10 minutes, which is logical.

However, if one uses the "permanent put" feature implemented by OpenDHT, it won't get notified since a "refresh" doesn't trigger a `tellListener` call and I think it should.

For instance, this [patch](https://gerrit-ring.savoirfairelinux.com/#/c/5127/) for the Ring daemon to get a buddy notification would need this. Otherwise, all buddies would not appear online more than 10 minutes.