### PR TITLE
proxy: remove useless callback_id

### DIFF
--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -354,12 +354,11 @@ private:
      * NOTE: empty by default to avoid to use services like FCM or APN.
      */
     std::string deviceKey_ {};
-    std::atomic_uint callbackId_ {0};
 
     const std::function<void()> loopSignal_;
 
 #if OPENDHT_PUSH_NOTIFICATIONS
-    void fillBodyToGetToken(std::shared_ptr<restbed::Request> request, unsigned callbackId);
+    void fillBodyToGetToken(std::shared_ptr<restbed::Request> request, unsigned token = 0);
 #endif // OPENDHT_PUSH_NOTIFICATIONS
 
     bool isDestroying_ {false};

--- a/include/opendht/dht_proxy_server.h
+++ b/include/opendht/dht_proxy_server.h
@@ -183,24 +183,18 @@ private:
     /**
      * Subscribe to push notifications for an iOS or Android device.
      * Method: SUBSCRIBE "/{InfoHash: .*}"
-     * Body: {"key": "device_key", (optional)"callback_id":y,
-     * (optional)"isAndroid":false (default true)}"
+     * Body: {"key": "device_key", (optional)"isAndroid":false (default true)}"
      * Return: {"token": x}" where x if a token to save
      * @note: the listen will timeout after six hours (and send a push notification).
      * so you need to refresh the operation each six hours.
-     * @note: callback_id is used to add the possibility to have multiple listen
-     * on same hash for same device and must be > 0
      * @param session
      */
     void subscribe(const std::shared_ptr<restbed::Session>& session);
     /**
      * Unsubscribe to push notifications for an iOS or Android device.
      * Method: UNSUBSCRIBE "/{InfoHash: .*}"
-     * Body: {"key": "device_key", "token": x, (optional)"callback_id":y"
-     * where x if the token to cancel
+     * Body: {"key": "device_key", "token": x} where x if the token to cancel
      * Return: nothing
-     * @note: callback id is used to add the possibility to have multiple listen
-     * on same hash for same device
      * @param session
      */
     void unsubscribe(const std::shared_ptr<restbed::Session>& session);
@@ -247,7 +241,7 @@ private:
     std::map<std::string, PushListener> pushListeners_;
     unsigned tokenPushNotif_ {0};
 
-    void cancelPushListen(const std::string& pushToken, const InfoHash& key, unsigned token, unsigned callbackId);
+    void cancelPushListen(const std::string& pushToken, const InfoHash& key, unsigned token);
 #endif //OPENDHT_PUSH_NOTIFICATIONS
     const std::string pushServer_;
 

--- a/tools/dhtnode.cpp
+++ b/tools/dhtnode.cpp
@@ -73,7 +73,7 @@ void print_help() {
 #if OPENDHT_PUSH_NOTIFICATIONS
               << "  stt [server_address] <device_key> Start the proxy client." << std::endl
               << "  rs  [token]                       Resubscribe to opendht." << std::endl
-              << "  rp  [push_notification]           Inject a push notification in Opendht." << std::endl
+              << "  rp  [token]                       Inject a push notification in Opendht." << std::endl
 #else
               << "  stt [server_address]              Start the proxy client." << std::endl
 #endif // OPENDHT_PUSH_NOTIFICATIONS
@@ -237,7 +237,7 @@ void cmd_loop(std::shared_ptr<DhtRunner>& dht, dht_params& params
 #if OPENDHT_PUSH_NOTIFICATIONS
         else if (op == "rp") {
             iss >> value;
-            dht->pushNotificationReceived({{"token", value}});
+            dht->pushNotificationReceived({{"to", "dhtnode"}, {"token", value}});
             continue;
         }
 #endif // OPENDHT_PUSH_NOTIFICATIONS


### PR DESCRIPTION
callback_id was used for token problems which are not present anymore.
Now token is sufficient and we can remove callback_id.

fix #246