### PR TITLE
benchmark: fix invalid ifname error

### DIFF
--- a/python/tools/benchmark.py
+++ b/python/tools/benchmark.py
@@ -186,6 +186,7 @@ if __name__ == '__main__':
     wb = WorkBench(args.ifname, args.virtual_locs, args.node_num, loss=args.loss,
             delay=args.delay, disable_ipv4=args.disable_ipv4,
             disable_ipv6=args.disable_ipv6)
+    wb.create_virtual_net()
     bootstrap = wb.get_bootstrap()
 
     bs_dht_log_enabled = False
@@ -203,7 +204,6 @@ if __name__ == '__main__':
         bs_dht_log_enabled = True
         bootstrap.front().enableLogging()
 
-    wb.create_virtual_net()
     bootstrap.resize(1)
     print("Launching", wb.node_num, "nodes (", wb.clusters, "clusters of", wb.node_per_loc, "nodes)")
 

--- a/python/tools/dht/tests.py
+++ b/python/tools/dht/tests.py
@@ -11,6 +11,7 @@ import string
 import time
 import subprocess
 import re
+import traceback
 import collections
 
 from matplotlib.ticker import FuncFormatter


### PR DESCRIPTION
Two instructions were mutually misordered, hence the error message below:
```
Traceback (most recent call last):
  File "benchmark.py", line 189, in <module>
    bootstrap = wb.get_bootstrap()
  File "benchmark.py", line 64, in get_bootstrap
    bootstrap=[(self.remote_bootstrap, self.bs_port)] if self.remote_bootstrap else [])
  File "/home/simon/prog/opendht/python/tools/dht/network.py", line 334, in __init__
    ips = DhtNetwork.find_ip(iface)
  File "/home/simon/prog/opendht/python/tools/dht/network.py", line 327, in find_ip
    if_ip4 = netifaces.ifaddresses(iface)[netifaces.AF_INET][0]['addr']
ValueError: You must specify a valid interface name.
```
This error was partly reported in #59, more precisely in the first pastebin linked by @kaldoran.