### PR TITLE
proxy: implement basic DhtProxyClient with the ability to get and put.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ list (APPEND opendht_HEADERS
     include/opendht/node.h
     include/opendht/value.h
     include/opendht/dht.h
+    include/opendht/dht_interface.h
     include/opendht/callbacks.h
     include/opendht/routing_table.h
     include/opendht/node_cache.h
@@ -170,12 +171,30 @@ if (OPENDHT_PROXY_SERVER)
   )
   list (APPEND opendht_SOURCES
     src/dht_proxy_server.cpp
-    src/base64.h
-    src/base64.cpp
   )
 else ()
     add_definitions(-DENABLE_PROXY_SERVER=false)
 endif ()
+
+if (OPENDHT_PROXY_CLIENT)
+  add_definitions(-DOPENDHT_PROXY_CLIENT=true)
+  list (APPEND opendht_HEADERS
+    include/opendht/dht_proxy_client.h
+  )
+  list (APPEND opendht_SOURCES
+    src/dht_proxy_client.cpp
+  )
+else ()
+  add_definitions(-DOPENDHT_PROXY_CLIENT=false)
+endif ()
+
+if (OPENDHT_PROXY_SERVER OR OPENDHT_PROXY_CLIENT)
+  list (APPEND opendht_SOURCES
+    src/base64.h
+    src/base64.cpp
+  )
+endif ()
+
 
 if(OPENDHT_ARGON2)
     # make sure argon2 submodule is up to date and initialized

--- a/include/opendht/callbacks.h
+++ b/include/opendht/callbacks.h
@@ -56,6 +56,8 @@ struct OPENDHT_PUBLIC NodeStats {
      * Build a json object from a NodeStats
      */
     Json::Value toJson() const;
+    NodeStats() {};
+    NodeStats(const Json::Value& v);
 #endif //OPENDHT_PROXY_SERVER
 };
 

--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -26,7 +26,7 @@
 #include "scheduler.h"
 #include "routing_table.h"
 #include "callbacks.h"
-#include "log_enable.h"
+#include "dht_interface.h"
 
 #include <string>
 #include <array>
@@ -58,14 +58,8 @@ struct LocalListener;
  * Must be given open UDP sockets and ::periodic must be
  * called regularly.
  */
-class OPENDHT_PUBLIC Dht {
+class OPENDHT_PUBLIC Dht : public DhtInterface {
 public:
-
-    // [[deprecated]]
-    using NodeExport = dht::NodeExport;
-
-    // [[deprecated]]
-    using Status = NodeStatus;
 
     Dht();
 
@@ -102,18 +96,6 @@ public:
      *      is running for the provided family.
      */
     bool isRunning(sa_family_t af = 0) const;
-
-    /**
-     * Enable or disable logging of DHT internal messages
-     */
-    void setLoggers(LogMethod error = NOLOG, LogMethod warn = NOLOG, LogMethod debug = NOLOG);
-
-    /**
-     * Only print logs related to the given InfoHash (if given), or disable filter (if zeroes).
-     */
-    void setLogFilter(const InfoHash& f) {
-        DHT_LOG.setFilter(f);
-    }
 
     virtual void registerType(const ValueType& type) {
         types[type.id] = type;
@@ -306,11 +288,6 @@ public:
     }
 
     std::vector<SockAddr> getPublicAddress(sa_family_t family = 0);
-
-protected:
-    Logger DHT_LOG;
-    bool logFilerEnable_ {};
-    InfoHash logFiler_ {};
 
 private:
 

--- a/include/opendht/dht_interface.h
+++ b/include/opendht/dht_interface.h
@@ -1,0 +1,235 @@
+/*
+ *  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
+ *  Author: Sébastien Blin <sebastien.blin@savoirfairelinux.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "infohash.h"
+#include "log_enable.h"
+
+namespace dht {
+
+class OPENDHT_PUBLIC DhtInterface {
+public:
+    DhtInterface() = default;
+    virtual ~DhtInterface() = default;
+
+    // [[deprecated]]
+    using Status = NodeStatus;
+    // [[deprecated]]
+    using NodeExport = dht::NodeExport;
+
+    /**
+     * Get the current status of the node for the given family.
+     */
+    virtual NodeStatus getStatus(sa_family_t af) const = 0;
+    virtual NodeStatus getStatus() const = 0;
+
+    /**
+     * Get the ID of the node.
+     */
+    virtual const InfoHash& getNodeId() const = 0;
+
+    /**
+     * Performs final operations before quitting.
+     */
+    virtual void shutdown(ShutdownCallback cb) = 0;
+
+    /**
+     * Returns true if the node is running (have access to an open socket).
+     *
+     *  af: address family. If non-zero, will return true if the node
+     *     is running for the provided family.
+     */
+    virtual bool isRunning(sa_family_t af = 0) const = 0;
+
+    virtual void registerType(const ValueType& type) = 0;
+
+    virtual const ValueType& getType(ValueType::Id type_id) const = 0;
+
+    /**
+     * Insert a node in the main routing table.
+     * The node is not pinged, so this should be
+     * used to bootstrap efficiently from previously known nodes.
+     */
+    virtual void insertNode(const InfoHash& id, const SockAddr&) = 0;
+    virtual void insertNode(const InfoHash& id, const sockaddr* sa, socklen_t salen) = 0;
+    virtual void insertNode(const NodeExport& n) = 0;
+
+    virtual void pingNode(const sockaddr*, socklen_t, DoneCallbackSimple&& cb={}) = 0;
+
+    virtual time_point periodic(const uint8_t *buf, size_t buflen, const SockAddr&) = 0;
+    virtual time_point periodic(const uint8_t *buf, size_t buflen, const sockaddr* from, socklen_t fromlen) = 0;
+
+    /**
+     * Get a value by searching on all available protocols (IPv4, IPv6),
+     * and call the provided get callback when values are found at key.
+     * The operation will start as soon as the node is connected to the network.
+     * @param cb a function called when new values are found on the network.
+     *         It should return false to stop the operation.
+     * @param donecb a function called when the operation is complete.
+                  cb and donecb won't be called again afterward.
+     * @param f a filter function used to prefilter values.
+     */
+    virtual void get(const InfoHash& key, GetCallback cb, DoneCallback donecb={}, Value::Filter&& f={}, Where&& w = {}) = 0;
+    virtual void get(const InfoHash& key, GetCallback cb, DoneCallbackSimple donecb={}, Value::Filter&& f={}, Where&& w = {}) = 0;
+    virtual void get(const InfoHash& key, GetCallbackSimple cb, DoneCallback donecb={}, Value::Filter&& f={}, Where&& w = {}) = 0;
+    virtual void get(const InfoHash& key, GetCallbackSimple cb, DoneCallbackSimple donecb, Value::Filter&& f={}, Where&& w = {}) = 0;
+
+    /**
+      * Similar to Dht::get, but sends a Query to filter data remotely.
+      * @param key the key for which to query data for.
+      * @param cb a function called when new values are found on the network.
+      *         It should return false to stop the operation.
+      * @param done_cb a function called when the operation is complete.
+                      cb and done_cb won't be called again afterward.
+      * @param q a query used to filter values on the remotes before they send a
+      *        response.
+      */
+    virtual void query(const InfoHash& key, QueryCallback cb, DoneCallback done_cb = {}, Query&& q = {}) = 0;
+    virtual void query(const InfoHash& key, QueryCallback cb, DoneCallbackSimple done_cb = {}, Query&& q = {}) = 0;
+
+    /**
+     * Get locally stored data for the given hash.
+     */
+    virtual std::vector<Sp<Value>> getLocal(const InfoHash& key, Value::Filter f = Value::AllFilter()) const = 0;
+
+    /**
+     * Get locally stored data for the given key and value id.
+     */
+    virtual Sp<Value> getLocalById(const InfoHash& key, Value::Id vid) const = 0;
+
+    /**
+     * Announce a value on all available protocols (IPv4, IPv6).
+     *
+     * The operation will start as soon as the node is connected to the network.
+     * The done callback will be called once, when the first announce succeeds, or fails.
+     */
+    virtual void put(const InfoHash& key,
+           Sp<Value>,
+           DoneCallback cb=nullptr,
+           time_point created=time_point::max(),
+           bool permanent = false) = 0;
+    virtual void put(const InfoHash& key,
+           const Sp<Value>& v,
+           DoneCallbackSimple cb,
+           time_point created=time_point::max(),
+           bool permanent = false) = 0;
+    virtual void put(const InfoHash& key,
+           Value&& v,
+           DoneCallback cb=nullptr,
+           time_point created=time_point::max(),
+           bool permanent = false) = 0;
+    virtual void put(const InfoHash& key,
+           Value&& v,
+           DoneCallbackSimple cb,
+           time_point created=time_point::max(),
+           bool permanent = false) = 0;
+
+    /**
+     * Get data currently being put at the given hash.
+     */
+    virtual std::vector<Sp<Value>> getPut(const InfoHash&) = 0;
+
+    /**
+     * Get data currently being put at the given hash with the given id.
+     */
+    virtual Sp<Value> getPut(const InfoHash&, const Value::Id&) = 0;
+
+    /**
+     * Stop any put/announce operation at the given location,
+     * for the value with the given id.
+     */
+    virtual bool cancelPut(const InfoHash&, const Value::Id&) = 0;
+
+    /**
+     * Listen on the network for any changes involving a specified hash.
+     * The node will register to receive updates from relevent nodes when
+     * new values are added or removed.
+     *
+     * @return a token to cancel the listener later.
+     */
+    virtual size_t listen(const InfoHash&, GetCallback, Value::Filter&&={}, Where&& w = {}) = 0;
+    virtual size_t listen(const InfoHash& key, GetCallbackSimple cb, Value::Filter f={}, Where w = {}) = 0;
+
+    virtual bool cancelListen(const InfoHash&, size_t token) = 0;
+
+    /**
+     * Inform the DHT of lower-layer connectivity changes.
+     * This will cause the DHT to assume a public IP address change.
+     * The DHT will recontact neighbor nodes, re-register for listen ops etc.
+     */
+    virtual void connectivityChanged(sa_family_t) = 0;
+    virtual void connectivityChanged() = 0;
+
+    /**
+     * Get the list of good nodes for local storage saving purposes
+     * The list is ordered to minimize the back-to-work delay.
+     */
+    virtual std::vector<NodeExport> exportNodes() = 0;
+
+    virtual std::vector<ValuesExport> exportValues() const = 0;
+    virtual void importValues(const std::vector<ValuesExport>&) = 0;
+
+    virtual NodeStats getNodesStats(sa_family_t af) const = 0;
+
+    virtual std::string getStorageLog() const = 0;
+    virtual std::string getStorageLog(const InfoHash&) const = 0;
+
+    virtual std::string getRoutingTablesLog(sa_family_t) const = 0;
+    virtual std::string getSearchesLog(sa_family_t) const = 0;
+    virtual std::string getSearchLog(const InfoHash&, sa_family_t af = AF_UNSPEC) const = 0;
+
+    virtual void dumpTables() const = 0;
+    virtual std::vector<unsigned> getNodeMessageStats(bool in = false) = 0;
+
+    /**
+     * Set the in-memory storage limit in bytes
+     */
+    virtual void setStorageLimit(size_t limit = DEFAULT_STORAGE_LIMIT) = 0;
+
+    /**
+     * Returns the total memory usage of stored values and the number
+     * of stored values.
+     */
+    virtual std::pair<size_t, size_t> getStoreSize() const = 0;
+
+    virtual std::vector<SockAddr> getPublicAddress(sa_family_t family = 0) = 0;
+
+    Logger DHT_LOG;
+    /**
+     * Enable or disable logging of DHT internal messages
+     */
+    virtual void setLoggers(LogMethod error = NOLOG, LogMethod warn = NOLOG, LogMethod debug = NOLOG)
+    {
+        DHT_LOG.DEBUG = debug;
+        DHT_LOG.WARN = warn;
+        DHT_LOG.ERR = error;
+    }
+
+    /**
+     * Only print logs related to the given InfoHash (if given), or disable filter (if zeroes).
+     */
+    virtual void setLogFilter(const InfoHash& f) {
+        DHT_LOG.setFilter(f);
+    }
+protected:
+    bool logFilerEnable_ {};
+    InfoHash logFiler_ {};
+};
+
+} // namespace dht

--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -1,0 +1,274 @@
+/*
+ *  Copyright (C) 2016 Savoir-faire Linux Inc.
+ *  Author : Sébastien Blin <sebastien.blin@savoirfairelinux.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#if OPENDHT_PROXY_SERVER
+
+#pragma once
+
+#include "callbacks.h"
+#include "def.h"
+#include "dht_interface.h"
+
+namespace dht {
+
+class OPENDHT_PUBLIC DhtProxyClient : public DhtInterface {
+public:
+
+    DhtProxyClient() {}
+
+    /**
+     * Initialise the DhtProxyClient with two open sockets (for IPv4 and IP6)
+     * and an ID for the node.
+     */
+    explicit DhtProxyClient(const std::string& serverHost);
+    virtual ~DhtProxyClient() {}
+
+    /**
+     * Get the ID of the node.
+     */
+    inline const InfoHash& getNodeId() const { return myid; }
+
+    /**
+     * Get the current status of the node for the given family.
+     */
+    NodeStatus getStatus(sa_family_t af) const;
+    NodeStatus getStatus() const {
+        return std::max(getStatus(AF_INET), getStatus(AF_INET6));
+    }
+
+    /**
+     * Performs final operations before quitting.
+     */
+    void shutdown(ShutdownCallback cb) { cb(); }
+
+    /**
+     * Returns true if the node is running (have access to an open socket).
+     *
+     *  af: address family. If non-zero, will return true if the node
+     *      is running for the provided family.
+     */
+    bool isRunning(sa_family_t af = 0) const;
+
+    /**
+     * Get a value by asking the proxy and call the provided get callback when
+     * values are found at key.
+     * The operation will start as soon as the node is connected to the network.
+     * @param cb a function called when new values are found on the network.
+     *           It should return false to stop the operation.
+     * @param donecb a function called when the operation is complete.
+                     cb and donecb won't be called again afterward.
+     * @param f a filter function used to prefilter values.
+     */
+    virtual void get(const InfoHash& key, GetCallback cb, DoneCallback donecb={}, Value::Filter&& f={}, Where&& w = {});
+    virtual void get(const InfoHash& key, GetCallback cb, DoneCallbackSimple donecb={}, Value::Filter&& f={}, Where&& w = {}) {
+        get(key, cb, bindDoneCb(donecb), std::forward<Value::Filter>(f), std::forward<Where>(w));
+    }
+    virtual void get(const InfoHash& key, GetCallbackSimple cb, DoneCallback donecb={}, Value::Filter&& f={}, Where&& w = {}) {
+        get(key, bindGetCb(cb), donecb, std::forward<Value::Filter>(f), std::forward<Where>(w));
+    }
+    virtual void get(const InfoHash& key, GetCallbackSimple cb, DoneCallbackSimple donecb, Value::Filter&& f={}, Where&& w = {}) {
+        get(key, bindGetCb(cb), bindDoneCb(donecb), std::forward<Value::Filter>(f), std::forward<Where>(w));
+    }
+
+    /**
+     * Announce a value on all available protocols (IPv4, IPv6).
+     *
+     * The operation will start as soon as the node is connected to the network.
+     * The done callback will be called once, when the first announce succeeds, or fails.
+     * NOTE: For now, created parameter is ignored.
+     */
+    void put(const InfoHash& key,
+            Sp<Value>,
+            DoneCallback cb=nullptr,
+            time_point created=time_point::max(),
+            bool permanent = false);
+    void put(const InfoHash& key,
+            const Sp<Value>& v,
+            DoneCallbackSimple cb,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        put(key, v, bindDoneCb(cb), created, permanent);
+    }
+
+    void put(const InfoHash& key,
+            Value&& v,
+            DoneCallback cb=nullptr,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        put(key, std::make_shared<Value>(std::move(v)), cb, created, permanent);
+    }
+    void put(const InfoHash& key,
+            Value&& v,
+            DoneCallbackSimple cb,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        put(key, std::forward<Value>(v), bindDoneCb(cb), created, permanent);
+    }
+
+    NodeStats getNodesStats(sa_family_t af) const;
+
+    std::vector<SockAddr> getPublicAddress(sa_family_t family = 0);
+
+
+    /**
+     * TODO
+     * NOTE: For now, there is no endpoint in the DhtProxyServer to do the following methods.
+     * It will come in another version.
+     */
+
+    /**
+     * Listen on the network for any changes involving a specified hash.
+     * The node will register to receive updates from relevent nodes when
+     * new values are added or removed.
+     *
+     * @return a token to cancel the listener later.
+     */
+    virtual size_t listen(const InfoHash&, GetCallback, Value::Filter&&={}, Where&&={}) { return 0; };
+    virtual size_t listen(const InfoHash& key, GetCallbackSimple cb, Value::Filter f={}, Where w = {}) {
+        return listen(key, bindGetCb(cb), std::forward<Value::Filter>(f), std::forward<Where>(w));
+    }
+    virtual bool cancelListen(const InfoHash&, size_t /*token*/) { return false; }
+
+    /**
+     * Similar to Dht::get, but sends a Query to filter data remotely.
+     * @param key the key for which to query data for.
+     * @param cb a function called when new values are found on the network.
+     *           It should return false to stop the operation.
+     * @param done_cb a function called when the operation is complete.
+               cb and done_cb won't be called again afterward.
+     * @param q a query used to filter values on the remotes before they send a
+     *          response.
+     */
+    virtual void query(const InfoHash& /*key*/, QueryCallback /*cb*/, DoneCallback /*done_cb*/ = {}, Query&& /*q*/ = {}) { }
+    virtual void query(const InfoHash& key, QueryCallback cb, DoneCallbackSimple done_cb = {}, Query&& q = {}) {
+        query(key, cb, bindDoneCb(done_cb), std::forward<Query>(q));
+    }
+
+    /**
+     * Get data currently being put at the given hash.
+     */
+    std::vector<Sp<Value>> getPut(const InfoHash&) { return {}; }
+
+    /**
+     * Get data currently being put at the given hash with the given id.
+     */
+    Sp<Value> getPut(const InfoHash&, const Value::Id&) { return {}; }
+
+    /**
+     * Stop any put/announce operation at the given location,
+     * for the value with the given id.
+     */
+    bool cancelPut(const InfoHash&, const Value::Id&) { return false; }
+
+    void pingNode(const sockaddr*, socklen_t, DoneCallbackSimple&& /*cb*/={}) { }
+
+    /**
+     * NOTE: The following methods will not be implemented because the
+     * DhtProxyClient doesn't have any storage nor synchronization process
+     */
+
+    /**
+     * Insert a node in the main routing table.
+     * The node is not pinged, so this should be
+     * used to bootstrap efficiently from previously known nodes.
+     */
+    void insertNode(const InfoHash&, const SockAddr&) { }
+    void insertNode(const InfoHash&, const sockaddr*, socklen_t) { }
+    void insertNode(const NodeExport&) { }
+
+    /**
+     * Returns the total memory usage of stored values and the number
+     * of stored values.
+     */
+    std::pair<size_t, size_t> getStoreSize() const { return {}; }
+
+    virtual void registerType(const ValueType&) { }
+    const ValueType& getType(ValueType::Id) const { }
+
+    /**
+     * Get locally stored data for the given hash.
+     */
+    std::vector<Sp<Value>> getLocal(const InfoHash&, Value::Filter) const { return {}; }
+
+    /**
+     * Get locally stored data for the given key and value id.
+     */
+    Sp<Value> getLocalById(const InfoHash&, Value::Id) const { return {}; }
+
+    /**
+     * Get the list of good nodes for local storage saving purposes
+     * The list is ordered to minimize the back-to-work delay.
+     */
+    std::vector<NodeExport> exportNodes() { return {}; }
+
+    std::vector<ValuesExport> exportValues() const { return {}; }
+    void importValues(const std::vector<ValuesExport>&) {}
+
+    std::string getStorageLog() const { return {}; }
+    std::string getStorageLog(const InfoHash&) const { return {}; }
+
+    std::string getRoutingTablesLog(sa_family_t) const { return {}; }
+    std::string getSearchesLog(sa_family_t) const { return {}; }
+    std::string getSearchLog(const InfoHash&, sa_family_t) const { return {}; }
+
+    void dumpTables() const {}
+    std::vector<unsigned> getNodeMessageStats(bool) { return {}; }
+
+    /**
+     * Set the in-memory storage limit in bytes
+     */
+    void setStorageLimit(size_t) {}
+
+    /**
+     * Inform the DHT of lower-layer connectivity changes.
+     * This will cause the DHT to assume a public IP address change.
+     * The DHT will recontact neighbor nodes, re-register for listen ops etc.
+     */
+    void connectivityChanged(sa_family_t) {}
+    void connectivityChanged() {
+        connectivityChanged(AF_INET);
+        connectivityChanged(AF_INET6);
+    }
+
+    time_point periodic(const uint8_t*, size_t, const SockAddr&) {
+        // The DhtProxyClient doesn't use NetworkEngine, so here, we have nothing to do for now.
+        return {};
+    }
+    time_point periodic(const uint8_t *buf, size_t buflen, const sockaddr* from, socklen_t fromlen) {
+        return periodic(buf, buflen, SockAddr(from, fromlen));
+    }
+
+private:
+    Json::Value getProxyInfos() const;
+    /**
+     * Initialize statusIpvX_
+     */
+    void getConnectivityStatus();
+    std::string serverHost_;
+    NodeStatus statusIpv4_ {NodeStatus::Disconnected};
+    NodeStatus statusIpv6_ {NodeStatus::Disconnected};
+
+    InfoHash myid {};
+};
+
+}
+
+#endif // OPENDHT_PROXY_CLIENT

--- a/include/opendht/securedht.h
+++ b/include/opendht/securedht.h
@@ -29,12 +29,20 @@
 
 namespace dht {
 
-class OPENDHT_PUBLIC SecureDht : public Dht {
+class OPENDHT_PUBLIC SecureDht : public DhtInterface {
 public:
 
     typedef std::function<void(bool)> SignatureCheckCallback;
 
     using Config = SecureDhtConfig;
+
+    static dht::Config& getConfig(SecureDht::Config& conf)
+    {
+        auto& c = conf.node_config;
+        if (not c.node_id and conf.id.second)
+            c.node_id = InfoHash::get("node:"+conf.id.second->getId().toString());
+        return c;
+    }
 
     SecureDht() {}
 
@@ -44,7 +52,7 @@ public:
      * id:    the identity to use for the crypto layer and to compute
      *        our own hash on the Dht.
      */
-    SecureDht(int s, int s6, Config config);
+    SecureDht(std::unique_ptr<DhtInterface> dht, Config config);
 
     virtual ~SecureDht();
 
@@ -62,14 +70,17 @@ public:
         return secureType(std::move(tmp_type));
     }
 
-    virtual void registerType(const ValueType& type) override {
-        Dht::registerType(secureType(type));
+    void registerType(const ValueType& type) {
+        if (dht_)
+            dht_->registerType(secureType(type));
     }
-    virtual void registerType(ValueType&& type) {
-        Dht::registerType(secureType(std::forward<ValueType>(type)));
+    void registerType(ValueType&& type) {
+        if (dht_)
+            dht_->registerType(secureType(std::forward<ValueType>(type)));
     }
-    virtual void registerInsecureType(const ValueType& type) {
-        Dht::registerType(type);
+    void registerInsecureType(const ValueType& type) {
+        if (dht_)
+            dht_->registerType(type);
     }
 
     /**
@@ -77,18 +88,18 @@ public:
      * If the signature can't be checked, or if the data can't be decrypted, it is not returned.
      * Public, non-signed & non-encrypted data is retransmitted as-is.
      */
-    virtual void get(const InfoHash& id, GetCallback cb, DoneCallback donecb={}, Value::Filter&& = {}, Where&& w = {}) override;
-    virtual void get(const InfoHash& id, GetCallback cb, DoneCallbackSimple donecb={}, Value::Filter&& f = {}, Where&& w = {}) override {
+    void get(const InfoHash& id, GetCallback cb, DoneCallback donecb={}, Value::Filter&& = {}, Where&& w = {});
+    void get(const InfoHash& id, GetCallback cb, DoneCallbackSimple donecb={}, Value::Filter&& f = {}, Where&& w = {}) {
         get(id, cb, bindDoneCb(donecb), std::forward<Value::Filter>(f), std::forward<Where>(w));
     }
-    virtual void get(const InfoHash& key, GetCallbackSimple cb, DoneCallback donecb={}, Value::Filter&& f={}, Where&& w = {}) override {
+    void get(const InfoHash& key, GetCallbackSimple cb, DoneCallback donecb={}, Value::Filter&& f={}, Where&& w = {}) {
         get(key, bindGetCb(cb), donecb, std::forward<Value::Filter>(f), std::forward<Where>(w));
     }
-    virtual void get(const InfoHash& key, GetCallbackSimple cb, DoneCallbackSimple donecb, Value::Filter&& f={}, Where&& w = {}) override {
+    void get(const InfoHash& key, GetCallbackSimple cb, DoneCallbackSimple donecb, Value::Filter&& f={}, Where&& w = {}) {
         get(key, bindGetCb(cb), bindDoneCb(donecb), std::forward<Value::Filter>(f), std::forward<Where>(w));
     }
 
-    virtual size_t listen(const InfoHash& id, GetCallback cb, Value::Filter&& = {}, Where&& w = {}) override;
+    size_t listen(const InfoHash& id, GetCallback cb, Value::Filter&& = {}, Where&& w = {});
 
     /**
      * Will take ownership of the value, sign it using our private key and put it in the DHT.
@@ -135,7 +146,160 @@ public:
         localQueryMethod_ = std::move(query_method);
     }
 
+    /**
+     * SecureDht to Dht proxy
+     */
+    void shutdown(ShutdownCallback cb) {
+        dht_->shutdown(cb);
+    }
+    void dumpTables() const {
+        dht_->dumpTables();
+    }
+    inline const InfoHash& getNodeId() const { return dht_->getNodeId(); }
+    std::pair<size_t, size_t> getStoreSize() const {
+        return dht_->getStoreSize();
+    }
+    std::string getStorageLog() const {
+        return dht_->getStorageLog();
+    }
+    std::string getStorageLog(const InfoHash& h) const {
+        return dht_->getStorageLog(h);
+    }
+    void setStorageLimit(size_t limit = DEFAULT_STORAGE_LIMIT) {
+        dht_->setStorageLimit(limit);
+    }
+    std::vector<NodeExport> exportNodes() {
+        return dht_->exportNodes();
+    }
+    std::vector<ValuesExport> exportValues() const {
+        return dht_->exportValues();
+    }
+    void setLoggers(LogMethod error = NOLOG, LogMethod warn = NOLOG, LogMethod debug = NOLOG) {
+        dht_->setLoggers(error, warn, debug);
+    }
+    void setLogFilter(const InfoHash& f) {
+        dht_->setLogFilter(f);
+    }
+    void importValues(const std::vector<ValuesExport>& v) {
+        dht_->importValues(v);
+    }
+    NodeStats getNodesStats(sa_family_t af) const {
+        return dht_->getNodesStats(af);
+    }
+    std::vector<unsigned> getNodeMessageStats(bool in = false) {
+        return dht_->getNodeMessageStats(in);
+    }
+    std::string getRoutingTablesLog(sa_family_t af) const {
+        return dht_->getRoutingTablesLog(af);
+    }
+    std::string getSearchesLog(sa_family_t af) const {
+        return dht_->getSearchesLog(af);
+    }
+    std::string getSearchLog(const InfoHash& h, sa_family_t af = AF_UNSPEC) const {
+        return dht_->getSearchLog(h, af);
+    }
+    std::vector<SockAddr> getPublicAddress(sa_family_t family = 0) {
+        return dht_->getPublicAddress(family);
+    }
+    time_point periodic(const uint8_t *buf, size_t buflen, const SockAddr& sa) {
+        return dht_->periodic(buf, buflen, sa);
+    }
+    time_point periodic(const uint8_t *buf, size_t buflen, const sockaddr* from, socklen_t fromlen) {
+        return dht_->periodic(buf, buflen, from, fromlen);
+    }
+    NodeStatus getStatus(sa_family_t af) const {
+        return dht_->getStatus(af);
+    }
+    NodeStatus getStatus() const {
+        return dht_->getStatus();
+    }
+    bool isRunning(sa_family_t af = 0) const {
+        return dht_->isRunning(af);
+    }
+    const ValueType& getType(ValueType::Id type_id) const {
+        return dht_->getType(type_id);
+    }
+    void insertNode(const InfoHash& id, const SockAddr& sa) {
+        dht_->insertNode(id, sa);
+    }
+    void insertNode(const InfoHash& id, const sockaddr* sa, socklen_t salen) {
+        dht_->insertNode(id, sa, salen);
+    }
+    void insertNode(const NodeExport& n) {
+        dht_->insertNode(n);
+    }
+    void pingNode(const sockaddr* sa, socklen_t salen, DoneCallbackSimple&& cb={}) {
+        dht_->pingNode(sa, salen, std::move(cb));
+    }
+    void query(const InfoHash& key, QueryCallback cb, DoneCallback done_cb = {}, Query&& q = {}) {
+        dht_->query(key, cb, done_cb, std::move(q));
+    }
+    void query(const InfoHash& key, QueryCallback cb, DoneCallbackSimple done_cb = {}, Query&& q = {}) {
+        dht_->query(key, cb, done_cb, std::move(q));
+    }
+    std::vector<Sp<Value>> getLocal(const InfoHash& key, Value::Filter f = Value::AllFilter()) const {
+        return dht_->getLocal(key, f);
+    }
+    Sp<Value> getLocalById(const InfoHash& key, Value::Id vid) const {
+        return dht_->getLocalById(key, vid);
+    }
+    void put(const InfoHash& key,
+            Sp<Value> v,
+            DoneCallback cb=nullptr,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        dht_->put(key, v, cb, created, permanent);
+    }
+    void put(const InfoHash& key,
+            const Sp<Value>& v,
+            DoneCallbackSimple cb,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        dht_->put(key, v, cb, created, permanent);
+    }
+
+    void put(const InfoHash& key,
+            Value&& v,
+            DoneCallback cb=nullptr,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        dht_->put(key, std::move(v), cb, created, permanent);
+    }
+    void put(const InfoHash& key,
+            Value&& v,
+            DoneCallbackSimple cb,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        dht_->put(key, std::move(v), cb, created, permanent);
+    }
+    std::vector<Sp<Value>> getPut(const InfoHash& h) {
+        return dht_->getPut(h);
+    }
+    Sp<Value> getPut(const InfoHash& h, const Value::Id& vid) {
+        return dht_->getPut(h, vid);
+    }
+    bool cancelPut(const InfoHash& h, const Value::Id& vid) {
+        return dht_->cancelPut(h, vid);
+    }
+    size_t listen(const InfoHash& key, GetCallbackSimple cb, Value::Filter f={}, Where w = {}) {
+        return dht_->listen(key, cb, f, w);
+    }
+    bool cancelListen(const InfoHash& h, size_t token) {
+        return dht_->cancelListen(h, token);
+    }
+    void connectivityChanged(sa_family_t af) {
+        dht_->connectivityChanged(af);
+    }
+    void connectivityChanged() {
+        dht_->connectivityChanged();
+    }
+
 private:
+    std::unique_ptr<DhtInterface> dht_;
     // prevent copy
     SecureDht(const SecureDht&) = delete;
     SecureDht& operator=(const SecureDht&) = delete;

--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -86,6 +86,18 @@ NodeStats::toJson() const
     }
     return val;
 }
+
+NodeStats::NodeStats(const Json::Value& val)
+{
+    if (val.isMember("good"))
+        good_nodes = static_cast<unsigned>(val["good"].asLargestUInt());
+    if (val.isMember("dubious"))
+        dubious_nodes = static_cast<unsigned>(val["dubious"].asLargestUInt());
+    if (val.isMember("incoming"))
+        incoming_nodes = static_cast<unsigned>(val["incoming"].asLargestUInt());
+    if (val.isMember("table_depth"))
+        table_depth = static_cast<unsigned>(val["table_depth"].asLargestUInt());
+}
 #endif //OPENDHT_PROXY_SERVER
 
 }

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -39,14 +39,6 @@ constexpr std::chrono::minutes Dht::SEARCH_EXPIRE_TIME;
 constexpr std::chrono::seconds Dht::LISTEN_EXPIRE_TIME;
 constexpr std::chrono::seconds Dht::REANNOUNCE_MARGIN;
 
-void
-Dht::setLoggers(LogMethod error, LogMethod warn, LogMethod debug)
-{
-    DHT_LOG.DEBUG = debug;
-    DHT_LOG.WARN = warn;
-    DHT_LOG.ERR = error;
-}
-
 NodeStatus
 Dht::getStatus(sa_family_t af) const
 {

--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -1,0 +1,272 @@
+/*
+ *  Copyright (C) 2016 Savoir-faire Linux Inc.
+ *  Author : Sébastien Blin <sebastien.blin@savoirfairelinux.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#if OPENDHT_PROXY_SERVER
+
+#include "dht_proxy_client.h"
+
+#include <restbed>
+#include <json/json.h>
+#include <sstream>
+#include <vector>
+
+#include "dhtrunner.h"
+
+constexpr const char* const HTTP_PROTO {"http://"};
+
+// TODO connectivity changed
+// TODO follow listen between non proxified and proxified
+
+namespace dht {
+
+DhtProxyClient::DhtProxyClient(const std::string& serverHost)
+: serverHost_(serverHost)
+{
+    getConnectivityStatus();
+}
+
+NodeStatus
+DhtProxyClient::getStatus(sa_family_t af) const
+{
+    switch (af)
+    {
+    case AF_INET:
+        return statusIpv4_;
+    case AF_INET6:
+        return statusIpv6_;
+    default:
+        return NodeStatus::Disconnected;
+    }
+}
+
+bool
+DhtProxyClient::isRunning(sa_family_t af) const
+{
+    switch (af)
+    {
+    case AF_INET:
+        return statusIpv4_ == NodeStatus::Connected;
+    case AF_INET6:
+        return statusIpv6_ == NodeStatus::Connected;
+    default:
+        return false;
+    }
+}
+
+void
+DhtProxyClient::get(const InfoHash& key, GetCallback cb, DoneCallback donecb,
+                    Value::Filter&& filter, Where&& where)
+{
+    restbed::Uri uri(HTTP_PROTO + serverHost_ + "/" + key.toString());
+    auto req = std::make_shared<restbed::Request>(uri);
+
+    Query query {{}, where};
+    auto filterChain = filter.chain(query.where.getFilter());
+
+    // Try to contact the proxy and set the status to connected when done.
+    // will change the connectivity status
+    auto ok = std::make_shared<bool>(true);
+    auto future = restbed::Http::async(req,
+        [this, ok, cb, filterChain](const std::shared_ptr<restbed::Request>& req,
+                                    const std::shared_ptr<restbed::Response>& reply) {
+        auto code = reply->get_status_code();
+
+        if (code == 200) {
+            while (restbed::Http::is_open(req)) {
+                restbed::Http::fetch("\n", reply);
+                std::string body;
+                reply->get_body(body);
+                reply->set_body(""); // Reset the body for the next fetch
+
+                Json::Value json;
+                Json::Reader reader;
+                if (reader.parse(body, json)) {
+                    auto value = std::make_shared<Value>(json);
+                    if (not filterChain or filterChain(*value))
+                        cb({value});
+                } else {
+                    *ok = false;
+                }
+            }
+        } else {
+            *ok = false;
+        }
+    });
+    future.wait();
+    donecb(*ok, {});
+    if (!ok) {
+        // Connection failed, update connectivity
+        getConnectivityStatus();
+    }
+}
+
+void
+DhtProxyClient::put(const InfoHash& key, Sp<Value> val, DoneCallback cb, time_point, bool permanent)
+{
+    restbed::Uri uri(HTTP_PROTO + serverHost_ + "/" + key.toString());
+    auto req = std::make_shared<restbed::Request>(uri);
+    req->set_method("POST");
+    Json::FastWriter writer;
+    auto json = val->toJson();
+    if (permanent)
+        json["permanent"] = true;
+    auto body = writer.write(json);
+    req->set_body(body);
+    req->set_header("Content-Length", std::to_string(body.size()));
+
+    auto ok = std::make_shared<bool>(true);
+    auto future = restbed::Http::async(req,
+        [this, val, ok](const std::shared_ptr<restbed::Request>& /*req*/,
+                    const std::shared_ptr<restbed::Response>& reply) {
+        auto code = reply->get_status_code();
+
+        if (code == 200) {
+            restbed::Http::fetch("\n", reply);
+            std::string body;
+            reply->get_body(body);
+            reply->set_body(""); // Reset the body for the next fetch
+
+            Json::Value json;
+            Json::Reader reader;
+            if (reader.parse(body, json)) {
+                auto value = std::make_shared<Value>(json);
+            } else {
+                *ok = false;
+            }
+        } else {
+            *ok = false;
+        }
+    });
+    future.wait();
+    cb(*ok, {});
+    if (!ok) {
+        // Connection failed, update connectivity
+        getConnectivityStatus();
+    }
+}
+
+NodeStats
+DhtProxyClient::getNodesStats(sa_family_t af) const
+{
+    auto proxyInfos = getProxyInfos();
+    NodeStats stats {};
+    auto identifier = af == AF_INET6 ? "ipv6" : "ipv4";
+    try {
+        stats = NodeStats(proxyInfos[identifier]);
+    } catch (...) { }
+    return stats;
+}
+
+Json::Value
+DhtProxyClient::getProxyInfos() const
+{
+    auto result = std::make_shared<Json::Value>();
+    restbed::Uri uri(HTTP_PROTO + serverHost_ + "/");
+    auto req = std::make_shared<restbed::Request>(uri);
+
+    // Try to contact the proxy and set the status to connected when done.
+    // will change the connectivity status
+    auto future = restbed::Http::async(req,
+        [this, result](const std::shared_ptr<restbed::Request>&,
+                       const std::shared_ptr<restbed::Response>& reply) {
+        auto code = reply->get_status_code();
+
+        if (code == 200) {
+            restbed::Http::fetch("\n", reply);
+            std::string body;
+            reply->get_body(body);
+
+            Json::Reader reader;
+            reader.parse(body, *result);
+        }
+    });
+    future.wait();
+    return *result;
+}
+
+std::vector<SockAddr>
+DhtProxyClient::getPublicAddress(sa_family_t family)
+{
+    auto proxyInfos = getProxyInfos();
+    // json["public_ip"] contains [ipv6:ipv4]:port or ipv4:port
+    if (!proxyInfos.isMember("public_ip")) {
+        getConnectivityStatus();
+        return {};
+    }
+    auto public_ip = proxyInfos["public_ip"].asString();
+    if (public_ip.length() < 2) {
+        getConnectivityStatus();
+        return {};
+    }
+    std::string ipv4Address = "";
+    std::string ipv6Address = "";
+    std::string port = "";
+    if (public_ip[0] == '[') {
+        // ipv6 complient
+        auto endIp = public_ip.find(']');
+        if (public_ip.length() > endIp + 2) {
+            port = public_ip.substr(endIp + 2);
+            auto ips = public_ip.substr(1, endIp - 1);
+            auto ipv4And6Separator = ips.find_last_of(':');
+            ipv4Address = ips.substr(ipv4And6Separator + 1);
+            ipv6Address = ips.substr(0, ipv4And6Separator - 1);
+        }
+    } else {
+        auto endIp = public_ip.find_last_of(':');
+        port = public_ip.substr(endIp + 1);
+        ipv4Address = public_ip.substr(0, endIp - 1);
+    }
+    switch (family)
+    {
+    case AF_INET:
+        return DhtRunner::getAddrInfo(ipv4Address, port);
+    case AF_INET6:
+        return DhtRunner::getAddrInfo(ipv6Address, port);
+    default:
+        return {};
+    }
+}
+
+void
+DhtProxyClient::getConnectivityStatus()
+{
+    auto proxyInfos = getProxyInfos();
+    // json["ipvX"] contains NodeStats::toJson()
+    try {
+        auto goodIpv4 = static_cast<long>(proxyInfos["ipv4"]["good"].asLargestUInt());
+        auto dubiousIpv4 = static_cast<long>(proxyInfos["ipv4"]["dubious"].asLargestUInt());
+        if (goodIpv4 + dubiousIpv4 > 0) {
+            statusIpv4_ = NodeStatus::Connected;
+        }
+        auto goodIpv6 = static_cast<long>(proxyInfos["ipv6"]["good"].asLargestUInt());
+        auto dubiousIpv6 = static_cast<long>(proxyInfos["ipv6"]["dubious"].asLargestUInt());
+        if (goodIpv6 + dubiousIpv6 > 0) {
+            statusIpv6_ = NodeStatus::Connected;
+        }
+        myid = InfoHash(proxyInfos["node_id"].asString());
+    } catch (...) {
+        statusIpv4_ = NodeStatus::Disconnected;
+        statusIpv6_ = NodeStatus::Disconnected;
+    }
+
+    // TODO for now, we don't handle connectivity issues. (when the proxy is down, we don't try to reconnect)
+}
+
+} // namespace dht
+
+#endif // OPENDHT_PROXY_CLIENT

--- a/tools/dhtnode.cpp
+++ b/tools/dhtnode.cpp
@@ -63,6 +63,12 @@ void print_help() {
               << "  psp [port]            Stop the proxy interface on port." << std::endl;
 #endif //OPENDHT_PROXY_SERVER
 
+#if OPENDHT_PROXY_CLIENT
+    std::cout << std::endl << "Operations with the proxy:" << std::endl
+              << "  stt [server_address]  Start the proxy client." << std::endl
+              << "  stp                   Stop the proxy client." << std::endl;
+#endif //OPENDHT_PROXY_CLIENT
+
     std::cout << std::endl << "Operations on the DHT:" << std::endl
               << "  b <ip:port>           Ping potential node at given IP address/port." << std::endl
               << "  g <key>               Get values at <key>." << std::endl
@@ -96,6 +102,12 @@ void cmd_loop(std::shared_ptr<DhtRunner>& dht, dht_params& params)
         proxies.emplace(params.proxyserver, new DhtProxyServer(dht, params.proxyserver));
     }
 #endif //OPENDHT_PROXY_SERVER
+#if OPENDHT_PROXY_CLIENT
+    if (!params.proxyclient.empty()) {
+        dht->setProxyServer(params.proxyclient);
+        dht->enableProxy(true);
+    }
+#endif //OPENDHT_PROXY_CLIENT
 
     while (true)
     {
@@ -191,6 +203,17 @@ void cmd_loop(std::shared_ptr<DhtRunner>& dht, dht_params& params)
             continue;
         }
 #endif //OPENDHT_PROXY_SERVER
+#if OPENDHT_PROXY_CLIENT
+        else if (op == "stt") {
+            iss >> idstr;
+            dht->setProxyServer(idstr);
+            dht->enableProxy(true);
+            continue;
+        } else if (op == "stp") {
+            dht->enableProxy(false);
+            continue;
+        }
+#endif //OPENDHT_PROXY_CLIENT
 
         if (op.empty())
             continue;

--- a/tools/tools_common.h
+++ b/tools/tools_common.h
@@ -120,6 +120,7 @@ struct dht_params {
     bool service {false};
     std::pair<std::string, std::string> bootstrap {};
     in_port_t proxyserver {0};
+    std::string proxyclient {};
 };
 
 static const constexpr struct option long_options[] = {
@@ -134,6 +135,7 @@ static const constexpr struct option long_options[] = {
    {"logfile",    required_argument, nullptr, 'l'},
    {"syslog",     no_argument      , nullptr, 'L'},
    {"proxyserver",required_argument, nullptr, 'S'},
+   {"proxyclient",required_argument, nullptr, 'C'},
    {nullptr,      0                , nullptr,  0}
 };
 
@@ -158,6 +160,9 @@ parseArgs(int argc, char **argv) {
                 else
                     std::cout << "Invalid port: " << port_arg << std::endl;
             }
+            break;
+        case 'C':
+            params.proxyclient = optarg;
             break;
         case 'n':
             params.network = strtoul(optarg, nullptr, 0);


### PR DESCRIPTION
**WIP** cf 1. #218

+ Add an abstract class to describe the Dht
+ Now, we can modify the Dht linked to a SecureDht. So we can choose
between the classic Dht and the Dht using a proxy.
+ Implement a basic client which can Get and Put values on the Dht using
the proxy.

Note: Update dhtnode to have the ability to use the DhtProxyClient.
Todo: Implement Listen, ping, connectivityChanged for the client.