### PR TITLE
benchmark: no virtual namespaces by default

### DIFF
--- a/python/tools/dht/network.py
+++ b/python/tools/dht/network.py
@@ -31,7 +31,8 @@ import subprocess
 import ipaddress
 import netifaces
 import numpy as np
-from pyroute2.netns.process.proxy import NSPopen
+if "linux" in sys.platform:
+    from pyroute2.netns.process.proxy import NSPopen
 import msgpack
 
 from opendht import *

--- a/python/tools/dht/tests.py
+++ b/python/tools/dht/tests.py
@@ -12,6 +12,7 @@ import time
 import subprocess
 import re
 import collections
+import traceback
 
 from matplotlib.ticker import FuncFormatter
 import math
@@ -302,7 +303,8 @@ class PhtTest(FeatureTest):
             if self._test == 'insert':
                 self._insertTest()
         except Exception as e:
-            print(e)
+            traceback.print_tb(e.__traceback__)
+            print(type(e).__name__+':', e, file=sys.stderr)
         finally:
             self._bootstrap.resize(1)
 


### PR DESCRIPTION
Following the suggestion from #177, I have enabled the benchmark to work on interfaces other than virtual networks. To run tests on virtual namespaces, one should add the options `--virt-ns` and `--ifname some_name` since the default value for `--ifname` is now `lo`: the loop interface.