### PR TITLE
benchmark: fix pht insert test

### DIFF
--- a/python/opendht.pyx
+++ b/python/opendht.pyx
@@ -49,7 +49,9 @@ cdef inline void lookup_callback(cpp.vector[cpp.shared_ptr[cpp.IndexValue]]* val
             v = IndexValue()
             v._value = val
             vals.append(v)
-        cbs['lookup'](vals, p.toString())
+        prefix = Prefix(p.size_)
+        prefix._prefix.reset(new cpp.Prefix(deref(p)))
+        cbs['lookup'](vals, prefix)
 
 cdef inline void shutdown_callback(void* user_data) with gil:
     cbs = <object>user_data
@@ -470,6 +472,25 @@ cdef class DhtRunner(_WithID):
         self.thisptr.get().cancelListen(token._h, token._t)
         ref.Py_DECREF(<object>token._cb['cb'])
         # fixme: not thread safe
+
+cdef class Prefix(object):
+    cdef shared_ptr[cpp.Prefix] _prefix
+    def __init__(self, int size, bytes val=b''):
+        cdef cpp.vector[cpp.uint8_t] blob
+        for c in val:
+            blob.push_back(c)
+        self._prefix.reset(new cpp.Prefix(blob, size))
+    def __str__(self):
+        return self._prefix.get().toString().decode()
+    property size_:
+        def __get__(self):
+            return self._prefix.get().size_
+    property content_:
+        def __get__(self):
+            return self._prefix.get().toString().decode()
+    property flags_:
+        def __get__(self):
+            return self._prefix.get().flagsToString().decode()
 
 cdef class IndexValue(object):
     cdef cpp.shared_ptr[cpp.IndexValue] _value

--- a/python/opendht_cpp.pxd
+++ b/python/opendht_cpp.pxd
@@ -187,7 +187,13 @@ cdef extern from "opendht/indexation/pht.h" namespace "dht::indexation":
     cdef cppclass Prefix:
         Prefix() except +
         Prefix(vector[uint8_t]) except +
+        Prefix(vector[uint8_t], size_t first) except +
+        Prefix(Prefix& p) except +
         string toString() const
+        string flagsToString() const
+        size_t size_
+        vector[uint8_t] flags_
+        vector[uint8_t] content_
     ctypedef pair[InfoHash, uint64_t] IndexValue "dht::indexation::Value"
     ctypedef map[string, vector[uint8_t]] IndexKey "dht::indexation::Pht::Key"
     ctypedef map[string, uint32_t] IndexKeySpec "dht::indexation::Pht::KeySpec"

--- a/python/tools/benchmark.py
+++ b/python/tools/benchmark.py
@@ -171,7 +171,7 @@ if __name__ == '__main__':
     featureArgs.add_argument('--pht', action='store_true', default=False,
             help='Launches PHT benchmark test. '\
                     'Available args for "-t" are: insert. '\
-                    'Timer available by adding "timer" to "-o" args'\
+                    'Timer available by adding "timer" to "-o" args. '\
                     'Use "-m" option for fixing number of keys to create during the test.')
     featureArgs.add_argument('--data-persistence', action='store_true', default=0,
             help='Launches data persistence benchmark test. '\


### PR DESCRIPTION
Output from `insertTest` in benchmark has been wrong since the begining due to minor errors. This PR fixes those errors and also **depends on #183** to build and run right. Keep that in mind before merging.

I have attached `before.txt` and `after.txt` files to compare outputs.

[before.txt](https://github.com/savoirfairelinux/opendht/files/889030/before.txt)
[after.txt](https://github.com/savoirfairelinux/opendht/files/889031/after.txt)
