### PR TITLE
Fix/get after listen

### DIFF
--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -280,8 +280,7 @@ private:
     bool doCancelListen(const InfoHash& key, size_t token);
 
     struct ListenState;
-    void sendListen(const std::shared_ptr<restbed::Request>& request, const ValueCallback&, const Value::Filter& filter, const Sp<ListenState>& state);
-    void sendSubscribe(const std::shared_ptr<restbed::Request>& request, const ValueCallback&, const Value::Filter& filter, const Sp<ListenState>& state);
+    void sendListen(const std::shared_ptr<restbed::Request>& request, const ValueCallback&, const Value::Filter& filter, const Sp<ListenState>& state, bool usePush = false);
 
     void doPut(const InfoHash&, Sp<Value>, DoneCallback, time_point created, bool permanent);
 

--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -281,7 +281,7 @@ private:
 
     struct ListenState;
     void sendListen(const std::shared_ptr<restbed::Request>& request, const ValueCallback&, const Value::Filter& filter, const Sp<ListenState>& state);
-    void sendSubscribe(const std::shared_ptr<restbed::Request>& request, const Sp<ListenState>& state);
+    void sendSubscribe(const std::shared_ptr<restbed::Request>& request, const ValueCallback&, const Value::Filter& filter, const Sp<ListenState>& state);
 
     void doPut(const InfoHash&, Sp<Value>, DoneCallback, time_point created, bool permanent);
 

--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -750,19 +750,62 @@ DhtProxyClient::sendListen(const std::shared_ptr<restbed::Request>& req, const V
 }
 
 void
-DhtProxyClient::sendSubscribe(const std::shared_ptr<restbed::Request>& req, const Sp<ListenState>& state) {
+DhtProxyClient::sendSubscribe(const std::shared_ptr<restbed::Request>& req, const ValueCallback& cb, const Value::Filter& filter, const Sp<ListenState>& state) {
 #if OPENDHT_PUSH_NOTIFICATIONS
     req->set_method("SUBSCRIBE");
     try {
         fillBody(req);
-        restbed::Http::async(req, [this,state](const std::shared_ptr<restbed::Request>&,
-                                                const std::shared_ptr<restbed::Response>& reply) {
+        restbed::Http::async(req, [this, state, cb, filter, req](const std::shared_ptr<restbed::Request>&,
+                                                                 const std::shared_ptr<restbed::Response>& reply) {
+
             auto code = reply->get_status_code();
             if (code == 200) {
                 try {
-                    restbed::Http::fetch("\n", reply);
-                    auto code = reply->get_status_code();
-                    state->ok = code == 200;
+                        DHT_LOG.e("################1.");
+                    while (restbed::Http::is_open(req) and not state->cancel) {
+                        DHT_LOG.e("################2.");
+                        restbed::Http::fetch("\n", reply);
+                        DHT_LOG.e("################3.");
+                        auto code = reply->get_status_code();
+                        DHT_LOG.e("################4.");
+                        state->ok = code == 200;
+                        if (state->cancel) {
+                            DHT_LOG.e("################5.");
+
+                            break;
+                        }
+                        std::string body;
+                        reply->get_body(body);
+                        reply->set_body(""); // Reset the body for the next fetch
+                        DHT_LOG.e("###BODY: %s\n", body.c_str());;
+                        if (body.empty() || body == "{}") {
+                            DHT_LOG.e("################6.");
+                            break;
+
+                        }
+                        DHT_LOG.e("################7.");
+
+                        Json::Value json;
+                        std::string err;
+                        Json::CharReaderBuilder rbuilder;
+                        auto reader = std::unique_ptr<Json::CharReader>(rbuilder.newCharReader());
+                        if (reader->parse(body.data(), body.data() + body.size(), &json, &err)) {
+                            if (json.size() == 0) {
+                                DHT_LOG.e("################*.");
+                                break;
+                            }
+                            auto expired = json.get("expired", Json::Value(false)).asBool();
+                            auto value = std::make_shared<Value>(json);
+                            if ((not filter or filter(*value)) and cb)  {
+                                std::lock_guard<std::mutex> lock(lockCallbacks);
+                                callbacks_.emplace_back([cb, value, state, expired]() {
+                                    if (not state->cancel and not cb({value}, expired))
+                                        state->cancel = true;
+                                });
+                                loopSignal_();
+                            }
+                        }
+                    }
                 } catch (const std::exception& e) {
                     if (not state->cancel) {
                         DHT_LOG.e("sendSubscribe: error: %s", e.what());
@@ -864,12 +907,14 @@ DhtProxyClient::doListen(const InfoHash& key, ValueCallback cb, Value::Filter fi
                 }
             }
         });
-        l->second.thread = std::thread([this, req, state](){
-            sendSubscribe(req, state);
+        auto vcb = l->second.cb;
+        auto filter = l->second.filter;
+        l->second.thread = std::thread([this, req, vcb, filter, state](){
+            sendSubscribe(req, vcb, filter, state);
         });
     } else {
         l->second.thread = std::thread([this, req, vcb, filter, state]{
-            sendListen(req,vcb,filter,state);
+            sendListen(req, vcb, filter, state);
         });
     }
     return token;
@@ -1080,8 +1125,10 @@ DhtProxyClient::resubscribe(const InfoHash& key, Listener& listener)
     state->ok = true;
     listener.req = req;
     scheduler.edit(listener.refreshJob, scheduler.time() + proxy::OP_TIMEOUT - proxy::OP_MARGIN);
-    listener.thread = std::thread([this, req, state]() {
-        sendSubscribe(req, state);
+    auto vcb = listener.cb;
+    auto filter = listener.filter;
+    listener.thread = std::thread([this, req, vcb, filter, state]() {
+        sendSubscribe(req, vcb, filter, state);
     });
 #endif
 }

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -430,6 +430,15 @@ DhtProxyServer::subscribe(const std::shared_ptr<restbed::Session>& session)
                             scheduler_.edit(listener.expireNotifyJob, timeout - proxy::OP_MARGIN);
                             s->close(restbed::OK, "{}\n");
                             schedulerCv_.notify_one();
+                            dht_->get(infoHash,
+                                [this, infoHash, pushToken, isAndroid, clientId](std::vector<std::shared_ptr<Value>> /*value*/) {
+                                    // Build message content.
+                                    Json::Value json;
+                                    json["key"] = infoHash.toString();
+                                    json["to"] = clientId;
+                                    sendPushNotification(pushToken, json, isAndroid);
+                                    return true;
+                                }, [](bool /*ok* */) {});
                             return;
                         }
                     }

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -558,6 +558,8 @@ DhtProxyServer::cancelPushListen(const std::string& pushToken, const dht::InfoHa
 void
 DhtProxyServer::sendPushNotification(const std::string& token, const Json::Value& json, bool isAndroid) const
 {
+    if (pushServer_.empty())
+        return;
     restbed::Uri uri(proxy::HTTP_PROTO + pushServer_ + "/api/push");
     auto req = std::make_shared<restbed::Request>(uri);
     req->set_method("POST");

--- a/tests/dhtproxytester.h
+++ b/tests/dhtproxytester.h
@@ -32,6 +32,7 @@ class DhtProxyTester : public CppUnit::TestFixture {
     CPPUNIT_TEST_SUITE(DhtProxyTester);
     CPPUNIT_TEST(testGetPut);
     CPPUNIT_TEST(testListen);
+    CPPUNIT_TEST(testResubscribeGetValues);
     CPPUNIT_TEST_SUITE_END();
 
  public:
@@ -39,19 +40,25 @@ class DhtProxyTester : public CppUnit::TestFixture {
      * Method automatically called before each test by CppUnit
      * Init nodes
      */
-    void setUp();
+   void setUp();
     /**
      * Method automatically called after each test CppUnit
      */
-    void tearDown();
+   void tearDown();
     /**
      * Test get and put methods
      */
-    void testGetPut();
+   void testGetPut();
     /**
      * Test listen
      */
-    void testListen();
+   void testListen();
+
+   /**
+    * When a proxy redo a subscribe on the proxy
+    * it should retrieve existant values
+    */
+   void testResubscribeGetValues();
 
  private:
     dht::DhtRunner nodePeer {};


### PR DESCRIPTION
This patch is the first part to fix the presence when the android client is using the proxy.

Like a normal listen, we should be able to retrieve old values.