### PR TITLE
buildtools: add def.h to include files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ list (APPEND opendht_SOURCES
 )
 
 list (APPEND opendht_HEADERS
+    include/opendht/def.h
     include/opendht/utils.h
     include/opendht/sockaddr.h
     include/opendht/rng.h
@@ -92,7 +93,6 @@ list (APPEND opendht_HEADERS
     include/opendht/log_enable.h
     include/opendht.h
     include/opendht/indexation/pht.h
-    include/opendht/indexation/def.h
 )
 
 configure_file (

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ list (APPEND opendht_HEADERS
     include/opendht/log_enable.h
     include/opendht.h
     include/opendht/indexation/pht.h
+    include/opendht/indexation/def.h
 )
 
 configure_file (

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,7 +49,8 @@ nobase_include_HEADERS = \
         ../include/opendht/log.h \
         ../include/opendht/log_enable.h \
         ../include/opendht/rng.h \
-        ../include/opendht/indexation/pht.h
+        ../include/opendht/indexation/pht.h \
+        ../include/opendht/def.h
 
 nobase_noinst_HEADERS = \
         ../include/opendht/request.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,6 +29,7 @@ endif
 
 nobase_include_HEADERS = \
         ../include/opendht.h \
+        ../include/opendht/def.h \
         ../include/opendht/dht.h \
         ../include/opendht/callbacks.h \
         ../include/opendht/node_cache.h \
@@ -49,8 +50,7 @@ nobase_include_HEADERS = \
         ../include/opendht/log.h \
         ../include/opendht/log_enable.h \
         ../include/opendht/rng.h \
-        ../include/opendht/indexation/pht.h \
-        ../include/opendht/def.h
+        ../include/opendht/indexation/pht.h
 
 nobase_noinst_HEADERS = \
         ../include/opendht/request.h


### PR DESCRIPTION
Seems like this file was forgotten in the buildtools' include arrays. Applications using opendht cannot build without that.