### PR TITLE
dht: standardize announce status check

### DIFF
--- a/include/opendht/request.h
+++ b/include/opendht/request.h
@@ -78,7 +78,7 @@ struct Request {
     bool over() const { return not pending(); }
     State getState() const { return state_; }
 
-    Request() {}
+    Request(State state = State::PENDING) : state_(state) {}
     Request(TransId tid,
             std::shared_ptr<Node> node,
             Blob&& msg,

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -1357,7 +1357,7 @@ void Dht::searchSendAnnounceValue(const Sp<Search>& sr) {
                                 } else {
                                     DHT_LOG.w(sr->id, sn->node->id, "[search %s] [node %s] already has value (vid: %d). Aborting.",
                                             sr->id.toString().c_str(), sn->node->toString().c_str(), a.value->id);
-                                    auto ack_req = std::make_shared<net::Request>();
+                                    auto ack_req = std::make_shared<net::Request>(net::Request::State::COMPLETED);
                                     ack_req->reply_time = now;
                                     sn->acked[a.value->id] = std::make_pair(std::move(ack_req), next_refresh_time);
 
@@ -2721,7 +2721,7 @@ Dht::dumpSearch(const Search& sr, std::ostream& out) const
                     if (ack == n.acked.end() or not ack->second.first) {
                         out << ' ';
                     } else {
-                        if (ack->second.first->reply_time + getType(a.value->type).expiration > now)
+                        if (ack->second.first->completed())
                             out << 'a';
                         else if (ack->second.first->pending())
                             out << 'f';


### PR DESCRIPTION
Fixes a bug where some callbacks wouldn't be called when a dummy request was inserted to cancel some operation while not using the `net::Request::State::COMPLETED` flag as per 19c47ec.