### PR TITLE
routing_table: complete connecting state resolution

### DIFF
--- a/include/opendht/callbacks.h
+++ b/include/opendht/callbacks.h
@@ -46,7 +46,7 @@ struct OPENDHT_PUBLIC Config {
     /** DHT node ID */
     InfoHash node_id;
 
-    /** 
+    /**
      * DHT network ID. A node will only talk with other nodes having
      * the same network ID.
      * Network ID 0 (default) represents the main public network.

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -283,7 +283,7 @@ public:
     std::string getStorageLog(const InfoHash&) const;
     std::string getRoutingTablesLog(sa_family_t af) const;
     std::string getSearchesLog(sa_family_t af = AF_UNSPEC) const;
-    std::string getSearchLog(const InfoHash&, sa_family_t af = AF_UNSPEC) const;    
+    std::string getSearchLog(const InfoHash&, sa_family_t af = AF_UNSPEC) const;
     std::vector<SockAddr> getPublicAddress(sa_family_t af = AF_UNSPEC);
     std::vector<std::string> getPublicAddressStr(sa_family_t af = AF_UNSPEC);
 
@@ -370,7 +370,7 @@ private:
      * nodes so that the DHT node can recover quickly from losing connection
      * with the network.
      */
-    void tryBootstrapCoutinuously();
+    void tryBootstrapContinuously();
 
     void doRun(const sockaddr_in* sin4, const sockaddr_in6* sin6, SecureDhtConfig config);
     time_point loop_();

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -348,7 +348,7 @@ DhtRunner::loop_()
             // We have lost connection with the DHT.  Try to recover using bootstrap nodes.
             std::unique_lock<std::mutex> lck(bootstrap_mtx);
             bootstrap_nodes = bootstrap_nodes_all;
-            tryBootstrapCoutinuously();
+            tryBootstrapContinuously();
         } else {
             std::unique_lock<std::mutex> lck(bootstrap_mtx);
             bootstrap_nodes.clear();
@@ -618,7 +618,7 @@ DhtRunner::putEncrypted(const std::string& key, InfoHash to, Value&& value, Done
 }
 
 void
-DhtRunner::tryBootstrapCoutinuously()
+DhtRunner::tryBootstrapContinuously()
 {
     if (bootstrap_thread.joinable()) {
         if (bootstraping)
@@ -707,7 +707,7 @@ DhtRunner::bootstrap(const std::string& host, const std::string& service)
     std::lock_guard<std::mutex> lck(bootstrap_mtx);
     bootstrap_nodes_all.emplace_back(host, service);
     bootstrap_nodes.emplace_back(host, service);
-    tryBootstrapCoutinuously();
+    tryBootstrapContinuously();
 }
 
 void

--- a/src/routing_table.cpp
+++ b/src/routing_table.cpp
@@ -17,10 +17,21 @@ Bucket::randomNode()
 {
     if (nodes.empty())
         return nullptr;
-    std::uniform_int_distribution<unsigned> rand_node(0, nodes.size()-1);
+    unsigned expired_node_count = std::count_if(nodes.cbegin(), nodes.cend(), [](const decltype(nodes)::value_type& node) {
+        return node->isExpired();
+    });
+    auto prioritize_not_expired = expired_node_count < nodes.size();
+
+    std::uniform_int_distribution<unsigned> rand_node(0, prioritize_not_expired
+            ? nodes.size() - expired_node_count - 1
+            : nodes.size()-1);
     unsigned nn = rand_node(rd);
-    for (auto& n : nodes)
-        if (not nn--) return n;
+    for (auto& n : nodes) {
+        if (not (prioritize_not_expired and n->isExpired())) {
+            if (not nn--)
+                return n;
+        }
+    }
     return nodes.back();
 }
 


### PR DESCRIPTION
After a connectivity change, the DHT would enter the "connecting" state in order to try to resolve good nodes. However, the previous algorithm would probabilistically increase time for completion each time a node would fail to resolve. We now avoid this by prioritizing non-expired nodes in the process.  Also, a subtle error would sensibly stop the process for 30 minutes due to using the Node::NODE_EXPIRE_TIME constant instead of Node::MAX_RESPONSE_TIME.
