### PR TITLE
proxy: implement DhtProxyClient

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ list (APPEND opendht_HEADERS
     include/opendht/node.h
     include/opendht/value.h
     include/opendht/dht.h
+    include/opendht/dht_interface.h
     include/opendht/callbacks.h
     include/opendht/routing_table.h
     include/opendht/node_cache.h
@@ -170,12 +171,30 @@ if (OPENDHT_PROXY_SERVER)
   )
   list (APPEND opendht_SOURCES
     src/dht_proxy_server.cpp
-    src/base64.h
-    src/base64.cpp
   )
 else ()
     add_definitions(-DENABLE_PROXY_SERVER=false)
 endif ()
+
+if (OPENDHT_PROXY_CLIENT)
+  add_definitions(-DOPENDHT_PROXY_CLIENT=true)
+  list (APPEND opendht_HEADERS
+    include/opendht/dht_proxy_client.h
+  )
+  list (APPEND opendht_SOURCES
+    src/dht_proxy_client.cpp
+  )
+else ()
+  add_definitions(-DOPENDHT_PROXY_CLIENT=false)
+endif ()
+
+if (OPENDHT_PROXY_SERVER OR OPENDHT_PROXY_CLIENT)
+  list (APPEND opendht_SOURCES
+    src/base64.h
+    src/base64.cpp
+  )
+endif ()
+
 
 if(OPENDHT_ARGON2)
     # make sure argon2 submodule is up to date and initialized

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ for r in results:
 - msgpack-c 1.2+, used for data serialization.
 - GnuTLS 3.3+, used for cryptographic operations.
 - Nettle 2.4+, a GnuTLS dependency for crypto.
-- (optional) restbed 4.0+, used for the REST API.
+- (optional) restbed used for the REST API. commit fb84213e170bc171fecd825a8e47ed9f881a12cd (https://github.com/AmarOk1412/restbed/tree/async_read_until)
 - (optional) jsoncpp 1.7.4-3+, used for the REST API.
 - Build tested with GCC 4.8+ (GNU/Linux, Android, Windows with MinGW), Clang/LLVM (Linux, macOS).
 - Build tested with Microsoft Visual Studio 2015

--- a/configure.ac
+++ b/configure.ac
@@ -130,6 +130,12 @@ AM_COND_IF([ENABLE_TOOLS], [
 
 AC_ARG_ENABLE([proxy_server], AS_HELP_STRING([--enable-proxy-server], [Enable proxy server ability]), proxy_server=yes, proxy_server=no)
 AM_CONDITIONAL(ENABLE_PROXY_SERVER, test x$proxy_server == xyes)
+AC_ARG_ENABLE([proxy_server_identity], AS_HELP_STRING([--enable-proxy-server-identity],
+	[Enable proxy server ability]), proxy_server_identity=yes, proxy_server_identity=no)
+AM_CONDITIONAL(ENABLE_PROXY_SERVER_IDENTITY, test x$proxy_server_identity == xyes)
+AC_ARG_ENABLE([proxy_client], AS_HELP_STRING([--enable-proxy-client], [Enable proxy client ability]), proxy_client=yes, proxy_client=no)
+AM_CONDITIONAL(ENABLE_PROXY_CLIENT, test x$proxy_client == xyes)
+
 AM_COND_IF([ENABLE_PROXY_SERVER], [
 	AC_CHECK_LIB(restbed, exit,, AC_MSG_ERROR([Missing restbed files]))
 	PKG_CHECK_MODULES([Jsoncpp], [jsoncpp >= 1.7.4])
@@ -145,6 +151,20 @@ AM_COND_IF([ENABLE_PROXY_SERVER_IDENTITY], [
 ], [
     CPPFLAGS+=" -DOPENDHT_PROXY_SERVER_IDENTITY=false"
 ])
+
+AM_COND_IF([ENABLE_PROXY_CLIENT], [
+	CPPFLAGS+=" -DOPENDHT_PROXY_CLIENT=true"
+], [
+	CPPFLAGS+=" -DOPENDHT_PROXY_CLIENT=false"
+])
+
+AM_CONDITIONAL(PROXY_CLIENT_OR_SERVER, test x$proxy_client == xyes | test x$proxy_server == xyes)
+AM_COND_IF([PROXY_CLIENT_OR_SERVER], [
+	AC_CHECK_LIB(restbed, exit,, AC_MSG_ERROR([Missing restbed files]))
+	PKG_CHECK_MODULES([Jsoncpp], [jsoncpp >= 1.7.4])
+	CPPFLAGS="${CPPFLAGS} ${Jsoncpp_CFLAGS}"
+	LDFLAGS="${LDFLAGS} ${Jsoncpp_LIBS} -lrestbed"
+], [])
 
 
 AC_CONFIG_FILES([doc/Doxyfile doc/Makefile])

--- a/include/opendht/callbacks.h
+++ b/include/opendht/callbacks.h
@@ -1,7 +1,8 @@
 /*
  *  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
- *  Author : Adrien Béraud <adrien.beraud@savoirfairelinux.com>
+ *  Authors: Adrien Béraud <adrien.beraud@savoirfairelinux.com>
  *           Simon Désaulniers <simon.desaulniers@savoirfairelinux.com>
+ *           Sébastien Blin <sebastien.blin@savoirfairelinux.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/opendht/callbacks.h
+++ b/include/opendht/callbacks.h
@@ -44,11 +44,11 @@ enum class NodeStatus {
 };
 
 struct OPENDHT_PUBLIC NodeStats {
-    unsigned good_nodes,
-             dubious_nodes,
-             cached_nodes,
-             incoming_nodes;
-    unsigned table_depth;
+    unsigned good_nodes {0},
+             dubious_nodes {0},
+             cached_nodes {0},
+             incoming_nodes {0};
+    unsigned table_depth {0};
     unsigned getKnownNodes() const { return good_nodes + dubious_nodes; }
     std::string toString() const;
 #if OPENDHT_PROXY_SERVER
@@ -56,6 +56,8 @@ struct OPENDHT_PUBLIC NodeStats {
      * Build a json object from a NodeStats
      */
     Json::Value toJson() const;
+    NodeStats() {};
+    explicit NodeStats(const Json::Value& v);
 #endif //OPENDHT_PROXY_SERVER
 };
 

--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -26,7 +26,7 @@
 #include "scheduler.h"
 #include "routing_table.h"
 #include "callbacks.h"
-#include "log_enable.h"
+#include "dht_interface.h"
 
 #include <string>
 #include <array>
@@ -58,14 +58,8 @@ struct LocalListener;
  * Must be given open UDP sockets and ::periodic must be
  * called regularly.
  */
-class OPENDHT_PUBLIC Dht {
+class OPENDHT_PUBLIC Dht : public DhtInterface {
 public:
-
-    // [[deprecated]]
-    using NodeExport = dht::NodeExport;
-
-    // [[deprecated]]
-    using Status = NodeStatus;
 
     Dht();
 
@@ -102,18 +96,6 @@ public:
      *      is running for the provided family.
      */
     bool isRunning(sa_family_t af = 0) const;
-
-    /**
-     * Enable or disable logging of DHT internal messages
-     */
-    void setLoggers(LogMethod error = NOLOG, LogMethod warn = NOLOG, LogMethod debug = NOLOG);
-
-    /**
-     * Only print logs related to the given InfoHash (if given), or disable filter (if zeroes).
-     */
-    void setLogFilter(const InfoHash& f) {
-        DHT_LOG.setFilter(f);
-    }
 
     virtual void registerType(const ValueType& type) {
         types[type.id] = type;
@@ -306,11 +288,6 @@ public:
     }
 
     std::vector<SockAddr> getPublicAddress(sa_family_t family = 0);
-
-protected:
-    Logger DHT_LOG;
-    bool logFilerEnable_ {};
-    InfoHash logFiler_ {};
 
 private:
 

--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -1,7 +1,8 @@
 /*
  *  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
- *  Author(s) : Adrien Béraud <adrien.beraud@savoirfairelinux.com>
- *              Simon Désaulniers <simon.desaulniers@savoirfairelinux.com>
+ *  Authors: Adrien Béraud <adrien.beraud@savoirfairelinux.com>
+ *           Simon Désaulniers <simon.desaulniers@savoirfairelinux.com>
+ *           Sébastien Blin <sebastien.blin@savoirfairelinux.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -58,7 +58,7 @@ struct LocalListener;
  * Must be given open UDP sockets and ::periodic must be
  * called regularly.
  */
-class OPENDHT_PUBLIC Dht : public DhtInterface {
+class OPENDHT_PUBLIC Dht final : public DhtInterface {
 public:
 
     Dht();
@@ -71,7 +71,9 @@ public:
     virtual ~Dht();
 
 
-    virtual void start(const std::string& ) {};
+#if OPENDHT_PROXY_CLIENT
+    void startProxy(const std::string&) {};
+#endif
 
     /**
      * Get the ID of the node.

--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -70,6 +70,9 @@ public:
     Dht(int s, int s6, Config config);
     virtual ~Dht();
 
+
+    virtual void start(const std::string& ) {};
+
     /**
      * Get the ID of the node.
      */

--- a/include/opendht/dht_interface.h
+++ b/include/opendht/dht_interface.h
@@ -28,6 +28,8 @@ public:
     DhtInterface() = default;
     virtual ~DhtInterface() = default;
 
+    virtual void start(const std::string& host) = 0;
+
     // [[deprecated]]
     using Status = NodeStatus;
     // [[deprecated]]

--- a/include/opendht/dht_interface.h
+++ b/include/opendht/dht_interface.h
@@ -1,0 +1,235 @@
+/*
+ *  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
+ *  Author: Sébastien Blin <sebastien.blin@savoirfairelinux.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "infohash.h"
+#include "log_enable.h"
+
+namespace dht {
+
+class OPENDHT_PUBLIC DhtInterface {
+public:
+    DhtInterface() = default;
+    virtual ~DhtInterface() = default;
+
+    // [[deprecated]]
+    using Status = NodeStatus;
+    // [[deprecated]]
+    using NodeExport = dht::NodeExport;
+
+    /**
+     * Get the current status of the node for the given family.
+     */
+    virtual NodeStatus getStatus(sa_family_t af) const = 0;
+    virtual NodeStatus getStatus() const = 0;
+
+    /**
+     * Get the ID of the node.
+     */
+    virtual const InfoHash& getNodeId() const = 0;
+
+    /**
+     * Performs final operations before quitting.
+     */
+    virtual void shutdown(ShutdownCallback cb) = 0;
+
+    /**
+     * Returns true if the node is running (have access to an open socket).
+     *
+     *  af: address family. If non-zero, will return true if the node
+     *     is running for the provided family.
+     */
+    virtual bool isRunning(sa_family_t af = 0) const = 0;
+
+    virtual void registerType(const ValueType& type) = 0;
+
+    virtual const ValueType& getType(ValueType::Id type_id) const = 0;
+
+    /**
+     * Insert a node in the main routing table.
+     * The node is not pinged, so this should be
+     * used to bootstrap efficiently from previously known nodes.
+     */
+    virtual void insertNode(const InfoHash& id, const SockAddr&) = 0;
+    virtual void insertNode(const InfoHash& id, const sockaddr* sa, socklen_t salen) = 0;
+    virtual void insertNode(const NodeExport& n) = 0;
+
+    virtual void pingNode(const sockaddr*, socklen_t, DoneCallbackSimple&& cb={}) = 0;
+
+    virtual time_point periodic(const uint8_t *buf, size_t buflen, const SockAddr&) = 0;
+    virtual time_point periodic(const uint8_t *buf, size_t buflen, const sockaddr* from, socklen_t fromlen) = 0;
+
+    /**
+     * Get a value by searching on all available protocols (IPv4, IPv6),
+     * and call the provided get callback when values are found at key.
+     * The operation will start as soon as the node is connected to the network.
+     * @param cb a function called when new values are found on the network.
+     *         It should return false to stop the operation.
+     * @param donecb a function called when the operation is complete.
+                  cb and donecb won't be called again afterward.
+     * @param f a filter function used to prefilter values.
+     */
+    virtual void get(const InfoHash& key, GetCallback cb, DoneCallback donecb={}, Value::Filter&& f={}, Where&& w = {}) = 0;
+    virtual void get(const InfoHash& key, GetCallback cb, DoneCallbackSimple donecb={}, Value::Filter&& f={}, Where&& w = {}) = 0;
+    virtual void get(const InfoHash& key, GetCallbackSimple cb, DoneCallback donecb={}, Value::Filter&& f={}, Where&& w = {}) = 0;
+    virtual void get(const InfoHash& key, GetCallbackSimple cb, DoneCallbackSimple donecb, Value::Filter&& f={}, Where&& w = {}) = 0;
+
+    /**
+      * Similar to Dht::get, but sends a Query to filter data remotely.
+      * @param key the key for which to query data for.
+      * @param cb a function called when new values are found on the network.
+      *         It should return false to stop the operation.
+      * @param done_cb a function called when the operation is complete.
+                      cb and done_cb won't be called again afterward.
+      * @param q a query used to filter values on the remotes before they send a
+      *        response.
+      */
+    virtual void query(const InfoHash& key, QueryCallback cb, DoneCallback done_cb = {}, Query&& q = {}) = 0;
+    virtual void query(const InfoHash& key, QueryCallback cb, DoneCallbackSimple done_cb = {}, Query&& q = {}) = 0;
+
+    /**
+     * Get locally stored data for the given hash.
+     */
+    virtual std::vector<Sp<Value>> getLocal(const InfoHash& key, Value::Filter f = Value::AllFilter()) const = 0;
+
+    /**
+     * Get locally stored data for the given key and value id.
+     */
+    virtual Sp<Value> getLocalById(const InfoHash& key, Value::Id vid) const = 0;
+
+    /**
+     * Announce a value on all available protocols (IPv4, IPv6).
+     *
+     * The operation will start as soon as the node is connected to the network.
+     * The done callback will be called once, when the first announce succeeds, or fails.
+     */
+    virtual void put(const InfoHash& key,
+           Sp<Value>,
+           DoneCallback cb=nullptr,
+           time_point created=time_point::max(),
+           bool permanent = false) = 0;
+    virtual void put(const InfoHash& key,
+           const Sp<Value>& v,
+           DoneCallbackSimple cb,
+           time_point created=time_point::max(),
+           bool permanent = false) = 0;
+    virtual void put(const InfoHash& key,
+           Value&& v,
+           DoneCallback cb=nullptr,
+           time_point created=time_point::max(),
+           bool permanent = false) = 0;
+    virtual void put(const InfoHash& key,
+           Value&& v,
+           DoneCallbackSimple cb,
+           time_point created=time_point::max(),
+           bool permanent = false) = 0;
+
+    /**
+     * Get data currently being put at the given hash.
+     */
+    virtual std::vector<Sp<Value>> getPut(const InfoHash&) = 0;
+
+    /**
+     * Get data currently being put at the given hash with the given id.
+     */
+    virtual Sp<Value> getPut(const InfoHash&, const Value::Id&) = 0;
+
+    /**
+     * Stop any put/announce operation at the given location,
+     * for the value with the given id.
+     */
+    virtual bool cancelPut(const InfoHash&, const Value::Id&) = 0;
+
+    /**
+     * Listen on the network for any changes involving a specified hash.
+     * The node will register to receive updates from relevent nodes when
+     * new values are added or removed.
+     *
+     * @return a token to cancel the listener later.
+     */
+    virtual size_t listen(const InfoHash&, GetCallback, Value::Filter&&={}, Where&& w = {}) = 0;
+    virtual size_t listen(const InfoHash& key, GetCallbackSimple cb, Value::Filter f={}, Where w = {}) = 0;
+
+    virtual bool cancelListen(const InfoHash&, size_t token) = 0;
+
+    /**
+     * Inform the DHT of lower-layer connectivity changes.
+     * This will cause the DHT to assume a public IP address change.
+     * The DHT will recontact neighbor nodes, re-register for listen ops etc.
+     */
+    virtual void connectivityChanged(sa_family_t) = 0;
+    virtual void connectivityChanged() = 0;
+
+    /**
+     * Get the list of good nodes for local storage saving purposes
+     * The list is ordered to minimize the back-to-work delay.
+     */
+    virtual std::vector<NodeExport> exportNodes() = 0;
+
+    virtual std::vector<ValuesExport> exportValues() const = 0;
+    virtual void importValues(const std::vector<ValuesExport>&) = 0;
+
+    virtual NodeStats getNodesStats(sa_family_t af) const = 0;
+
+    virtual std::string getStorageLog() const = 0;
+    virtual std::string getStorageLog(const InfoHash&) const = 0;
+
+    virtual std::string getRoutingTablesLog(sa_family_t) const = 0;
+    virtual std::string getSearchesLog(sa_family_t) const = 0;
+    virtual std::string getSearchLog(const InfoHash&, sa_family_t af = AF_UNSPEC) const = 0;
+
+    virtual void dumpTables() const = 0;
+    virtual std::vector<unsigned> getNodeMessageStats(bool in = false) = 0;
+
+    /**
+     * Set the in-memory storage limit in bytes
+     */
+    virtual void setStorageLimit(size_t limit = DEFAULT_STORAGE_LIMIT) = 0;
+
+    /**
+     * Returns the total memory usage of stored values and the number
+     * of stored values.
+     */
+    virtual std::pair<size_t, size_t> getStoreSize() const = 0;
+
+    virtual std::vector<SockAddr> getPublicAddress(sa_family_t family = 0) = 0;
+
+    Logger DHT_LOG;
+    /**
+     * Enable or disable logging of DHT internal messages
+     */
+    virtual void setLoggers(LogMethod error = NOLOG, LogMethod warn = NOLOG, LogMethod debug = NOLOG)
+    {
+        DHT_LOG.DEBUG = debug;
+        DHT_LOG.WARN = warn;
+        DHT_LOG.ERR = error;
+    }
+
+    /**
+     * Only print logs related to the given InfoHash (if given), or disable filter (if zeroes).
+     */
+    virtual void setLogFilter(const InfoHash& f) {
+        DHT_LOG.setFilter(f);
+    }
+protected:
+    bool logFilerEnable_ {};
+    InfoHash logFiler_ {};
+};
+
+} // namespace dht

--- a/include/opendht/dht_interface.h
+++ b/include/opendht/dht_interface.h
@@ -28,7 +28,9 @@ public:
     DhtInterface() = default;
     virtual ~DhtInterface() = default;
 
-    virtual void start(const std::string& host) = 0;
+#if OPENDHT_PROXY_CLIENT
+    virtual void startProxy(const std::string& host) = 0;
+#endif
 
     // [[deprecated]]
     using Status = NodeStatus;

--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -317,7 +317,7 @@ private:
     struct Operation
     {
         std::shared_ptr<restbed::Request> req;
-        std::unique_ptr<std::thread> thread;
+        std::thread thread;
     };
     std::vector<Operation> operations_;
 
@@ -336,6 +336,8 @@ private:
      * Relaunch LISTEN requests if the client disconnect/reconnect.
      */
     void restartListeners();
+
+    std::shared_ptr<Json::Value> currentProxyInfos_;
 };
 
 }

--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2016 Savoir-faire Linux Inc.
- *  Author : Sébastien Blin <sebastien.blin@savoirfairelinux.com>
+ *  Author: Sébastien Blin <sebastien.blin@savoirfairelinux.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -281,8 +281,10 @@ private:
     {
         std::shared_ptr<restbed::Request> req;
         std::thread thread;
+        std::shared_ptr<bool> finished;
     };
     std::vector<Operation> operations_;
+    std::mutex lockOperations_;
     /**
      * Callbacks should be executed in the main thread.
      */

--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -217,7 +217,7 @@ public:
     void insertNode(const NodeExport&) { }
     std::pair<size_t, size_t> getStoreSize() const { return {}; }
     virtual void registerType(const ValueType&) { }
-    const ValueType& getType(ValueType::Id) const { }
+    const ValueType& getType(ValueType::Id) const { return NO_VALUE; }
     std::vector<Sp<Value>> getLocal(const InfoHash&, Value::Filter) const { return {}; }
     Sp<Value> getLocalById(const InfoHash&, Value::Id) const { return {}; }
     std::vector<NodeExport> exportNodes() { return {}; }
@@ -235,6 +235,7 @@ public:
     void connectivityChanged() { }
 
 private:
+    const ValueType NO_VALUE;
     /**
      * Get informations from the proxy node
      * @return the JSON returned by the proxy

--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -1,0 +1,296 @@
+/*
+ *  Copyright (C) 2016 Savoir-faire Linux Inc.
+ *  Author : Sébastien Blin <sebastien.blin@savoirfairelinux.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#if OPENDHT_PROXY_SERVER
+
+#pragma once
+
+#include <thread>
+
+#include "callbacks.h"
+#include "def.h"
+#include "dht_interface.h"
+#include "scheduler.h"
+
+namespace restbed
+{
+    class Request;
+}
+
+namespace dht {
+
+class OPENDHT_PUBLIC DhtProxyClient : public DhtInterface {
+public:
+
+    DhtProxyClient() : scheduler(DHT_LOG) {}
+
+    /**
+     * Initialise the DhtProxyClient with two open sockets (for IPv4 and IP6)
+     * and an ID for the node.
+     */
+    explicit DhtProxyClient(const std::string& serverHost);
+    virtual ~DhtProxyClient();
+
+    /**
+     * Get the ID of the node.
+     */
+    inline const InfoHash& getNodeId() const { return myid; }
+
+    /**
+     * Get the current status of the node for the given family.
+     */
+    NodeStatus getStatus(sa_family_t af) const;
+    NodeStatus getStatus() const {
+        return std::max(getStatus(AF_INET), getStatus(AF_INET6));
+    }
+
+    /**
+     * Performs final operations before quitting.
+     */
+    void shutdown(ShutdownCallback cb);
+
+    /**
+     * Returns true if the node is running (have access to an open socket).
+     *
+     *  af: address family. If non-zero, will return true if the node
+     *      is running for the provided family.
+     */
+    bool isRunning(sa_family_t af = 0) const;
+
+    /**
+     * Get a value by asking the proxy and call the provided get callback when
+     * values are found at key.
+     * The operation will start as soon as the node is connected to the network.
+     * @param cb a function called when new values are found on the network.
+     *           It should return false to stop the operation.
+     * @param donecb a function called when the operation is complete.
+                     cb and donecb won't be called again afterward.
+     * @param f a filter function used to prefilter values.
+     */
+    virtual void get(const InfoHash& key, GetCallback cb, DoneCallback donecb={}, Value::Filter&& f={}, Where&& w = {});
+    virtual void get(const InfoHash& key, GetCallback cb, DoneCallbackSimple donecb={}, Value::Filter&& f={}, Where&& w = {}) {
+        get(key, cb, bindDoneCb(donecb), std::forward<Value::Filter>(f), std::forward<Where>(w));
+    }
+    virtual void get(const InfoHash& key, GetCallbackSimple cb, DoneCallback donecb={}, Value::Filter&& f={}, Where&& w = {}) {
+        get(key, bindGetCb(cb), donecb, std::forward<Value::Filter>(f), std::forward<Where>(w));
+    }
+    virtual void get(const InfoHash& key, GetCallbackSimple cb, DoneCallbackSimple donecb, Value::Filter&& f={}, Where&& w = {}) {
+        get(key, bindGetCb(cb), bindDoneCb(donecb), std::forward<Value::Filter>(f), std::forward<Where>(w));
+    }
+
+    /**
+     * Announce a value on all available protocols (IPv4, IPv6).
+     *
+     * The operation will start as soon as the node is connected to the network.
+     * The done callback will be called once, when the first announce succeeds, or fails.
+     * NOTE: For now, created parameter is ignored.
+     */
+    void put(const InfoHash& key,
+            Sp<Value>,
+            DoneCallback cb=nullptr,
+            time_point created=time_point::max(),
+            bool permanent = false);
+    void put(const InfoHash& key,
+            const Sp<Value>& v,
+            DoneCallbackSimple cb,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        put(key, v, bindDoneCb(cb), created, permanent);
+    }
+
+    void put(const InfoHash& key,
+            Value&& v,
+            DoneCallback cb=nullptr,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        put(key, std::make_shared<Value>(std::move(v)), cb, created, permanent);
+    }
+    void put(const InfoHash& key,
+            Value&& v,
+            DoneCallbackSimple cb,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        put(key, std::forward<Value>(v), bindDoneCb(cb), created, permanent);
+    }
+
+    NodeStats getNodesStats(sa_family_t af) const;
+
+    std::vector<SockAddr> getPublicAddress(sa_family_t family = 0);
+
+
+    /**
+     * TODO
+     * NOTE: For now, there is no endpoint in the DhtProxyServer to do the following methods.
+     * It will come in another version.
+     */
+
+    /**
+     * Listen on the network for any changes involving a specified hash.
+     * The node will register to receive updates from relevent nodes when
+     * new values are added or removed.
+     *
+     * @return a token to cancel the listener later.
+     */
+    virtual size_t listen(const InfoHash&, GetCallback, Value::Filter&&={}, Where&&={}) { return 0; };
+    virtual size_t listen(const InfoHash& key, GetCallbackSimple cb, Value::Filter f={}, Where w = {}) {
+        return listen(key, bindGetCb(cb), std::forward<Value::Filter>(f), std::forward<Where>(w));
+    }
+    virtual bool cancelListen(const InfoHash&, size_t /*token*/) { return false; }
+
+    /**
+     * Similar to Dht::get, but sends a Query to filter data remotely.
+     * @param key the key for which to query data for.
+     * @param cb a function called when new values are found on the network.
+     *           It should return false to stop the operation.
+     * @param done_cb a function called when the operation is complete.
+               cb and done_cb won't be called again afterward.
+     * @param q a query used to filter values on the remotes before they send a
+     *          response.
+     */
+    virtual void query(const InfoHash& /*key*/, QueryCallback /*cb*/, DoneCallback /*done_cb*/ = {}, Query&& /*q*/ = {}) { }
+    virtual void query(const InfoHash& key, QueryCallback cb, DoneCallbackSimple done_cb = {}, Query&& q = {}) {
+        query(key, cb, bindDoneCb(done_cb), std::forward<Query>(q));
+    }
+
+    /**
+     * Get data currently being put at the given hash.
+     */
+    std::vector<Sp<Value>> getPut(const InfoHash&) { return {}; }
+
+    /**
+     * Get data currently being put at the given hash with the given id.
+     */
+    Sp<Value> getPut(const InfoHash&, const Value::Id&) { return {}; }
+
+    /**
+     * Stop any put/announce operation at the given location,
+     * for the value with the given id.
+     */
+    bool cancelPut(const InfoHash&, const Value::Id&) { return false; }
+
+    void pingNode(const sockaddr*, socklen_t, DoneCallbackSimple&& /*cb*/={}) { }
+
+    /**
+     * NOTE: The following methods will not be implemented because the
+     * DhtProxyClient doesn't have any storage nor synchronization process
+     */
+
+    /**
+     * Insert a node in the main routing table.
+     * The node is not pinged, so this should be
+     * used to bootstrap efficiently from previously known nodes.
+     */
+    void insertNode(const InfoHash&, const SockAddr&) { }
+    void insertNode(const InfoHash&, const sockaddr*, socklen_t) { }
+    void insertNode(const NodeExport&) { }
+
+    /**
+     * Returns the total memory usage of stored values and the number
+     * of stored values.
+     */
+    std::pair<size_t, size_t> getStoreSize() const { return {}; }
+
+    virtual void registerType(const ValueType&) { }
+    const ValueType& getType(ValueType::Id) const { }
+
+    /**
+     * Get locally stored data for the given hash.
+     */
+    std::vector<Sp<Value>> getLocal(const InfoHash&, Value::Filter) const { return {}; }
+
+    /**
+     * Get locally stored data for the given key and value id.
+     */
+    Sp<Value> getLocalById(const InfoHash&, Value::Id) const { return {}; }
+
+    /**
+     * Get the list of good nodes for local storage saving purposes
+     * The list is ordered to minimize the back-to-work delay.
+     */
+    std::vector<NodeExport> exportNodes() { return {}; }
+
+    std::vector<ValuesExport> exportValues() const { return {}; }
+    void importValues(const std::vector<ValuesExport>&) {}
+
+    std::string getStorageLog() const { return {}; }
+    std::string getStorageLog(const InfoHash&) const { return {}; }
+
+    std::string getRoutingTablesLog(sa_family_t) const { return {}; }
+    std::string getSearchesLog(sa_family_t) const { return {}; }
+    std::string getSearchLog(const InfoHash&, sa_family_t) const { return {}; }
+
+    void dumpTables() const {}
+    std::vector<unsigned> getNodeMessageStats(bool) { return {}; }
+
+    /**
+     * Set the in-memory storage limit in bytes
+     */
+    void setStorageLimit(size_t) {}
+
+    /**
+     * Inform the DHT of lower-layer connectivity changes.
+     * This will cause the DHT to assume a public IP address change.
+     * The DHT will recontact neighbor nodes, re-register for listen ops etc.
+     */
+    void connectivityChanged(sa_family_t) {}
+    void connectivityChanged() {
+        connectivityChanged(AF_INET);
+        connectivityChanged(AF_INET6);
+    }
+
+    time_point periodic(const uint8_t*, size_t, const SockAddr&) {
+        scheduler.syncTime();
+        return scheduler.run();
+    }
+    time_point periodic(const uint8_t *buf, size_t buflen, const sockaddr* from, socklen_t fromlen) {
+        return periodic(buf, buflen, SockAddr(from, fromlen));
+    }
+
+private:
+    Json::Value getProxyInfos() const;
+    /**
+     * Initialize statusIpvX_
+     */
+    void getConnectivityStatus();
+    /**
+     * cancel all Operations
+     */
+    void cancelAllOperations();
+    std::string serverHost_;
+    NodeStatus statusIpv4_ {NodeStatus::Disconnected};
+    NodeStatus statusIpv6_ {NodeStatus::Disconnected};
+
+    InfoHash myid {};
+    struct Operation
+    {
+        std::shared_ptr<restbed::Request> req;
+        std::unique_ptr<std::thread> thread;
+    };
+    std::vector<Operation> operations_;
+
+    Scheduler scheduler;
+    Sp<Scheduler::Job> nextNodesConfirmation {};
+    void confirmProxy();
+};
+
+}
+
+#endif // OPENDHT_PROXY_CLIENT

--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -44,6 +44,7 @@ public:
      * and an ID for the node.
      */
     explicit DhtProxyClient(const std::string& serverHost);
+    void start(const std::string& serverHost);
     virtual ~DhtProxyClient();
 
     /**

--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -282,7 +282,7 @@ private:
     {
         std::shared_ptr<restbed::Request> req;
         std::thread thread;
-        std::shared_ptr<bool> finished;
+        std::shared_ptr<std::atomic_bool> finished;
     };
     std::vector<Operation> operations_;
     std::mutex lockOperations_;

--- a/include/opendht/dht_proxy_server.h
+++ b/include/opendht/dht_proxy_server.h
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2017 Savoir-faire Linux Inc.
- *  Author : Sébastien Blin <sebastien.blin@savoirfairelinux.com>
+ *  Author: Sébastien Blin <sebastien.blin@savoirfairelinux.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/opendht/dht_proxy_server.h
+++ b/include/opendht/dht_proxy_server.h
@@ -26,6 +26,7 @@
 
 #include <thread>
 #include <memory>
+#include <mutex>
 #include <restbed>
 
 namespace dht {
@@ -160,6 +161,7 @@ private:
         std::future<size_t> token;
     };
     mutable std::vector<SessionToHashToken> currentListeners_;
+    mutable std::mutex lockListener_;
     std::atomic_bool stopListeners {false};
 };
 

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -386,7 +386,6 @@ public:
     void forwardAllMessages(bool forward);
 #endif // OPENDHT_PROXY_SERVER
 
-    static std::vector<SockAddr> getAddrInfo(const std::string& host, const std::string& service);
 private:
     static constexpr std::chrono::seconds BOOTSTRAP_PERIOD {10};
 

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -1,7 +1,8 @@
 /*
  *  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
- *  Author(s) : Adrien Béraud <adrien.beraud@savoirfairelinux.com>
- *              Simon Désaulniers <simon.desaulniers@savoirfairelinux.com>
+ *  Authors: Adrien Béraud <adrien.beraud@savoirfairelinux.com>
+ *           Simon Désaulniers <simon.desaulniers@savoirfairelinux.com>
+ *           Sébastien Blin <sebastien.blin@savoirfairelinux.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -36,6 +36,10 @@
 #include <queue>
 #include <chrono>
 
+#if OPENDHT_PROXY_CLIENT
+#include "dht_proxy_client.h"
+#endif // OPENDHT_PROXY_CLIENT
+
 namespace dht {
 
 struct Node;
@@ -297,6 +301,9 @@ public:
     struct Config {
         SecureDhtConfig dht_config;
         bool threaded;
+#if OPENDHT_PROXY_CLIENT
+        std::string proxy_server;
+#endif //OPENDHT_PROXY_CLIENT
     };
 
     /**
@@ -305,7 +312,11 @@ public:
      * @param threaded: If false, ::loop() must be called periodically. Otherwise a thread is launched.
      * @param cb: Optional callback to receive general state information.
      */
-    void run(in_port_t port, const crypto::Identity identity, bool threaded = false, NetId network = 0) {
+    void run(in_port_t port, const crypto::Identity identity, bool threaded = false, NetId network = 0
+#if OPENDHT_PROXY_CLIENT
+    , const std::string& proxy_server = "127.0.0.1:8000"
+#endif //OPENDHT_PROXY_CLIENT
+) {
         run(port, {
             /*.dht_config = */{
                 /*.node_config = */{
@@ -316,7 +327,10 @@ public:
                 },
                 /*.id = */identity
             },
-            /*.threaded = */threaded
+            /*.threaded = */threaded,
+#if OPENDHT_PROXY_CLIENT
+            /*.proxy_server = */proxy_server
+#endif //OPENDHT_PROXY_CLIENT
         });
     }
     void run(in_port_t port, Config config);
@@ -362,6 +376,14 @@ public:
      */
     void join();
 
+#if OPENDHT_PROXY_CLIENT
+    void setProxyServer(const std::string& url = "127.0.0.1:8000") {
+        config_.proxy_server = url;
+    }
+    void enableProxy(bool proxify);
+#endif // OPENDHT_PROXY_CLIENT
+
+    static std::vector<SockAddr> getAddrInfo(const std::string& host, const std::string& service);
 private:
     static constexpr std::chrono::seconds BOOTSTRAP_PERIOD {10};
 
@@ -381,6 +403,13 @@ private:
     }
 
     std::unique_ptr<SecureDht> dht_;
+    void resetDht();
+    SecureDht* activeDht() const;
+#if OPENDHT_PROXY_CLIENT
+    std::atomic_bool use_proxy {false};
+    std::unique_ptr<SecureDht> dht_via_proxy_;
+    Config config_;
+#endif // OPENDHT_PROXY_CLIENT
     mutable std::mutex dht_mtx {};
     std::thread dht_thread {};
     std::condition_variable cv {};

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -403,13 +403,40 @@ private:
     }
 
     std::unique_ptr<SecureDht> dht_;
+    /**
+     * reset dht clients
+     */
     void resetDht();
+    /**
+     * @return the current active DHT
+     */
     SecureDht* activeDht() const;
 #if OPENDHT_PROXY_CLIENT
+    /**
+     * true if we are currently using a proxy
+     */
     std::atomic_bool use_proxy {false};
+    /**
+     * The current proxy client
+     */
     std::unique_ptr<SecureDht> dht_via_proxy_;
     Config config_;
 #endif // OPENDHT_PROXY_CLIENT
+    /**
+     * Store current listeners and translates global tokens for each client.
+     */
+    struct Listener {
+        size_t globalToken;
+        size_t tokenClassicDht;
+        size_t tokenProxyDht;
+        GetCallback gcb;
+        InfoHash hash;
+        Value::Filter f;
+        Where w;
+    };
+    std::vector<std::unique_ptr<Listener>> listeners_ {};
+    size_t listener_token_ {1};
+
     mutable std::mutex dht_mtx {};
     std::thread dht_thread {};
     std::condition_variable cv {};

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -382,6 +382,9 @@ public:
     }
     void enableProxy(bool proxify);
 #endif // OPENDHT_PROXY_CLIENT
+#if OPENDHT_PROXY_SERVER
+    void forwardAllMessages(bool forward);
+#endif // OPENDHT_PROXY_SERVER
 
     static std::vector<SockAddr> getAddrInfo(const std::string& host, const std::string& service);
 private:

--- a/include/opendht/securedht.h
+++ b/include/opendht/securedht.h
@@ -1,7 +1,8 @@
 /*
  *  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
- *  Author : Adrien Béraud <adrien.beraud@savoirfairelinux.com>
+ *  Authors: Adrien Béraud <adrien.beraud@savoirfairelinux.com>
  *           Simon Désaulniers <simon.desaulniers@savoirfairelinux.com>
+ *           Sébastien Blin <sebastien.blin@savoirfairelinux.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/opendht/securedht.h
+++ b/include/opendht/securedht.h
@@ -29,12 +29,20 @@
 
 namespace dht {
 
-class OPENDHT_PUBLIC SecureDht : public Dht {
+class OPENDHT_PUBLIC SecureDht : public DhtInterface {
 public:
 
     typedef std::function<void(bool)> SignatureCheckCallback;
 
     using Config = SecureDhtConfig;
+
+    static dht::Config& getConfig(SecureDht::Config& conf)
+    {
+        auto& c = conf.node_config;
+        if (not c.node_id and conf.id.second)
+            c.node_id = InfoHash::get("node:"+conf.id.second->getId().toString());
+        return c;
+    }
 
     SecureDht() {}
 
@@ -44,7 +52,7 @@ public:
      * id:    the identity to use for the crypto layer and to compute
      *        our own hash on the Dht.
      */
-    SecureDht(int s, int s6, Config config);
+    SecureDht(std::unique_ptr<DhtInterface> dht, Config config);
 
     virtual ~SecureDht();
 
@@ -62,14 +70,17 @@ public:
         return secureType(std::move(tmp_type));
     }
 
-    virtual void registerType(const ValueType& type) override {
-        Dht::registerType(secureType(type));
+    void registerType(const ValueType& type) {
+        if (dht_)
+            dht_->registerType(secureType(type));
     }
-    virtual void registerType(ValueType&& type) {
-        Dht::registerType(secureType(std::forward<ValueType>(type)));
+    void registerType(ValueType&& type) {
+        if (dht_)
+            dht_->registerType(secureType(std::forward<ValueType>(type)));
     }
-    virtual void registerInsecureType(const ValueType& type) {
-        Dht::registerType(type);
+    void registerInsecureType(const ValueType& type) {
+        if (dht_)
+            dht_->registerType(type);
     }
 
     /**
@@ -77,18 +88,18 @@ public:
      * If the signature can't be checked, or if the data can't be decrypted, it is not returned.
      * Public, non-signed & non-encrypted data is retransmitted as-is.
      */
-    virtual void get(const InfoHash& id, GetCallback cb, DoneCallback donecb={}, Value::Filter&& = {}, Where&& w = {}) override;
-    virtual void get(const InfoHash& id, GetCallback cb, DoneCallbackSimple donecb={}, Value::Filter&& f = {}, Where&& w = {}) override {
+    void get(const InfoHash& id, GetCallback cb, DoneCallback donecb={}, Value::Filter&& = {}, Where&& w = {});
+    void get(const InfoHash& id, GetCallback cb, DoneCallbackSimple donecb={}, Value::Filter&& f = {}, Where&& w = {}) {
         get(id, cb, bindDoneCb(donecb), std::forward<Value::Filter>(f), std::forward<Where>(w));
     }
-    virtual void get(const InfoHash& key, GetCallbackSimple cb, DoneCallback donecb={}, Value::Filter&& f={}, Where&& w = {}) override {
+    void get(const InfoHash& key, GetCallbackSimple cb, DoneCallback donecb={}, Value::Filter&& f={}, Where&& w = {}) {
         get(key, bindGetCb(cb), donecb, std::forward<Value::Filter>(f), std::forward<Where>(w));
     }
-    virtual void get(const InfoHash& key, GetCallbackSimple cb, DoneCallbackSimple donecb, Value::Filter&& f={}, Where&& w = {}) override {
+    void get(const InfoHash& key, GetCallbackSimple cb, DoneCallbackSimple donecb, Value::Filter&& f={}, Where&& w = {}) {
         get(key, bindGetCb(cb), bindDoneCb(donecb), std::forward<Value::Filter>(f), std::forward<Where>(w));
     }
 
-    virtual size_t listen(const InfoHash& id, GetCallback cb, Value::Filter&& = {}, Where&& w = {}) override;
+    size_t listen(const InfoHash& id, GetCallback cb, Value::Filter&& = {}, Where&& w = {});
 
     /**
      * Will take ownership of the value, sign it using our private key and put it in the DHT.
@@ -135,7 +146,160 @@ public:
         localQueryMethod_ = std::move(query_method);
     }
 
+    /**
+     * SecureDht to Dht proxy
+     */
+    void shutdown(ShutdownCallback cb) {
+        dht_->shutdown(cb);
+    }
+    void dumpTables() const {
+        dht_->dumpTables();
+    }
+    inline const InfoHash& getNodeId() const { return dht_->getNodeId(); }
+    std::pair<size_t, size_t> getStoreSize() const {
+        return dht_->getStoreSize();
+    }
+    std::string getStorageLog() const {
+        return dht_->getStorageLog();
+    }
+    std::string getStorageLog(const InfoHash& h) const {
+        return dht_->getStorageLog(h);
+    }
+    void setStorageLimit(size_t limit = DEFAULT_STORAGE_LIMIT) {
+        dht_->setStorageLimit(limit);
+    }
+    std::vector<NodeExport> exportNodes() {
+        return dht_->exportNodes();
+    }
+    std::vector<ValuesExport> exportValues() const {
+        return dht_->exportValues();
+    }
+    void setLoggers(LogMethod error = NOLOG, LogMethod warn = NOLOG, LogMethod debug = NOLOG) {
+        dht_->setLoggers(error, warn, debug);
+    }
+    void setLogFilter(const InfoHash& f) {
+        dht_->setLogFilter(f);
+    }
+    void importValues(const std::vector<ValuesExport>& v) {
+        dht_->importValues(v);
+    }
+    NodeStats getNodesStats(sa_family_t af) const {
+        return dht_->getNodesStats(af);
+    }
+    std::vector<unsigned> getNodeMessageStats(bool in = false) {
+        return dht_->getNodeMessageStats(in);
+    }
+    std::string getRoutingTablesLog(sa_family_t af) const {
+        return dht_->getRoutingTablesLog(af);
+    }
+    std::string getSearchesLog(sa_family_t af) const {
+        return dht_->getSearchesLog(af);
+    }
+    std::string getSearchLog(const InfoHash& h, sa_family_t af = AF_UNSPEC) const {
+        return dht_->getSearchLog(h, af);
+    }
+    std::vector<SockAddr> getPublicAddress(sa_family_t family = 0) {
+        return dht_->getPublicAddress(family);
+    }
+    time_point periodic(const uint8_t *buf, size_t buflen, const SockAddr& sa) {
+        return dht_->periodic(buf, buflen, sa);
+    }
+    time_point periodic(const uint8_t *buf, size_t buflen, const sockaddr* from, socklen_t fromlen) {
+        return dht_->periodic(buf, buflen, from, fromlen);
+    }
+    NodeStatus getStatus(sa_family_t af) const {
+        return dht_->getStatus(af);
+    }
+    NodeStatus getStatus() const {
+        return dht_->getStatus();
+    }
+    bool isRunning(sa_family_t af = 0) const {
+        return dht_->isRunning(af);
+    }
+    const ValueType& getType(ValueType::Id type_id) const {
+        return dht_->getType(type_id);
+    }
+    void insertNode(const InfoHash& id, const SockAddr& sa) {
+        dht_->insertNode(id, sa);
+    }
+    void insertNode(const InfoHash& id, const sockaddr* sa, socklen_t salen) {
+        dht_->insertNode(id, sa, salen);
+    }
+    void insertNode(const NodeExport& n) {
+        dht_->insertNode(n);
+    }
+    void pingNode(const sockaddr* sa, socklen_t salen, DoneCallbackSimple&& cb={}) {
+        dht_->pingNode(sa, salen, std::move(cb));
+    }
+    void query(const InfoHash& key, QueryCallback cb, DoneCallback done_cb = {}, Query&& q = {}) {
+        dht_->query(key, cb, done_cb, std::move(q));
+    }
+    void query(const InfoHash& key, QueryCallback cb, DoneCallbackSimple done_cb = {}, Query&& q = {}) {
+        dht_->query(key, cb, done_cb, std::move(q));
+    }
+    std::vector<Sp<Value>> getLocal(const InfoHash& key, Value::Filter f = Value::AllFilter()) const {
+        return dht_->getLocal(key, f);
+    }
+    Sp<Value> getLocalById(const InfoHash& key, Value::Id vid) const {
+        return dht_->getLocalById(key, vid);
+    }
+    void put(const InfoHash& key,
+            Sp<Value> v,
+            DoneCallback cb=nullptr,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        dht_->put(key, v, cb, created, permanent);
+    }
+    void put(const InfoHash& key,
+            const Sp<Value>& v,
+            DoneCallbackSimple cb,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        dht_->put(key, v, cb, created, permanent);
+    }
+
+    void put(const InfoHash& key,
+            Value&& v,
+            DoneCallback cb=nullptr,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        dht_->put(key, std::move(v), cb, created, permanent);
+    }
+    void put(const InfoHash& key,
+            Value&& v,
+            DoneCallbackSimple cb,
+            time_point created=time_point::max(),
+            bool permanent = false)
+    {
+        dht_->put(key, std::move(v), cb, created, permanent);
+    }
+    std::vector<Sp<Value>> getPut(const InfoHash& h) {
+        return dht_->getPut(h);
+    }
+    Sp<Value> getPut(const InfoHash& h, const Value::Id& vid) {
+        return dht_->getPut(h, vid);
+    }
+    bool cancelPut(const InfoHash& h, const Value::Id& vid) {
+        return dht_->cancelPut(h, vid);
+    }
+    size_t listen(const InfoHash& key, GetCallbackSimple cb, Value::Filter f={}, Where w = {}) {
+        return dht_->listen(key, cb, f, w);
+    }
+    bool cancelListen(const InfoHash& h, size_t token) {
+        return dht_->cancelListen(h, token);
+    }
+    void connectivityChanged(sa_family_t af) {
+        dht_->connectivityChanged(af);
+    }
+    void connectivityChanged() {
+        dht_->connectivityChanged();
+    }
+
 private:
+    std::unique_ptr<DhtInterface> dht_;
     // prevent copy
     SecureDht(const SecureDht&) = delete;
     SecureDht& operator=(const SecureDht&) = delete;

--- a/include/opendht/securedht.h
+++ b/include/opendht/securedht.h
@@ -298,6 +298,16 @@ public:
         dht_->connectivityChanged();
     }
 
+    void start(const std::string& host) {
+        dht_->start(host);
+    }
+
+#if OPENDHT_PROXY_SERVER
+    void forwardAllMessages(bool forward) {
+        force_forward_ = forward;
+    }
+#endif //OPENDHT_PROXY_SERVER
+
 private:
     std::unique_ptr<DhtInterface> dht_;
     // prevent copy
@@ -317,6 +327,10 @@ private:
     std::map<InfoHash, Sp<const crypto::PublicKey>> nodesPubKeys_ {};
 
     std::uniform_int_distribution<Value::Id> rand_id {};
+
+#if OPENDHT_PROXY_SERVER
+    std::atomic_bool force_forward_ {false};
+#endif //OPENDHT_PROXY_SERVER
 };
 
 const ValueType CERTIFICATE_TYPE = {

--- a/include/opendht/securedht.h
+++ b/include/opendht/securedht.h
@@ -29,7 +29,7 @@
 
 namespace dht {
 
-class OPENDHT_PUBLIC SecureDht : public DhtInterface {
+class OPENDHT_PUBLIC SecureDht final : public DhtInterface {
 public:
 
     typedef std::function<void(bool)> SignatureCheckCallback;
@@ -174,12 +174,6 @@ public:
     std::vector<ValuesExport> exportValues() const {
         return dht_->exportValues();
     }
-    void setLoggers(LogMethod error = NOLOG, LogMethod warn = NOLOG, LogMethod debug = NOLOG) {
-        dht_->setLoggers(error, warn, debug);
-    }
-    void setLogFilter(const InfoHash& f) {
-        dht_->setLogFilter(f);
-    }
     void importValues(const std::vector<ValuesExport>& v) {
         dht_->importValues(v);
     }
@@ -298,13 +292,15 @@ public:
         dht_->connectivityChanged();
     }
 
-    void start(const std::string& host) {
-        dht_->start(host);
+#if OPENDHT_PROXY_CLIENT
+    void startProxy(const std::string& host) {
+        dht_->startProxy(host);
     }
+#endif
 
 #if OPENDHT_PROXY_SERVER
     void forwardAllMessages(bool forward) {
-        force_forward_ = forward;
+        forward_all_ = forward;
     }
 #endif //OPENDHT_PROXY_SERVER
 
@@ -329,7 +325,7 @@ private:
     std::uniform_int_distribution<Value::Id> rand_id {};
 
 #if OPENDHT_PROXY_SERVER
-    std::atomic_bool force_forward_ {false};
+    std::atomic_bool forward_all_ {false};
 #endif //OPENDHT_PROXY_SERVER
 };
 

--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -86,6 +86,18 @@ NodeStats::toJson() const
     }
     return val;
 }
+
+NodeStats::NodeStats(const Json::Value& val)
+{
+    if (val.isMember("good"))
+        good_nodes = static_cast<unsigned>(val["good"].asLargestUInt());
+    if (val.isMember("dubious"))
+        dubious_nodes = static_cast<unsigned>(val["dubious"].asLargestUInt());
+    if (val.isMember("incoming"))
+        incoming_nodes = static_cast<unsigned>(val["incoming"].asLargestUInt());
+    if (val.isMember("table_depth"))
+        table_depth = static_cast<unsigned>(val["table_depth"].asLargestUInt());
+}
 #endif //OPENDHT_PROXY_SERVER
 
 }

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -39,14 +39,6 @@ constexpr std::chrono::minutes Dht::SEARCH_EXPIRE_TIME;
 constexpr std::chrono::seconds Dht::LISTEN_EXPIRE_TIME;
 constexpr std::chrono::seconds Dht::REANNOUNCE_MARGIN;
 
-void
-Dht::setLoggers(LogMethod error, LogMethod warn, LogMethod debug)
-{
-    DHT_LOG.DEBUG = debug;
-    DHT_LOG.WARN = warn;
-    DHT_LOG.ERR = error;
-}
-
 NodeStatus
 Dht::getStatus(sa_family_t af) const
 {

--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -1,0 +1,323 @@
+/*
+ *  Copyright (C) 2016 Savoir-faire Linux Inc.
+ *  Author : Sébastien Blin <sebastien.blin@savoirfairelinux.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#if OPENDHT_PROXY_SERVER
+
+#include "dht_proxy_client.h"
+
+#include <chrono>
+#include <json/json.h>
+#include <restbed>
+#include <vector>
+
+#include "dhtrunner.h"
+
+constexpr const char* const HTTP_PROTO {"http://"};
+
+// TODO connectivity changed
+// TODO follow listen between non proxified and proxified
+
+namespace dht {
+
+DhtProxyClient::DhtProxyClient(const std::string& serverHost)
+: serverHost_(serverHost), scheduler(DHT_LOG)
+{
+    auto confirm_nodes_time = scheduler.time() + std::chrono::seconds(5);
+    nextNodesConfirmation = scheduler.add(confirm_nodes_time, std::bind(&DhtProxyClient::confirmProxy, this));
+
+    getConnectivityStatus();
+}
+
+void
+DhtProxyClient::confirmProxy()
+{
+    getConnectivityStatus();
+    auto disconnected = statusIpv4_ == NodeStatus::Disconnected && statusIpv6_ == NodeStatus::Disconnected;
+    auto time = disconnected ? std::chrono::seconds(5) : std::chrono::seconds(600);
+    auto confirm_nodes_time = scheduler.time() + time;
+    scheduler.edit(nextNodesConfirmation, confirm_nodes_time);
+}
+
+DhtProxyClient::~DhtProxyClient()
+{
+    cancelAllOperations();
+}
+
+void
+DhtProxyClient::cancelAllOperations()
+{
+    for (auto& operation: operations_) {
+        if (operation.thread && operation.thread->joinable()) {
+            // Close connection to stop operation?
+            restbed::Http::close(operation.req);
+            operation.thread->join();
+        }
+    }
+}
+
+void
+DhtProxyClient::shutdown(ShutdownCallback cb)
+{
+    cancelAllOperations();
+    cb();
+}
+
+NodeStatus
+DhtProxyClient::getStatus(sa_family_t af) const
+{
+    switch (af)
+    {
+    case AF_INET:
+        return statusIpv4_;
+    case AF_INET6:
+        return statusIpv6_;
+    default:
+        return NodeStatus::Disconnected;
+    }
+}
+
+bool
+DhtProxyClient::isRunning(sa_family_t af) const
+{
+    switch (af)
+    {
+    case AF_INET:
+        return statusIpv4_ == NodeStatus::Connected;
+    case AF_INET6:
+        return statusIpv6_ == NodeStatus::Connected;
+    default:
+        return false;
+    }
+}
+
+
+void
+DhtProxyClient::get(const InfoHash& key, GetCallback cb, DoneCallback donecb,
+                    Value::Filter&& filter, Where&& where)
+{
+    restbed::Uri uri(HTTP_PROTO + serverHost_ + "/" + key.toString());
+    auto req = std::make_shared<restbed::Request>(uri);
+    Query query {{}, where};
+    auto filterChain = filter.chain(query.where.getFilter());
+
+    Operation o;
+    o.req = req;
+    o.thread = std::move(std::unique_ptr<std::thread>(
+    new std::thread([=](){
+        // Try to contact the proxy and set the status to connected when done.
+        // will change the connectivity status
+        auto ok = std::make_shared<bool>(true);
+        auto future = restbed::Http::async(req,
+            [=](const std::shared_ptr<restbed::Request>& req,
+                const std::shared_ptr<restbed::Response>& reply) {
+            auto code = reply->get_status_code();
+
+            if (code == 200) {
+                try {
+                    while (restbed::Http::is_open(req)) {
+                        restbed::Http::fetch("\n", reply);
+                        std::string body;
+                        reply->get_body(body);
+                        reply->set_body(""); // Reset the body for the next fetch
+
+                        Json::Value json;
+                        Json::Reader reader;
+                        if (reader.parse(body, json)) {
+                            auto value = std::make_shared<Value>(json);
+                            if (not filterChain or filterChain(*value))
+                                cb({value});
+                        } else {
+                            *ok = false;
+                        }
+                    }
+                } catch (std::runtime_error& e) { }
+            } else {
+                *ok = false;
+            }
+        });
+        future.wait();
+        donecb(*ok, {});
+        if (!ok) {
+            // Connection failed, update connectivity
+            getConnectivityStatus();
+        }
+    })));
+    operations_.emplace_back(std::move(o));
+}
+
+void
+DhtProxyClient::put(const InfoHash& key, Sp<Value> val, DoneCallback cb, time_point, bool permanent)
+{
+    restbed::Uri uri(HTTP_PROTO + serverHost_ + "/" + key.toString());
+    auto req = std::make_shared<restbed::Request>(uri);
+    req->set_method("POST");
+    Json::FastWriter writer;
+    auto json = val->toJson();
+    if (permanent)
+        json["permanent"] = true;
+    auto body = writer.write(json);
+    req->set_body(body);
+    req->set_header("Content-Length", std::to_string(body.size()));
+
+    Operation o;
+    o.req = req;
+    o.thread = std::move(std::unique_ptr<std::thread>(
+    new std::thread([=](){
+        auto ok = std::make_shared<bool>(true);
+        auto future = restbed::Http::async(req,
+            [this, val, ok](const std::shared_ptr<restbed::Request>& /*req*/,
+                        const std::shared_ptr<restbed::Response>& reply) {
+            auto code = reply->get_status_code();
+
+            if (code == 200) {
+                restbed::Http::fetch("\n", reply);
+                std::string body;
+                reply->get_body(body);
+                reply->set_body(""); // Reset the body for the next fetch
+
+                Json::Value json;
+                Json::Reader reader;
+                if (reader.parse(body, json)) {
+                    auto value = std::make_shared<Value>(json);
+                } else {
+                    *ok = false;
+                }
+            } else {
+                *ok = false;
+            }
+        });
+        future.wait();
+        cb(*ok, {});
+        if (!ok) {
+            // Connection failed, update connectivity
+            getConnectivityStatus();
+        }
+    })));
+    operations_.emplace_back(std::move(o));
+}
+
+NodeStats
+DhtProxyClient::getNodesStats(sa_family_t af) const
+{
+    auto proxyInfos = getProxyInfos();
+    NodeStats stats {};
+    auto identifier = af == AF_INET6 ? "ipv6" : "ipv4";
+    try {
+        stats = NodeStats(proxyInfos[identifier]);
+    } catch (...) { }
+    return stats;
+}
+
+Json::Value
+DhtProxyClient::getProxyInfos() const
+{
+    auto result = std::make_shared<Json::Value>();
+    restbed::Uri uri(HTTP_PROTO + serverHost_ + "/");
+    auto req = std::make_shared<restbed::Request>(uri);
+
+    // Try to contact the proxy and set the status to connected when done.
+    // will change the connectivity status
+    auto future = restbed::Http::async(req,
+        [this, result](const std::shared_ptr<restbed::Request>&,
+                       const std::shared_ptr<restbed::Response>& reply) {
+        auto code = reply->get_status_code();
+
+        if (code == 200) {
+            restbed::Http::fetch("\n", reply);
+            std::string body;
+            reply->get_body(body);
+
+            Json::Reader reader;
+            reader.parse(body, *result);
+        }
+    });
+    future.wait();
+    return *result;
+}
+
+std::vector<SockAddr>
+DhtProxyClient::getPublicAddress(sa_family_t family)
+{
+    auto proxyInfos = getProxyInfos();
+    // json["public_ip"] contains [ipv6:ipv4]:port or ipv4:port
+    if (!proxyInfos.isMember("public_ip")) {
+        getConnectivityStatus();
+        return {};
+    }
+    auto public_ip = proxyInfos["public_ip"].asString();
+    if (public_ip.length() < 2) {
+        getConnectivityStatus();
+        return {};
+    }
+    std::string ipv4Address = "";
+    std::string ipv6Address = "";
+    std::string port = "";
+    if (public_ip[0] == '[') {
+        // ipv6 complient
+        auto endIp = public_ip.find(']');
+        if (public_ip.length() > endIp + 2) {
+            port = public_ip.substr(endIp + 2);
+            auto ips = public_ip.substr(1, endIp - 1);
+            auto ipv4And6Separator = ips.find_last_of(':');
+            ipv4Address = ips.substr(ipv4And6Separator + 1);
+            ipv6Address = ips.substr(0, ipv4And6Separator - 1);
+        }
+    } else {
+        auto endIp = public_ip.find_last_of(':');
+        port = public_ip.substr(endIp + 1);
+        ipv4Address = public_ip.substr(0, endIp - 1);
+    }
+    switch (family)
+    {
+    case AF_INET:
+        return DhtRunner::getAddrInfo(ipv4Address, port);
+    case AF_INET6:
+        return DhtRunner::getAddrInfo(ipv6Address, port);
+    default:
+        return {};
+    }
+}
+
+void
+DhtProxyClient::getConnectivityStatus()
+{
+    auto proxyInfos = getProxyInfos();
+    // NOTE: json["ipvX"] contains NodeStats::toJson()
+    try {
+        auto goodIpv4 = static_cast<long>(proxyInfos["ipv4"]["good"].asLargestUInt());
+        auto dubiousIpv4 = static_cast<long>(proxyInfos["ipv4"]["dubious"].asLargestUInt());
+        if (goodIpv4 + dubiousIpv4 > 0) {
+            statusIpv4_ = NodeStatus::Connected;
+        }
+        auto goodIpv6 = static_cast<long>(proxyInfos["ipv6"]["good"].asLargestUInt());
+        auto dubiousIpv6 = static_cast<long>(proxyInfos["ipv6"]["dubious"].asLargestUInt());
+        if (goodIpv6 + dubiousIpv6 > 0) {
+            statusIpv6_ = NodeStatus::Connected;
+        }
+        myid = InfoHash(proxyInfos["node_id"].asString());
+    } catch (...) {
+        statusIpv4_ = NodeStatus::Disconnected;
+        statusIpv6_ = NodeStatus::Disconnected;
+    }
+
+    // TODO for now, we don't handle connectivity issues. (when the proxy is down, we don't try to reconnect)
+}
+
+} // namespace dht
+
+#endif // OPENDHT_PROXY_CLIENT

--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -192,14 +192,14 @@ DhtProxyClient::get(const InfoHash& key, GetCallback cb, DoneCallback donecb,
     Query query {{}, where};
     auto filterChain = filter.chain(query.where.getFilter());
 
-    auto finished = std::make_shared<bool>(false);
+    auto finished = std::make_shared<std::atomic_bool>(false);
     Operation o;
     o.req = req;
     o.finished = finished;
     o.thread = std::thread([=](){
         // Try to contact the proxy and set the status to connected when done.
         // will change the connectivity status
-        auto ok = std::make_shared<bool>(true);
+        auto ok = std::make_shared<std::atomic_bool>(true);
         restbed::Http::async(req,
             [=](const std::shared_ptr<restbed::Request>& req,
                 const std::shared_ptr<restbed::Response>& reply) {
@@ -267,12 +267,12 @@ DhtProxyClient::put(const InfoHash& key, Sp<Value> val, DoneCallback cb, time_po
     req->set_body(body);
     req->set_header("Content-Length", std::to_string(body.size()));
 
-    auto finished = std::make_shared<bool>(false);
+    auto finished = std::make_shared<std::atomic_bool>(false);
     Operation o;
     o.req = req;
     o.finished = finished;
     o.thread = std::thread([=](){
-        auto ok = std::make_shared<bool>(true);
+        auto ok = std::make_shared<std::atomic_bool>(true);
         restbed::Http::async(req,
             [this, ok](const std::shared_ptr<restbed::Request>& /*req*/,
                         const std::shared_ptr<restbed::Response>& reply) {
@@ -426,8 +426,8 @@ DhtProxyClient::listen(const InfoHash& key, GetCallback cb, Value::Filter&& filt
             settings->set_connection_timeout(timeout); // Avoid the client to close the socket after 5 seconds.
 
             struct State {
-                bool ok {true};
-                bool cancel {false};
+                std::atomic_bool ok {true};
+                std::atomic_bool cancel {false};
             };
             auto state = std::make_shared<State>();
             restbed::Http::async(req,

--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -27,8 +27,6 @@
 
 #include "dhtrunner.h"
 
-#include <iostream>
-
 constexpr const char* const HTTP_PROTO {"http://"};
 
 namespace dht {

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -28,8 +28,6 @@
 #include <json/json.h>
 #include <limits>
 
-#include <iostream>
-
 using namespace std::placeholders;
 
 namespace dht {
@@ -108,6 +106,8 @@ DhtProxyServer::DhtProxyServer(std::shared_ptr<DhtRunner> dht, in_port_t port)
             }
         }
     });
+
+    dht->forwardAllMessages(true);
 }
 
 DhtProxyServer::~DhtProxyServer()

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -229,7 +229,7 @@ DhtProxyServer::listen(const std::shared_ptr<restbed::Session>& session) const
                 // cache the session to avoid an incrementation of the shared_ptr's counter
                 // else, the session->close() will not close the socket.
                 auto cacheSession = std::weak_ptr<restbed::Session>(s);
-                listener.token = std::move(dht_->listen(infoHash, [cacheSession](std::shared_ptr<Value> value) {
+                listener.token = dht_->listen(infoHash, [cacheSession](std::shared_ptr<Value> value) {
                     auto s = cacheSession.lock();
                     if (!s) return false;
                     // Send values as soon as we get them
@@ -238,7 +238,7 @@ DhtProxyServer::listen(const std::shared_ptr<restbed::Session>& session) const
                         s->yield(writer.write(value->toJson()), [](const std::shared_ptr<restbed::Session>){ });
                     }
                     return !s->is_closed();
-                }));
+                });
                 lockListener_.lock();
                 currentListeners_.emplace_back(std::move(listener));
                 lockListener_.unlock();

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2017 Savoir-faire Linux Inc.
- *  Author : Sébastien Blin <sebastien.blin@savoirfairelinux.com>
+ *  Author: Sébastien Blin <sebastien.blin@savoirfairelinux.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -28,6 +28,8 @@
 #include <json/json.h>
 #include <limits>
 
+#include <iostream>
+
 using namespace std::placeholders;
 
 namespace dht {
@@ -129,6 +131,7 @@ DhtProxyServer::getNodeInfo(const std::shared_ptr<restbed::Session>& session) co
                 result["node_id"] = dht_->getNodeId().toString();
                 result["ipv4"] = dht_->getNodesStats(AF_INET).toJson();
                 result["ipv6"] = dht_->getNodesStats(AF_INET6).toJson();
+                result["public_ip"] = s->get_origin(); // [ipv6:ipv4]:port or ipv4:port
                 Json::FastWriter writer;
                 s->close(restbed::OK, writer.write(result));
             }
@@ -238,6 +241,7 @@ DhtProxyServer::put(const std::shared_ptr<restbed::Session>& session) const
                     if (parsingSuccessful) {
                         // Build the Value from json
                         auto value = std::make_shared<Value>(root);
+                        auto permanent = root.isMember("permanent") ? root["permanent"].asBool() : false;
 
                         dht_->put(infoHash, value, [s, value](bool ok) {
                             if (ok) {
@@ -246,7 +250,7 @@ DhtProxyServer::put(const std::shared_ptr<restbed::Session>& session) const
                             } else {
                                 s->close(restbed::BAD_GATEWAY, "{\"err\":\"put failed\"}");
                             }
-                        });
+                        }, time_point::max(), permanent);
                     } else {
                         s->close(restbed::BAD_REQUEST, "{\"err\":\"Incorrect JSON\"}");
                     }

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -164,7 +164,7 @@ void
 DhtRunner::dumpTables() const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    activeDht()->dumpTables(); // NOTE: NOT USED by RingAccount
+    activeDht()->dumpTables();
 }
 
 InfoHash
@@ -180,7 +180,7 @@ DhtRunner::getNodeId() const
 {
     if (!activeDht())
         return {};
-    return activeDht()->getNodeId(); // NOTE: This is OK, return the SecureDht id
+    return activeDht()->getNodeId();
 }
 
 
@@ -189,7 +189,7 @@ DhtRunner::getStoreSize() const {
     std::lock_guard<std::mutex> lck(dht_mtx);
     if (!activeDht())
         return {};
-    return activeDht()->getStoreSize(); // NOTE: NOT USED by RingAccount
+    return activeDht()->getStoreSize();
 }
 
 void
@@ -197,7 +197,7 @@ DhtRunner::setStorageLimit(size_t limit) {
     std::lock_guard<std::mutex> lck(dht_mtx);
     if (!activeDht())
         throw std::runtime_error("dht is not running");
-    return activeDht()->setStorageLimit(limit); // NOTE: NOT USED by RingAccount
+    return activeDht()->setStorageLimit(limit);
 }
 
 std::vector<NodeExport>
@@ -205,7 +205,7 @@ DhtRunner::exportNodes() const {
     std::lock_guard<std::mutex> lck(dht_mtx);
     if (!dht_)
         return {};
-    return activeDht()->exportNodes(); // NOTE: TBD Should be OK
+    return activeDht()->exportNodes();
 }
 
 std::vector<ValuesExport>
@@ -213,38 +213,38 @@ DhtRunner::exportValues() const {
     std::lock_guard<std::mutex> lck(dht_mtx);
     if (!activeDht())
         return {};
-    return activeDht()->exportValues(); // NOTE: TBD Should be OK
+    return activeDht()->exportValues();
 }
 
 void
 DhtRunner::setLoggers(LogMethod error, LogMethod warn, LogMethod debug) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    activeDht()->setLoggers(std::forward<LogMethod>(error), std::forward<LogMethod>(warn), std::forward<LogMethod>(debug)); // NOTE: TBD Should be OK
+    activeDht()->setLoggers(std::forward<LogMethod>(error), std::forward<LogMethod>(warn), std::forward<LogMethod>(debug));
 }
 
 void
 DhtRunner::setLogFilter(const InfoHash& f) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    activeDht()->setLogFilter(f); // NOTE: NOT USED by RingAccount
+    activeDht()->setLogFilter(f);
 }
 
 void
 DhtRunner::registerType(const ValueType& type) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    activeDht()->registerType(type); // NOTE: NOT USED by RingAccount
+    activeDht()->registerType(type);
 }
 
 void
 DhtRunner::importValues(const std::vector<ValuesExport>& values) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    activeDht()->importValues(values); // NOTE: TBD Should be OK
+    activeDht()->importValues(values);
 }
 
 unsigned
 DhtRunner::getNodesStats(sa_family_t af, unsigned *good_return, unsigned *dubious_return, unsigned *cached_return, unsigned *incoming_return) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    const auto stats = activeDht()->getNodesStats(af); // NOTE: TBD Should be OK
+    const auto stats = activeDht()->getNodesStats(af);
     if (good_return)
         *good_return = stats.good_nodes;
     if (dubious_return)
@@ -260,51 +260,51 @@ NodeStats
 DhtRunner::getNodesStats(sa_family_t af) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getNodesStats(af); // NOTE: TBD Should be OK
+    return activeDht()->getNodesStats(af);
 }
 
 std::vector<unsigned>
 DhtRunner::getNodeMessageStats(bool in) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getNodeMessageStats(in); // NOTE: NOT USED by RingAccount
+    return activeDht()->getNodeMessageStats(in);
 }
 
 std::string
 DhtRunner::getStorageLog() const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getStorageLog(); // NOTE: NOT USED by RingAccount
+    return activeDht()->getStorageLog();
 }
 std::string
 DhtRunner::getStorageLog(const InfoHash& f) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getStorageLog(f); // NOTE: NOT USED by RingAccount
+    return activeDht()->getStorageLog(f);
 }
 std::string
 DhtRunner::getRoutingTablesLog(sa_family_t af) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getRoutingTablesLog(af); // NOTE: NOT USED by RingAccount
+    return activeDht()->getRoutingTablesLog(af);
 }
 std::string
 DhtRunner::getSearchesLog(sa_family_t af) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getSearchesLog(af); // NOTE: NOT USED by RingAccount
+    return activeDht()->getSearchesLog(af);
 }
 std::string
 DhtRunner::getSearchLog(const InfoHash& f, sa_family_t af) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getSearchLog(f, af); // NOTE: NOT USED by RingAccount
+    return activeDht()->getSearchLog(f, af);
 }
 std::vector<SockAddr>
 DhtRunner::getPublicAddress(sa_family_t af)
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getPublicAddress(af); // NOTE: TBD Should be OK
+    return activeDht()->getPublicAddress(af);
 }
 std::vector<std::string>
 DhtRunner::getPublicAddressStr(sa_family_t af)
@@ -318,12 +318,14 @@ DhtRunner::getPublicAddressStr(sa_family_t af)
 void
 DhtRunner::registerCertificate(std::shared_ptr<crypto::Certificate> cert) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    activeDht()->registerCertificate(cert); // NOTE: NOT USED by RingAccount
+    activeDht()->registerCertificate(cert);
 }
 void
 DhtRunner::setLocalCertificateStore(CertificateStoreQuery&& query_method) {
     std::lock_guard<std::mutex> lck(dht_mtx);
+#if OPENDHT_PROXY_CLIENT
     dht_via_proxy_->setLocalCertificateStore(std::forward<CertificateStoreQuery>(query_method));
+#endif
     dht_->setLocalCertificateStore(std::forward<CertificateStoreQuery>(query_method));
 }
 
@@ -891,7 +893,7 @@ DhtRunner::enableProxy(bool proxify) {
     }
     if (proxify) {
         // Init the proxy client
-        dht_via_proxy_->start(config_.proxy_server);
+        dht_via_proxy_->startProxy(config_.proxy_server);
         // add current listeners
         for (auto& listener: listeners_) {
             auto tokenProxy = dht_via_proxy_->listen(listener->hash, listener->gcb, std::move(listener->f), std::move(listener->w));

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -1,7 +1,8 @@
 /*
  *  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
- *  Author(s) : Adrien Béraud <adrien.beraud@savoirfairelinux.com>
- *              Simon Désaulniers <simon.desaulniers@savoirfairelinux.com>
+ *  Authors: Adrien Béraud <adrien.beraud@savoirfairelinux.com>
+ *           Simon Désaulniers <simon.desaulniers@savoirfairelinux.com>
+ *           Sébastien Blin <sebastien.blin@savoirfairelinux.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -759,30 +759,6 @@ DhtRunner::tryBootstrapContinuously()
     });
 }
 
-std::vector<SockAddr>
-DhtRunner::getAddrInfo(const std::string& host, const std::string& service)
-{
-    std::vector<SockAddr> ips {};
-    if (host.empty())
-        return ips;
-
-    addrinfo hints;
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_socktype = SOCK_DGRAM;
-    addrinfo* info = nullptr;
-    int rc = getaddrinfo(host.c_str(), service.c_str(), &hints, &info);
-    if(rc != 0)
-        throw std::invalid_argument(std::string("Error: `") + host + ":" + service + "`: " + gai_strerror(rc));
-
-    addrinfo* infop = info;
-    while (infop) {
-        ips.emplace_back(infop->ai_addr, infop->ai_addrlen);
-        infop = infop->ai_next;
-    }
-    freeaddrinfo(info);
-    return ips;
-}
-
 void
 DhtRunner::bootstrap(const std::string& host, const std::string& service)
 {

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -382,10 +382,10 @@ int bindSocket(const SockAddr& addr, SockAddr& bound)
         throw DhtException(std::string("Can't open socket: ") + strerror(sock));
     int set = 1;
 #ifdef SO_NOSIGPIPE
-    setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, (void *)&set, sizeof(set));
+    setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, (const char*)&set, sizeof(set));
 #endif
     if (is_ipv6)
-        setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (void *)&set, sizeof(set));
+        setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&set, sizeof(set));
     int rc = bind(sock, addr.get(), addr.getLength());
     if(rc < 0)
         throw DhtException("Can't bind socket on " + addr.toString() + " " + strerror(rc));

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -39,6 +39,9 @@ namespace dht {
 constexpr std::chrono::seconds DhtRunner::BOOTSTRAP_PERIOD;
 
 DhtRunner::DhtRunner() : dht_()
+#if OPENDHT_PROXY_CLIENT
+, dht_via_proxy_()
+#endif //OPENDHT_PROXY_CLIENT
 {
 #ifdef _WIN32
     WSADATA wsd;
@@ -84,6 +87,10 @@ DhtRunner::run(const SockAddr& local4, const SockAddr& local6, DhtRunner::Config
     if (rcv_thread.joinable())
         rcv_thread.join();
     running = true;
+#if OPENDHT_PROXY_CLIENT
+    config_.dht_config = config.dht_config;
+    config_.threaded = config.threaded;
+#endif //OPENDHT_PROXY_CLIENT
     doRun(local4, local6, config.dht_config);
     if (not config.threaded)
         return;
@@ -142,7 +149,7 @@ DhtRunner::join()
     }
     {
         std::lock_guard<std::mutex> lck(dht_mtx);
-        dht_.reset();
+        resetDht();
         status4 = NodeStatus::Disconnected;
         status6 = NodeStatus::Disconnected;
         bound4 = {};
@@ -154,40 +161,40 @@ void
 DhtRunner::dumpTables() const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    dht_->dumpTables();
+    activeDht()->dumpTables();
 }
 
 InfoHash
 DhtRunner::getId() const
 {
-    if (!dht_)
+    if (!activeDht())
         return {};
-    return dht_->getId();
+    return activeDht()->getId();
 }
 
 InfoHash
 DhtRunner::getNodeId() const
 {
-    if (!dht_)
+    if (!activeDht())
         return {};
-    return dht_->getNodeId();
+    return activeDht()->getNodeId();
 }
 
 
 std::pair<size_t, size_t>
 DhtRunner::getStoreSize() const {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    if (!dht_)
+    if (!activeDht())
         return {};
-    return dht_->getStoreSize();
+    return activeDht()->getStoreSize();
 }
 
 void
 DhtRunner::setStorageLimit(size_t limit) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    if (!dht_)
+    if (!activeDht())
         throw std::runtime_error("dht is not running");
-    return dht_->setStorageLimit(limit);
+    return activeDht()->setStorageLimit(limit);
 }
 
 std::vector<NodeExport>
@@ -195,46 +202,46 @@ DhtRunner::exportNodes() const {
     std::lock_guard<std::mutex> lck(dht_mtx);
     if (!dht_)
         return {};
-    return dht_->exportNodes();
+    return activeDht()->exportNodes();
 }
 
 std::vector<ValuesExport>
 DhtRunner::exportValues() const {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    if (!dht_)
+    if (!activeDht())
         return {};
-    return dht_->exportValues();
+    return activeDht()->exportValues();
 }
 
 void
 DhtRunner::setLoggers(LogMethod error, LogMethod warn, LogMethod debug) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    dht_->setLoggers(std::forward<LogMethod>(error), std::forward<LogMethod>(warn), std::forward<LogMethod>(debug));
+    activeDht()->setLoggers(std::forward<LogMethod>(error), std::forward<LogMethod>(warn), std::forward<LogMethod>(debug));
 }
 
 void
 DhtRunner::setLogFilter(const InfoHash& f) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    dht_->setLogFilter(f);
+    activeDht()->setLogFilter(f);
 }
 
 void
 DhtRunner::registerType(const ValueType& type) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    dht_->registerType(type);
+    activeDht()->registerType(type);
 }
 
 void
 DhtRunner::importValues(const std::vector<ValuesExport>& values) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    dht_->importValues(values);
+    activeDht()->importValues(values);
 }
 
 unsigned
 DhtRunner::getNodesStats(sa_family_t af, unsigned *good_return, unsigned *dubious_return, unsigned *cached_return, unsigned *incoming_return) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    const auto stats = dht_->getNodesStats(af);
+    const auto stats = activeDht()->getNodesStats(af);
     if (good_return)
         *good_return = stats.good_nodes;
     if (dubious_return)
@@ -250,51 +257,51 @@ NodeStats
 DhtRunner::getNodesStats(sa_family_t af) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return dht_->getNodesStats(af);
+    return activeDht()->getNodesStats(af);
 }
 
 std::vector<unsigned>
 DhtRunner::getNodeMessageStats(bool in) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return dht_->getNodeMessageStats(in);
+    return activeDht()->getNodeMessageStats(in);
 }
 
 std::string
 DhtRunner::getStorageLog() const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return dht_->getStorageLog();
+    return activeDht()->getStorageLog();
 }
 std::string
 DhtRunner::getStorageLog(const InfoHash& f) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return dht_->getStorageLog(f);
+    return activeDht()->getStorageLog(f);
 }
 std::string
 DhtRunner::getRoutingTablesLog(sa_family_t af) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return dht_->getRoutingTablesLog(af);
+    return activeDht()->getRoutingTablesLog(af);
 }
 std::string
 DhtRunner::getSearchesLog(sa_family_t af) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return dht_->getSearchesLog(af);
+    return activeDht()->getSearchesLog(af);
 }
 std::string
 DhtRunner::getSearchLog(const InfoHash& f, sa_family_t af) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return dht_->getSearchLog(f, af);
+    return activeDht()->getSearchLog(f, af);
 }
 std::vector<SockAddr>
 DhtRunner::getPublicAddress(sa_family_t af)
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return dht_->getPublicAddress(af);
+    return activeDht()->getPublicAddress(af);
 }
 std::vector<std::string>
 DhtRunner::getPublicAddressStr(sa_family_t af)
@@ -308,18 +315,18 @@ DhtRunner::getPublicAddressStr(sa_family_t af)
 void
 DhtRunner::registerCertificate(std::shared_ptr<crypto::Certificate> cert) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    dht_->registerCertificate(cert);
+    activeDht()->registerCertificate(cert);
 }
 void
 DhtRunner::setLocalCertificateStore(CertificateStoreQuery&& query_method) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    dht_->setLocalCertificateStore(std::forward<CertificateStoreQuery>(query_method));
+    activeDht()->setLocalCertificateStore(std::forward<CertificateStoreQuery>(query_method));
 }
 
 time_point
 DhtRunner::loop_()
 {
-    if (!dht_)
+    if (!activeDht())
         return {};
 
     decltype(pending_ops) ops {};
@@ -330,7 +337,7 @@ DhtRunner::loop_()
                std::move(pending_ops) : std::move(pending_ops_prio);
     }
     while (not ops.empty()) {
-        ops.front()(*dht_);
+        ops.front()(*activeDht());
         ops.pop();
     }
 
@@ -345,15 +352,15 @@ DhtRunner::loop_()
         for (const auto& pck : received) {
             auto& buf = pck.first;
             auto& from = pck.second;
-            wakeup = dht_->periodic(buf.data(), buf.size()-1, from);
+            wakeup = activeDht()->periodic(buf.data(), buf.size()-1, from);
         }
         received.clear();
     } else {
-        wakeup = dht_->periodic(nullptr, 0, nullptr, 0);
+        wakeup = activeDht()->periodic(nullptr, 0, nullptr, 0);
     }
 
-    NodeStatus nstatus4 = dht_->getStatus(AF_INET);
-    NodeStatus nstatus6 = dht_->getStatus(AF_INET6);
+    NodeStatus nstatus4 = activeDht()->getStatus(AF_INET);
+    NodeStatus nstatus6 = activeDht()->getStatus(AF_INET6);
     if (nstatus4 != status4 || nstatus6 != status6) {
         status4 = nstatus4;
         status6 = nstatus6;
@@ -399,7 +406,7 @@ int bindSocket(const SockAddr& addr, SockAddr& bound)
 void
 DhtRunner::doRun(const SockAddr& sin4, const SockAddr& sin6, SecureDht::Config config)
 {
-    dht_.reset();
+    resetDht();
 
     int s4 = -1,
         s6 = -1;
@@ -414,7 +421,10 @@ DhtRunner::doRun(const SockAddr& sin4, const SockAddr& sin6, SecureDht::Config c
         s6 = bindSocket(sin6, bound6);
 #endif
 
-    dht_ = std::unique_ptr<SecureDht>(new SecureDht {s4, s6, config});
+    auto dht = std::unique_ptr<DhtInterface>(
+        new Dht(s4, s6, SecureDht::getConfig(config))
+    );
+    dht_ = std::unique_ptr<SecureDht>(new SecureDht(std::move(dht), config));
 
     rcv_thread = std::thread([this,s4,s6]() {
         try {
@@ -771,5 +781,46 @@ DhtRunner::findCertificate(InfoHash hash, std::function<void(const std::shared_p
     }
     cv.notify_all();
 }
+
+void
+DhtRunner::resetDht() {
+#if OPENDHT_PROXY_CLIENT
+    use_proxy? dht_via_proxy_.reset() : dht_.reset();
+#else
+    dht_.reset();
+#endif // OPENDHT_PROXY_CLIENT
+}
+
+SecureDht*
+DhtRunner::activeDht() const
+{
+#if OPENDHT_PROXY_CLIENT
+    return use_proxy? dht_via_proxy_.get() : dht_.get();
+#else
+    return dht_.get();
+#endif // OPENDHT_PROXY_CLIENT
+}
+
+#if OPENDHT_PROXY_CLIENT
+void
+DhtRunner::enableProxy(bool proxify) {
+    if (proxify) {
+        // If no proxy url in the config, use 127.0.0.1:8000
+        std::string serverHost = config_.proxy_server.empty() ? "127.0.0.1:8000" : config_.proxy_server;
+        // Init the proxy client
+        auto dht_via_proxy = std::unique_ptr<DhtInterface>(
+            new DhtProxyClient(serverHost)
+        );
+        dht_via_proxy_ = std::unique_ptr<SecureDht>(new SecureDht(std::move(dht_via_proxy), config_.dht_config));
+        // and use it
+        use_proxy = proxify;
+    } else {
+        use_proxy = proxify;
+        // We doesn't need to maintain the connection with the proxy.
+        // Delete it
+        dht_via_proxy_.reset(nullptr);
+    }
+}
+#endif // OPENDHT_PROXY_CLIENT
 
 }

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -123,8 +123,7 @@ DhtRunner::run(const SockAddr& local4, const SockAddr& local6, DhtRunner::Config
 void
 DhtRunner::shutdown(ShutdownCallback cb) {
 #if OPENDHT_PROXY_CLIENT
-    if (dht_via_proxy_)
-        dht_via_proxy_->shutdown(cb);
+    dht_via_proxy_->shutdown(cb);
 #endif
     std::lock_guard<std::mutex> lck(storage_mtx);
     pending_ops_prio.emplace([=](SecureDht& dht) mutable {
@@ -165,7 +164,7 @@ void
 DhtRunner::dumpTables() const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    activeDht()->dumpTables();
+    activeDht()->dumpTables(); // NOTE: NOT USED by RingAccount
 }
 
 InfoHash
@@ -181,7 +180,7 @@ DhtRunner::getNodeId() const
 {
     if (!activeDht())
         return {};
-    return activeDht()->getNodeId();
+    return activeDht()->getNodeId(); // NOTE: This is OK, return the SecureDht id
 }
 
 
@@ -190,7 +189,7 @@ DhtRunner::getStoreSize() const {
     std::lock_guard<std::mutex> lck(dht_mtx);
     if (!activeDht())
         return {};
-    return activeDht()->getStoreSize();
+    return activeDht()->getStoreSize(); // NOTE: NOT USED by RingAccount
 }
 
 void
@@ -198,7 +197,7 @@ DhtRunner::setStorageLimit(size_t limit) {
     std::lock_guard<std::mutex> lck(dht_mtx);
     if (!activeDht())
         throw std::runtime_error("dht is not running");
-    return activeDht()->setStorageLimit(limit);
+    return activeDht()->setStorageLimit(limit); // NOTE: NOT USED by RingAccount
 }
 
 std::vector<NodeExport>
@@ -206,7 +205,7 @@ DhtRunner::exportNodes() const {
     std::lock_guard<std::mutex> lck(dht_mtx);
     if (!dht_)
         return {};
-    return activeDht()->exportNodes();
+    return activeDht()->exportNodes(); // NOTE: TBD Should be OK
 }
 
 std::vector<ValuesExport>
@@ -214,38 +213,38 @@ DhtRunner::exportValues() const {
     std::lock_guard<std::mutex> lck(dht_mtx);
     if (!activeDht())
         return {};
-    return activeDht()->exportValues();
+    return activeDht()->exportValues(); // NOTE: TBD Should be OK
 }
 
 void
 DhtRunner::setLoggers(LogMethod error, LogMethod warn, LogMethod debug) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    activeDht()->setLoggers(std::forward<LogMethod>(error), std::forward<LogMethod>(warn), std::forward<LogMethod>(debug));
+    activeDht()->setLoggers(std::forward<LogMethod>(error), std::forward<LogMethod>(warn), std::forward<LogMethod>(debug)); // NOTE: TBD Should be OK
 }
 
 void
 DhtRunner::setLogFilter(const InfoHash& f) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    activeDht()->setLogFilter(f);
+    activeDht()->setLogFilter(f); // NOTE: NOT USED by RingAccount
 }
 
 void
 DhtRunner::registerType(const ValueType& type) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    activeDht()->registerType(type);
+    activeDht()->registerType(type); // NOTE: NOT USED by RingAccount
 }
 
 void
 DhtRunner::importValues(const std::vector<ValuesExport>& values) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    activeDht()->importValues(values);
+    activeDht()->importValues(values); // NOTE: TBD Should be OK
 }
 
 unsigned
 DhtRunner::getNodesStats(sa_family_t af, unsigned *good_return, unsigned *dubious_return, unsigned *cached_return, unsigned *incoming_return) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    const auto stats = activeDht()->getNodesStats(af);
+    const auto stats = activeDht()->getNodesStats(af); // NOTE: TBD Should be OK
     if (good_return)
         *good_return = stats.good_nodes;
     if (dubious_return)
@@ -261,51 +260,51 @@ NodeStats
 DhtRunner::getNodesStats(sa_family_t af) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getNodesStats(af);
+    return activeDht()->getNodesStats(af); // NOTE: TBD Should be OK
 }
 
 std::vector<unsigned>
 DhtRunner::getNodeMessageStats(bool in) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getNodeMessageStats(in);
+    return activeDht()->getNodeMessageStats(in); // NOTE: NOT USED by RingAccount
 }
 
 std::string
 DhtRunner::getStorageLog() const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getStorageLog();
+    return activeDht()->getStorageLog(); // NOTE: NOT USED by RingAccount
 }
 std::string
 DhtRunner::getStorageLog(const InfoHash& f) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getStorageLog(f);
+    return activeDht()->getStorageLog(f); // NOTE: NOT USED by RingAccount
 }
 std::string
 DhtRunner::getRoutingTablesLog(sa_family_t af) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getRoutingTablesLog(af);
+    return activeDht()->getRoutingTablesLog(af); // NOTE: NOT USED by RingAccount
 }
 std::string
 DhtRunner::getSearchesLog(sa_family_t af) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getSearchesLog(af);
+    return activeDht()->getSearchesLog(af); // NOTE: NOT USED by RingAccount
 }
 std::string
 DhtRunner::getSearchLog(const InfoHash& f, sa_family_t af) const
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getSearchLog(f, af);
+    return activeDht()->getSearchLog(f, af); // NOTE: NOT USED by RingAccount
 }
 std::vector<SockAddr>
 DhtRunner::getPublicAddress(sa_family_t af)
 {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    return activeDht()->getPublicAddress(af);
+    return activeDht()->getPublicAddress(af); // NOTE: TBD Should be OK
 }
 std::vector<std::string>
 DhtRunner::getPublicAddressStr(sa_family_t af)
@@ -319,12 +318,13 @@ DhtRunner::getPublicAddressStr(sa_family_t af)
 void
 DhtRunner::registerCertificate(std::shared_ptr<crypto::Certificate> cert) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    activeDht()->registerCertificate(cert);
+    activeDht()->registerCertificate(cert); // NOTE: NOT USED by RingAccount
 }
 void
 DhtRunner::setLocalCertificateStore(CertificateStoreQuery&& query_method) {
     std::lock_guard<std::mutex> lck(dht_mtx);
-    activeDht()->setLocalCertificateStore(std::forward<CertificateStoreQuery>(query_method));
+    dht_via_proxy_->setLocalCertificateStore(std::forward<CertificateStoreQuery>(query_method));
+    dht_->setLocalCertificateStore(std::forward<CertificateStoreQuery>(query_method));
 }
 
 time_point
@@ -430,6 +430,15 @@ DhtRunner::doRun(const SockAddr& sin4, const SockAddr& sin6, SecureDht::Config c
     );
     dht_ = std::unique_ptr<SecureDht>(new SecureDht(std::move(dht), config));
 
+#if OPENDHT_PROXY_CLIENT
+    if (!dht_via_proxy_) {
+        auto dht_via_proxy = std::unique_ptr<DhtInterface>(
+            new DhtProxyClient(config_.proxy_server)
+        );
+        dht_via_proxy_ = std::unique_ptr<SecureDht>(new SecureDht(std::move(dht_via_proxy), config_.dht_config));
+    }
+#endif
+
     rcv_thread = std::thread([this,s4,s6]() {
         try {
             while (true) {
@@ -522,7 +531,7 @@ DhtRunner::listen(InfoHash hash, GetCallback vcb, Value::Filter f, Where w)
             auto tokenProxy = 0, tokenClassic = 0;
             if (!use_proxy)
                 tokenClassic = dht_->listen(hash, vcb, std::move(f), std::move(w));
-            else if (dht_via_proxy_)
+            else
                 tokenProxy = dht_via_proxy_->listen(hash, vcb, std::move(f), std::move(w));
 #else
         pending_ops.emplace([=](SecureDht& dht) mutable {
@@ -573,7 +582,7 @@ DhtRunner::cancelListen(InfoHash h, size_t token)
             if (listener->tokenClassicDht != 0) {
                 dht_->cancelListen(h, listener->tokenClassicDht);
             }
-            if (dht_via_proxy_ && listener->tokenProxyDht > 0) {
+            if (listener->tokenProxyDht != 0) {
                 dht_via_proxy_->cancelListen(h, listener->tokenProxyDht);
             }
 #else
@@ -874,14 +883,15 @@ DhtRunner::activeDht() const
 #if OPENDHT_PROXY_CLIENT
 void
 DhtRunner::enableProxy(bool proxify) {
-    if (proxify) {
-        // If no proxy url in the config, use 127.0.0.1:8000
-        std::string serverHost = config_.proxy_server.empty() ? "127.0.0.1:8000" : config_.proxy_server;
-        // Init the proxy client
+    if (!dht_via_proxy_) {
         auto dht_via_proxy = std::unique_ptr<DhtInterface>(
-            new DhtProxyClient(serverHost)
+            new DhtProxyClient(config_.proxy_server)
         );
         dht_via_proxy_ = std::unique_ptr<SecureDht>(new SecureDht(std::move(dht_via_proxy), config_.dht_config));
+    }
+    if (proxify) {
+        // Init the proxy client
+        dht_via_proxy_->start(config_.proxy_server);
         // add current listeners
         for (auto& listener: listeners_) {
             auto tokenProxy = dht_via_proxy_->listen(listener->hash, listener->gcb, std::move(listener->f), std::move(listener->w));
@@ -894,7 +904,7 @@ DhtRunner::enableProxy(bool proxify) {
         loop_(); // Restart the classic DHT.
         // We doesn't need to maintain the connection with the proxy.
         // Delete it
-        dht_via_proxy_.reset(nullptr);
+        dht_via_proxy_->shutdown({});
         // update all proxyToken for all proxyListener
         auto it = listeners_.begin();
         for (; it != listeners_.end(); ++it) {
@@ -911,4 +921,15 @@ DhtRunner::enableProxy(bool proxify) {
     }
 }
 #endif // OPENDHT_PROXY_CLIENT
+
+#if OPENDHT_PROXY_SERVER
+void
+DhtRunner::forwardAllMessages(bool forward)
+{
+#if OPENDHT_PROXY_CLIENT
+    dht_via_proxy_->forwardAllMessages(forward);
+#endif // OPENDHT_PROXY_CLIENT
+    dht_->forwardAllMessages(forward);
+}
+#endif // OPENDHT_PROXY_SERVER
 }

--- a/src/securedht.cpp
+++ b/src/securedht.cpp
@@ -1,7 +1,8 @@
 /*
  *  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
- *  Author : Adrien Béraud <adrien.beraud@savoirfairelinux.com>
+ *  Authors: Adrien Béraud <adrien.beraud@savoirfairelinux.com>
  *           Simon Désaulniers <simon.desaulniers@savoirfairelinux.com>
+ *           Sébastien Blin <sebastien.blin@savoirfairelinux.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/securedht.cpp
+++ b/src/securedht.cpp
@@ -228,8 +228,11 @@ SecureDht::getCallbackFilter(GetCallback cb, Value::Filter&& filter)
         for (const auto& v : values) {
             // Decrypt encrypted values
             if (v->isEncrypted()) {
-                if (not key_)
+                if (not key_) {
+                    if (force_forward_)
+                        tmpvals.push_back(v);
                     continue;
+                }
                 try {
                     Value decrypted_val (decrypt(*v));
                     if (decrypted_val.recipient == getId()) {

--- a/src/securedht.cpp
+++ b/src/securedht.cpp
@@ -229,8 +229,10 @@ SecureDht::getCallbackFilter(GetCallback cb, Value::Filter&& filter)
             // Decrypt encrypted values
             if (v->isEncrypted()) {
                 if (not key_) {
-                    if (force_forward_)
+#if OPENDHT_PROXY_SERVER
+                    if (forward_all_) // We are currently a proxy, send messages to clients.
                         tmpvals.push_back(v);
+#endif
                     continue;
                 }
                 try {

--- a/tools/dhtchat.cpp
+++ b/tools/dhtchat.cpp
@@ -67,6 +67,13 @@ main(int argc, char **argv)
         if (not params.bootstrap.first.empty())
             dht.bootstrap(params.bootstrap.first.c_str(), params.bootstrap.second.c_str());
 
+#if OPENDHT_PROXY_CLIENT
+    if (!params.proxyclient.empty()) {
+        dht.setProxyServer(params.proxyclient);
+        dht.enableProxy(true);
+    }
+#endif //OPENDHT_PROXY_CLIENT
+
         print_node_info(dht, params);
         std::cout << "  type 'c {hash}' to join a channel" << std::endl << std::endl;
 

--- a/tools/dhtnode.cpp
+++ b/tools/dhtnode.cpp
@@ -1,8 +1,9 @@
 /*
  *  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
  *
- *  Author: Adrien Béraud <adrien.beraud@savoirfairelinux.com>
- *          Simon Désaulniers <simon.desaulniers@savoirfairelinux.com>
+ *  Authors: Adrien Béraud <adrien.beraud@savoirfairelinux.com>
+ *           Simon Désaulniers <simon.desaulniers@savoirfairelinux.com>
+ *           Sébastien Blin <sebastien.blin@savoirfairelinux.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/dhtnode.cpp
+++ b/tools/dhtnode.cpp
@@ -63,10 +63,17 @@ void print_help() {
               << "  psp [port]            Stop the proxy interface on port." << std::endl;
 #endif //OPENDHT_PROXY_SERVER
 
+#if OPENDHT_PROXY_CLIENT
+    std::cout << std::endl << "Operations with the proxy:" << std::endl
+              << "  stt [server_address]  Start the proxy client." << std::endl
+              << "  stp                   Stop the proxy client." << std::endl;
+#endif //OPENDHT_PROXY_CLIENT
+
     std::cout << std::endl << "Operations on the DHT:" << std::endl
               << "  b <ip:port>           Ping potential node at given IP address/port." << std::endl
               << "  g <key>               Get values at <key>." << std::endl
               << "  l <key>               Listen for value changes at <key>." << std::endl
+              << "  cl <key> <token>      Cancel listen for <token> and <key>." << std::endl
               << "  p <key> <str>         Put string value at <key>." << std::endl
               << "  pp <key> <str>        Put string value at <key> (persistent version)." << std::endl
               << "  s <key> <str>         Put string value at <key>, signed with our generated private key." << std::endl
@@ -96,6 +103,12 @@ void cmd_loop(std::shared_ptr<DhtRunner>& dht, dht_params& params)
         proxies.emplace(params.proxyserver, new DhtProxyServer(dht, params.proxyserver));
     }
 #endif //OPENDHT_PROXY_SERVER
+#if OPENDHT_PROXY_CLIENT
+    if (!params.proxyclient.empty()) {
+        dht->setProxyServer(params.proxyclient);
+        dht->enableProxy(true);
+    }
+#endif //OPENDHT_PROXY_CLIENT
 
     while (true)
     {
@@ -191,6 +204,17 @@ void cmd_loop(std::shared_ptr<DhtRunner>& dht, dht_params& params)
             continue;
         }
 #endif //OPENDHT_PROXY_SERVER
+#if OPENDHT_PROXY_CLIENT
+        else if (op == "stt") {
+            iss >> idstr;
+            dht->setProxyServer(idstr);
+            dht->enableProxy(true);
+            continue;
+        } else if (op == "stp") {
+            dht->enableProxy(false);
+            continue;
+        }
+#endif //OPENDHT_PROXY_CLIENT
 
         if (op.empty())
             continue;

--- a/tools/tools_common.h
+++ b/tools/tools_common.h
@@ -2,6 +2,7 @@
  *  Copyright (C) 2014-2017 Savoir-faire Linux Inc.
  *
  *  Author: Adrien Béraud <adrien.beraud@savoirfairelinux.com>
+ *  Author: Sébastien Blin <sebastien.blin@savoirfairelinux.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/tools_common.h
+++ b/tools/tools_common.h
@@ -120,6 +120,7 @@ struct dht_params {
     bool service {false};
     std::pair<std::string, std::string> bootstrap {};
     in_port_t proxyserver {0};
+    std::string proxyclient {};
 };
 
 static const constexpr struct option long_options[] = {
@@ -134,6 +135,7 @@ static const constexpr struct option long_options[] = {
    {"logfile",    required_argument, nullptr, 'l'},
    {"syslog",     no_argument      , nullptr, 'L'},
    {"proxyserver",required_argument, nullptr, 'S'},
+   {"proxyclient",required_argument, nullptr, 'C'},
    {nullptr,      0                , nullptr,  0}
 };
 
@@ -158,6 +160,9 @@ parseArgs(int argc, char **argv) {
                 else
                     std::cout << "Invalid port: " << port_arg << std::endl;
             }
+            break;
+        case 'C':
+            params.proxyclient = optarg;
             break;
         case 'n':
             params.network = strtoul(optarg, nullptr, 0);


### PR DESCRIPTION
cf #218, also fix #222

+ Add an abstract class to describe the Dht
+ Now, we can modify the Dht linked to a SecureDht. So we can choose
between the classic Dht and the Dht using a proxy.
+ Implement a basic client which can Get and Put values on the Dht using
the proxy.
+ Fix LISTEN endpoint for DhtProxyServer
+ Add listen/cancelListen for DhtProxyClient
+ Add connectivityChanged.

Note: Update `dhtnode` and `dhtchat` to have the ability to use the DhtProxyClient.