### PR TITLE
InfoHash: fix stream operator<< declaration

### DIFF
--- a/include/opendht/infohash.h
+++ b/include/opendht/infohash.h
@@ -378,7 +378,7 @@ struct OPENDHT_PUBLIC NodeExport {
 
     void msgpack_unpack(msgpack::object o);
 
-    OPENDHT_PUBLIC friend std::ostream& operator<< (std::ostream& s, const InfoHash& h);
+    OPENDHT_PUBLIC friend std::ostream& operator<< (std::ostream& s, const NodeExport& h);
 };
 
 }


### PR DESCRIPTION
The operator declaration's signature did not match the definition and was not ignored buy the Microsoft compiler and causes missing symbol errors at link time.