### PR TITLE
http server: WHERE functionnality for GET and set user_type, vid in POST

### DIFF
--- a/include/opendht/callbacks.h
+++ b/include/opendht/callbacks.h
@@ -99,6 +99,7 @@ using DoneCallback = std::function<void(bool success, const std::vector<std::sha
 typedef void (*DoneCallbackRaw)(bool, std::vector<std::shared_ptr<Node>>*, void *user_data);
 typedef void (*ShutdownCallbackRaw)(void *user_data);
 typedef void (*DoneCallbackSimpleRaw)(bool, void *user_data);
+typedef bool (*FilterRaw)(const Value&, void *user_data);
 
 using DoneCallbackSimple = std::function<void(bool success)>;
 
@@ -106,5 +107,6 @@ OPENDHT_PUBLIC ShutdownCallback bindShutdownCb(ShutdownCallbackRaw shutdown_cb_r
 OPENDHT_PUBLIC DoneCallback bindDoneCb(DoneCallbackSimple donecb);
 OPENDHT_PUBLIC DoneCallback bindDoneCb(DoneCallbackRaw raw_cb, void* user_data);
 OPENDHT_PUBLIC DoneCallbackSimple bindDoneCbSimple(DoneCallbackSimpleRaw raw_cb, void* user_data);
+OPENDHT_PUBLIC Value::Filter bindFilterRaw(FilterRaw raw_filter, void* user_data);
 
 }

--- a/include/opendht/value.h
+++ b/include/opendht/value.h
@@ -651,7 +651,8 @@ struct OPENDHT_PUBLIC Select
      * @return the resulting Select instance.
      */
     Select& field(Value::Field field) {
-        fieldSelection_.emplace_back(field);
+        if (std::find(fieldSelection_.begin(), fieldSelection_.end(), field) == fieldSelection_.end())
+            fieldSelection_.emplace_back(field);
         return *this;
     }
 
@@ -697,7 +698,9 @@ struct OPENDHT_PUBLIC Where
      * @return the resulting Where instance.
      */
     Where& id(Value::Id id) {
-        filters_.emplace_back(Value::Field::Id, id);
+        FieldValue fv {Value::Field::Id, id};
+        if (std::find(filters_.begin(), filters_.end(), fv) == filters_.end())
+            filters_.emplace_back(std::move(fv));
         return *this;
     }
 
@@ -709,7 +712,9 @@ struct OPENDHT_PUBLIC Where
      * @return the resulting Where instance.
      */
     Where& valueType(ValueType::Id type) {
-        filters_.emplace_back(Value::Field::ValueType, type);
+        FieldValue fv {Value::Field::ValueType, type};
+        if (std::find(filters_.begin(), filters_.end(), fv) == filters_.end())
+            filters_.emplace_back(std::move(fv));
         return *this;
     }
 
@@ -721,7 +726,9 @@ struct OPENDHT_PUBLIC Where
      * @return the resulting Where instance.
      */
     Where& owner(InfoHash owner_pk_hash) {
-        filters_.emplace_back(Value::Field::OwnerPk, owner_pk_hash);
+        FieldValue fv {Value::Field::OwnerPk, owner_pk_hash};
+        if (std::find(filters_.begin(), filters_.end(), fv) == filters_.end())
+            filters_.emplace_back(std::move(fv));
         return *this;
     }
 
@@ -733,7 +740,9 @@ struct OPENDHT_PUBLIC Where
      * @return the resulting Where instance.
      */
     Where& seq(uint16_t seq_no) {
-        filters_.emplace_back(Value::Field::SeqNum, seq_no);
+        FieldValue fv {Value::Field::SeqNum, seq_no};
+        if (std::find(filters_.begin(), filters_.end(), fv) == filters_.end())
+            filters_.emplace_back(std::move(fv));
         return *this;
     }
 
@@ -745,7 +754,9 @@ struct OPENDHT_PUBLIC Where
      * @return the resulting Where instance.
      */
     Where& userType(std::string user_type) {
-        filters_.emplace_back(Value::Field::UserType, Blob {user_type.begin(), user_type.end()});
+        FieldValue fv {Value::Field::UserType, Blob {user_type.begin(), user_type.end()}};
+        if (std::find(filters_.begin(), filters_.end(), fv) == filters_.end())
+            filters_.emplace_back(std::move(fv));
         return *this;
     }
 

--- a/include/opendht/value.h
+++ b/include/opendht/value.h
@@ -671,6 +671,12 @@ struct OPENDHT_PUBLIC Select
         fieldSelection_ = o.as<decltype(fieldSelection_)>();
     }
 
+    std::string toString() const {
+        std::stringstream ss;
+        ss << *this;
+        return ss.str();
+    }
+
     OPENDHT_PUBLIC friend std::ostream& operator<<(std::ostream& s, const dht::Select& q);
 private:
     std::vector<Value::Field> fieldSelection_ {};
@@ -783,6 +789,12 @@ struct OPENDHT_PUBLIC Where
         filters_ = o.as<decltype(filters_)>();
     }
 
+    std::string toString() const {
+        std::stringstream ss;
+        ss << *this;
+        return ss.str();
+    }
+
     OPENDHT_PUBLIC friend std::ostream& operator<<(std::ostream& s, const dht::Where& q);
 
 private:
@@ -839,7 +851,7 @@ struct OPENDHT_PUBLIC Query
 
     void msgpack_unpack(const msgpack::object& o);
 
-    std::string toString() {
+    std::string toString() const {
         std::stringstream ss;
         ss << *this;
         return ss.str();

--- a/include/opendht/value.h
+++ b/include/opendht/value.h
@@ -41,6 +41,7 @@ namespace dht {
 struct Value;
 struct Query;
 
+
 /**
  * A storage policy is applied once to every incoming value storage requests.
  * If the policy returns false, the value is dropped.

--- a/python/opendht.pyx
+++ b/python/opendht.pyx
@@ -187,6 +187,11 @@ cdef class Value(object):
             return string(<char*>self._value.get().data.data(), self._value.get().data.size())
         def __set__(self, bytes value):
             self._value.get().data = value
+    property user_type:
+        def __get__(self):
+            return self._value.get().user_type.decode()
+        def __set__(self, str t):
+            self._value.get().user_type = t.encode()
     property id:
         def __get__(self):
             return self._value.get().id

--- a/python/opendht.pyx
+++ b/python/opendht.pyx
@@ -164,6 +164,53 @@ cdef class NodeEntry(_WithID):
         n._node = self._v.second
         return n
 
+cdef class Query(object):
+    cdef cpp.Query _query
+    def __cinit__(self, str q_str=''):
+        self._query = cpp.Query(q_str.encode())
+    def __str__(self):
+        return self._query.toString().decode()
+    def buildFrom(self, Select s, Where w):
+        self._query = cpp.Query(s._select, w._where)
+    def isSatisfiedBy(self, Query q):
+        return self._query.isSatisfiedBy(q._query)
+
+cdef class Select(object):
+    cdef cpp.Select _select
+    def __cinit__(self, str q_str=''):
+        self._select = cpp.Select(q_str.encode())
+    def __str__(self):
+        return self._select.toString().decode()
+    def isSatisfiedBy(self, Select os):
+        return self._select.isSatisfiedBy(os._select)
+    def field(self, int field):
+        self._select.field(<cpp.Field> field)
+        return self
+
+cdef class Where(object):
+    cdef cpp.Where _where
+    def __cinit__(self, str q_str=''):
+        self._where = cpp.Where(q_str.encode())
+    def __str__(self):
+        return self._where.toString().decode()
+    def isSatisfiedBy(self, Where where):
+        return self._where.isSatisfiedBy(where._where)
+    def id(self, cpp.uint64_t id):
+        self._where.id(id)
+        return self
+    def valueType(self, cpp.uint16_t type):
+        self._where.valueType(type)
+        return self
+    def owner(self, InfoHash owner_pk_hash):
+        self._where.owner(owner_pk_hash._infohash)
+        return self
+    def seq(self, cpp.uint16_t seq_no):
+        self._where.seq(seq_no)
+        return self
+    def userType(self, str user_type):
+        self._where.userType(user_type.encode())
+        return self
+
 cdef class Value(object):
     cdef shared_ptr[cpp.Value] _value
     def __init__(self, bytes val=b''):

--- a/python/opendht_cpp.pxd
+++ b/python/opendht_cpp.pxd
@@ -120,6 +120,19 @@ cdef extern from "opendht/crypto.h" namespace "dht::crypto":
 
 ctypedef TrustList.VerifyResult TrustListVerifyResult
 
+cdef extern from "opendht/value.h" namespace "dht::Value":
+    cdef cppclass Field:
+        pass
+
+cdef extern from "opendht/value.h" namespace "dht::Value::Field":
+    cdef Field None
+    cdef Field Id
+    cdef Field ValueType
+    cdef Field OwnerPk
+    cdef Field SeqNum
+    cdef Field UserType
+    cdef Field COUNT
+
 cdef extern from "opendht/value.h" namespace "dht":
     cdef cppclass Value:
         Value() except +
@@ -132,6 +145,31 @@ cdef extern from "opendht/value.h" namespace "dht":
         InfoHash recipient
         vector[uint8_t] data
         string user_type
+
+    cdef cppclass Query:
+        Query() except +
+        Query(Select s, Where w) except +
+        Query(string q_str) except +
+        bool isSatisfiedBy(const Query& q) const
+        string toString() const
+
+    cdef cppclass Select:
+        Select() except +
+        Select(const string& q_str) except +
+        bool isSatisfiedBy(const Select& os) const
+        Select& field(Field field)
+        string toString() const
+
+    cdef cppclass Where:
+        Where() except +
+        Where(const string& q_str)
+        bool isSatisfiedBy(const Where& where) const
+        Where& id(uint64_t id)
+        Where& valueType(uint16_t type)
+        Where& owner(InfoHash owner_pk_hash)
+        Where& seq(uint16_t seq_no)
+        Where& userType(string user_type)
+        string toString() const
 
 cdef extern from "opendht/node.h" namespace "dht":
     cdef cppclass Node:

--- a/python/opendht_cpp.pxd
+++ b/python/opendht_cpp.pxd
@@ -121,6 +121,8 @@ cdef extern from "opendht/crypto.h" namespace "dht::crypto":
 ctypedef TrustList.VerifyResult TrustListVerifyResult
 
 cdef extern from "opendht/value.h" namespace "dht::Value":
+    ctypedef bool(*Filter)(const Value& value)
+
     cdef cppclass Field:
         pass
 
@@ -183,6 +185,7 @@ cdef extern from "opendht/callbacks.h" namespace "dht":
     ctypedef bool (*GetCallbackRaw)(shared_ptr[Value] values, void *user_data)
     ctypedef void (*DoneCallbackRaw)(bool done, vector[shared_ptr[Node]]* nodes, void *user_data)
     ctypedef void (*DoneCallbackSimpleRaw)(bool done, void *user_data)
+    ctypedef bool(*FilterRaw)(const Value& value, void *user_data)
 
     cppclass ShutdownCallback:
         ShutdownCallback() except +
@@ -197,6 +200,7 @@ cdef extern from "opendht/callbacks.h" namespace "dht":
     cdef GetCallback bindGetCb(GetCallbackRaw cb, void *user_data)
     cdef DoneCallback bindDoneCb(DoneCallbackRaw cb, void *user_data)
     cdef DoneCallbackSimple bindDoneCbSimple(DoneCallbackSimpleRaw cb, void *user_data)
+    cdef Value.Filter bindFilterRaw(FilterRaw f, void *user_data)
 
     cppclass Config:
         InfoHash node_id
@@ -229,6 +233,7 @@ cdef extern from "opendht/dhtrunner.h" namespace "dht":
         string getRoutingTablesLog(sa_family_t af) const
         string getSearchesLog(sa_family_t af) const
         void get(InfoHash key, GetCallback get_cb, DoneCallback done_cb)
+        void get(InfoHash key, GetCallback get_cb, DoneCallback done_cb, Value.Filter f, Where w)
         void put(InfoHash key, shared_ptr[Value] val, DoneCallback done_cb)
         ListenToken listen(InfoHash key, GetCallback get_cb)
         void cancelListen(InfoHash key, SharedListenToken token)

--- a/python/tools/http_server.py
+++ b/python/tools/http_server.py
@@ -42,13 +42,22 @@ class DhtServer(resource.Resource):
     def render_POST(self, req):
         uri = req.uri[1:]
         data = req.args[b'data'][0] if b'data' in req.args else None
+        user_type = req.args[b'user_type'][0].decode() if b'user_type' in req.args else ""
+        try:
+            vid = int(req.args[b'id'][0].decode()) if b'id' in req.args else 0
+        except ValueError:
+            vid = 0
         if not data and b'base64' in req.args:
             data = base64.b64decode(req.args[b'base64'][0])
         h = dht.InfoHash(uri) if len(uri) == 40 else dht.InfoHash.get(uri.decode())
         print('POST', h, data)
         req.setHeader(b"content-type", b"application/json")
         if data:
-            self.node.put(h, dht.Value(data))
+            v = dht.Value(data)
+            if vid != 0:
+                v.id = vid
+            v.user_type = user_type
+            self.node.put(h, v)
             return json.dumps({'success':True}).encode()
         else:
             req.setResponseCode(400)

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -26,6 +26,13 @@ namespace dht {
 
 const std::string Query::QUERY_PARSE_ERROR {"Error parsing query."};
 
+Value::Filter bindFilterRaw(FilterRaw raw_filter, void* user_data) {
+    if (not raw_filter) return {};
+    return [=](const Value& value) {
+        return raw_filter(value, user_data);
+    };
+}
+
 std::ostream& operator<< (std::ostream& s, const Value& v)
 {
     s << "Value[id:" << std::hex << v.id << std::dec << " ";


### PR DESCRIPTION
I enabled usage of `Where` class and setting of values' `user_type` and `id` in the http server. Indeed, to do so, I had to enable this in the python layer. At the same time, I decided to enable usage of `Query` and `Select` classes in the python layer. Due to the nature of the `DhtRunner.get` signature, I also had to enable usage of `Value.Filter` which I did. It is now easy to use filters and Where class like so:

```python
from opendht import DhtRunner, InfoHash, Query, Select, Where
n = DhtRunner()
n.run(port=5454)
n.bootstrap("bootstrap.ring.cx","4222")

q = Query()
w = Where("WHERE id=5") # SELECT * WHERE id=5
q.buildFrom(None, w)
s = Select("SELECT user_type")
s.field(1) # SELECT id,user_type

n.get(InfoHash.get("toto"), where=w) # blocking
n.get(InfoHash.get("toto"), filter=lambda v: v.id % 2 == 0) # blocking
```

Although `Query` and `Select` classes are enabled, to be useful, we'd need to enable the query function and then expose `FieldValue` class. Since it wasn't the goal of my PR, I didn't bother doing it.
