### PR TITLE
dht: randomize id in Dht layer

### DIFF
--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -2883,11 +2883,11 @@ Dht::~Dht()
 Dht::Dht() : store(), scheduler(DHT_LOG), network_engine(DHT_LOG, scheduler) {}
 
 Dht::Dht(int s, int s6, Config config)
- : myid(config.node_id),
-   is_bootstrap(config.is_bootstrap),
-   maintain_storage(config.maintain_storage), store(), store_quota(),
-   scheduler(DHT_LOG),
-   network_engine(myid, config.network, s, s6, DHT_LOG, scheduler,
+    : myid(config.node_id != zeroes ? config.node_id : InfoHash::getRandom()),
+    is_bootstrap(config.is_bootstrap),
+    maintain_storage(config.maintain_storage), store(), store_quota(),
+    scheduler(DHT_LOG),
+    network_engine(myid, config.network, s, s6, DHT_LOG, scheduler,
             std::bind(&Dht::onError, this, _1, _2),
             std::bind(&Dht::onNewNode, this, _1, _2),
             std::bind(&Dht::onReportedAddr, this, _1, _2),

--- a/src/securedht.cpp
+++ b/src/securedht.cpp
@@ -36,12 +36,8 @@ namespace dht {
 Config& getConfig(SecureDht::Config& conf)
 {
     auto& c = conf.node_config;
-    if (c.node_id == InfoHash()) {
-          if (conf.id.second)
-            c.node_id = InfoHash::get("node:"+conf.id.second->getId().toString());
-        else
-            c.node_id = InfoHash::getRandom();
-    }
+    if (c.node_id == InfoHash() and conf.id.second)
+        c.node_id = InfoHash::get("node:"+conf.id.second->getId().toString());
     return c;
 }
 


### PR DESCRIPTION
Since Dht may be used as a separate and independant component and that it the property of a node ID to default to random is also wanted on this layer, I propose to move `node_id` config defaulting to random to the `Dht` class constructor.