### PR TITLE
proxy_client: avoid to call getConnectivityStatus() when destroying

### DIFF
--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -349,6 +349,7 @@ private:
     void fillBodyToGetToken(std::shared_ptr<restbed::Request> request, unsigned callbackId);
 #endif // OPENDHT_PUSH_NOTIFICATIONS
 
+    bool isDestroying_ {false};
 };
 
 }

--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -56,6 +56,7 @@ DhtProxyClient::startProxy()
 
 DhtProxyClient::~DhtProxyClient()
 {
+    isDestroying_ = true;
     cancelAllOperations();
     cancelAllListeners();
 }
@@ -636,7 +637,7 @@ DhtProxyClient::opFailed()
 void
 DhtProxyClient::getConnectivityStatus()
 {
-    getProxyInfos();
+    if (!isDestroying_) getProxyInfos();
 }
 
 void


### PR DESCRIPTION
Because getConnectivityStatus is called each time an operation fails,
when destroying the proxy_client, we stop all operations so it fails.

Fix #257