### PR TITLE
proxy: remove useless token for push listeners

### DIFF
--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -281,7 +281,7 @@ private:
 
     struct ListenState;
     void sendListen(const std::shared_ptr<restbed::Request>& request, const ValueCallback&, const Value::Filter& filter, const Sp<ListenState>& state);
-    void sendSubscribe(const std::shared_ptr<restbed::Request>& request, const Sp<proxy::ListenToken>&, const Sp<ListenState>& state);
+    void sendSubscribe(const std::shared_ptr<restbed::Request>& request, const Sp<ListenState>& state);
 
     void doPut(const InfoHash&, Sp<Value>, DoneCallback, time_point created, bool permanent);
 
@@ -373,7 +373,7 @@ private:
     const std::function<void()> loopSignal_;
 
 #if OPENDHT_PUSH_NOTIFICATIONS
-    void fillBodyToGetToken(std::shared_ptr<restbed::Request> request, unsigned token = 0);
+    void fillBody(std::shared_ptr<restbed::Request> request);
     void getPushRequest(Json::Value&) const;
 #endif // OPENDHT_PUSH_NOTIFICATIONS
 


### PR DESCRIPTION
Since we authentificate listeners with the clientId and the hash and
we use only one listener by hash/clientId, we doesn't need to store
a token always equals to 0.

Note: also avoid to get multiple hashes for one push notification.