### PR TITLE
dhtrunner: pass SockAddrs by value to startNetwork

### DIFF
--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -404,7 +404,7 @@ private:
      */
     void tryBootstrapContinuously();
 
-    void startNetwork(const SockAddr& sin4, const SockAddr& sin6);
+    void startNetwork(const SockAddr sin4, const SockAddr sin6);
     time_point loop_();
 
     NodeStatus getStatus() const {

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -421,7 +421,7 @@ int bindSocket(const SockAddr& addr, SockAddr& bound)
 }
 
 void
-DhtRunner::startNetwork(const SockAddr& sin4, const SockAddr& sin6)
+DhtRunner::startNetwork(const SockAddr sin4, const SockAddr sin6)
 {
     running_network = false;
     if (rcv_thread.joinable())


### PR DESCRIPTION
In the case of a broken pipe, the bound SockAddr structure refs are passed to startNetwork and are emptied before binding (and at the end of rcv_thread), which would mean that bindSocket will get a couple empty stuctures as parameters and fail.