### PR TITLE
Avoid dereferencing an iterator to 'end()'

### DIFF
--- a/src/infohash.cpp
+++ b/src/infohash.cpp
@@ -65,8 +65,8 @@ InfoHash::getRandom()
     InfoHash h;
     crypto::random_device rdev;
     std::uniform_int_distribution<uint32_t> rand_int;
-    auto a = reinterpret_cast<uint32_t*>(&(*h.begin()));
-    auto b = reinterpret_cast<uint32_t*>(&(*h.end()));
+    auto a = reinterpret_cast<uint32_t*>(h.data());
+    auto b = reinterpret_cast<uint32_t*>(h.data() + h.size());
     std::generate(a, b, std::bind(rand_int, std::ref(rdev)));
     return h;
 }


### PR DESCRIPTION
*h.end() only works on VS 2015 with
_SECURE_SCL=0
_ITERATOR_DEBUG_LEVEL=0

Also, if these flags are used when compiling opendht, it seems that any client program that wants to link against opendht also needs the same flags enabled, which is a terrible requirement to force on a client.

The proposed change makes the code a bit cleaner and doesn't require any preprocessor tricks.