### PR TITLE
dht_proxy_server: avoid mutex when getting /

### DIFF
--- a/include/opendht/dht_proxy_server.h
+++ b/include/opendht/dht_proxy_server.h
@@ -21,12 +21,13 @@
 
 #pragma once
 
+#include "callbacks.h"
 #include "def.h"
-#include "sockaddr.h"
 #include "infohash.h"
-#include "scheduler.h"
-#include "value.h"
 #include "proxy.h"
+#include "scheduler.h"
+#include "sockaddr.h"
+#include "value.h"
 
 #include <thread>
 #include <memory>
@@ -237,6 +238,9 @@ private:
     std::thread schedulerThread_;
 
     Sp<Scheduler::Job> printStatsJob_;
+    mutable std::mutex statsMutex_;
+    mutable NodeStats ipv4Stats_ {};
+    mutable NodeStats ipv6Stats_ {};
 
     // Handle client quit for listen.
     // NOTE: can be simplified when we will supports restbed 5.0


### PR DESCRIPTION
dht_proxy_server: avoid mutex when getting /

The dht_proxy_server should be always up, so getNodesStats will
be pretty always up-to-date. We can add it into a job and avoid
to wait for this method to finish (and this method use an
internal lock) to have a quick answer about the status of the proxy.

Note: the update is forced during the initialization of the proxy
