### PR TITLE
proxy_server: return old values when resubscribe

### DIFF
--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -281,7 +281,7 @@ private:
 
     struct ListenState;
     void sendListen(const std::shared_ptr<restbed::Request>& request, const ValueCallback&, const Value::Filter& filter, const Sp<ListenState>& state);
-    void sendSubscribe(const std::shared_ptr<restbed::Request>& request, const Sp<ListenState>& state);
+    void sendSubscribe(const std::shared_ptr<restbed::Request>& request, const ValueCallback&, const Value::Filter& filter, const Sp<ListenState>& state);
 
     void doPut(const InfoHash&, Sp<Value>, DoneCallback, time_point created, bool permanent);
 

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -430,6 +430,15 @@ DhtProxyServer::subscribe(const std::shared_ptr<restbed::Session>& session)
                             scheduler_.edit(listener.expireNotifyJob, timeout - proxy::OP_MARGIN);
                             s->close(restbed::OK, "{}\n");
                             schedulerCv_.notify_one();
+                            dht_->get(infoHash,
+                                [this, infoHash, pushToken, isAndroid, clientId](std::vector<std::shared_ptr<Value>> /*value*/) {
+                                    // Build message content.
+                                    Json::Value json;
+                                    json["key"] = infoHash.toString();
+                                    json["to"] = clientId;
+                                    sendPushNotification(pushToken, json, isAndroid);
+                                    return true;
+                                }, [](bool /*ok* */) {});
                             return;
                         }
                     }


### PR DESCRIPTION
This patch is the first part to fix the presence when the android client is using the proxy.

Like a normal listen, we should be able to retrieve old values.