### PR TITLE
dht: permanent put improvements and fix

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -409,7 +409,8 @@ private:
 
     // Storage
     void storageAddListener(const InfoHash& id, const Sp<Node>& node, size_t tid, Query&& = {});
-    bool storageStore(const InfoHash& id, const Sp<Value>& value, time_point created, const SockAddr& sa = {});
+    bool storageStore(const InfoHash& id, const Sp<Value>& value, time_point created, const SockAddr& sa = {}, bool permanent = false);
+    bool storageErase(const InfoHash& id, Value::Id vid);
     void expireStore();
     void expireStorage(InfoHash h);
     void expireStore(decltype(store)::iterator);

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -261,11 +261,11 @@ void Dht::paginate(std::weak_ptr<Search> ws, Sp<Query> query, SearchNode* n) {
     auto select_q = std::make_shared<Query>(Select {}.field(Value::Field::Id), query ? query->where : Where {});
     auto onSelectDone = [this,ws,query](const net::Request& status,
                                         net::RequestAnswer&& answer) mutable {
-        // retreive search
+        // Retrieve search
         auto sr = ws.lock();
         if (not sr) return;
         const auto& id = sr->id;
-        // retreive search node
+        // Retrieve search node
         auto sn = sr->getNode(status.node);
         if (not sn) return;
         // backward compatibility

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -2363,7 +2363,10 @@ Dht::onRefresh(Sp<Node> node, const InfoHash& hash, const Blob& token, const Val
     }
 
     auto s = store.find(hash);
-    if (s != store.end() and s->second.refresh(now, vid)) {
+    if (s != store.end()) {
+        auto expiration = s->second.refresh(now, vid, types);
+        if (expiration != time_point::max())
+            scheduler.add(expiration, std::bind(&Dht::expireStorage, this, hash));
         DHT_LOG.d(hash, node->id, "[store %s] [node %s] refreshed value %s", hash.toString().c_str(), node->toString().c_str(), std::to_string(vid).c_str());
     } else {
         DHT_LOG.d(hash, node->id, "[store %s] [node %s] got refresh for unknown value",

--- a/src/search.h
+++ b/src/search.h
@@ -320,7 +320,7 @@ struct Dht::SearchNode {
     }
 
     /**
-     * Assumng the node is synced, should a "put" request be sent to this node now ?
+     * Assuming the node is synced, should a "put" request be sent to this node now ?
      */
     time_point getAnnounceTime(Value::Id vid) const {
         const auto& ack = acked.find(vid);
@@ -335,7 +335,7 @@ struct Dht::SearchNode {
     }
 
     /**
-     * Assumng the node is synced, should the "listen" request with Query q be
+     * Assuming the node is synced, should the "listen" request with Query q be
      * sent to this node now ?
      */
     time_point getListenTime(const Sp<Query>& q) const {

--- a/src/storage.h
+++ b/src/storage.h
@@ -154,15 +154,16 @@ struct Storage {
      *
      * @param now  The reference to now
      * @param vid  The value id
-     * @return true if a value storage was updated, false otherwise
+     * @return time of the next expiration, time_point::max() if no expiration
      */
-    bool refresh(const time_point& now, const Value::Id& vid) {
+    time_point refresh(const time_point& now, const Value::Id& vid, const TypeStore& types) {
         for (auto& vs : values)
             if (vs.data->id == vid) {
                 vs.created = now;
-                return true;
+                vs.expiration = std::max(vs.expiration, now + types.getType(vs.data->type).expiration);
+                return vs.expiration;
             }
-        return false;
+        return time_point::max();
     }
 
     StoreDiff remove(const InfoHash& id, Value::Id);


### PR DESCRIPTION
Fix 3 issues with permanent put:
* store: don't expire permanent values from local storage
* refresh: properly refresh "expiration" field in ValueStorage and reschedule value expiration
* search: reschedule permanent values announce for next expiration