### PR TITLE
Generates RSA pairs for dhtnode instead of EC cert

### DIFF
--- a/tools/dhtnode.cpp
+++ b/tools/dhtnode.cpp
@@ -484,7 +484,7 @@ main(int argc, char **argv)
         dht::crypto::Identity crt {};
         if (params.generate_identity) {
             auto ca_tmp = dht::crypto::generateEcIdentity("DHT Node CA");
-            crt = dht::crypto::generateEcIdentity("DHT Node", ca_tmp);
+            crt = dht::crypto::generateIdentity("DHT Node", ca_tmp);
         }
 
         dht::DhtRunner::Config config;


### PR DESCRIPTION
* dhtnode was generating twice an EC cert which rendered encryption
impossible since opendht lib is expecting an RSA public key to encrypt
the data for the destination.

* fix savoirfairelinux/opendht#238
