### PR TITLE
peerdiscovery: modify to add support for sending and receiving msgpack

### DIFF
--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -278,7 +278,7 @@ public:
     /**
      * Insert known nodes to the routing table by using the received msgpack
      */
-    void nodeInsertionCallback(std::string& type, msgpack::object&& sbuf, SockAddr& add);
+    void nodeInsertionCallback(msgpack::object&& sbuf, SockAddr& add);
 
     /**
      * Fill up the callback map for Peerdiscovery
@@ -558,8 +558,9 @@ private:
     /** PeerDiscovery Parameters */
     std::unique_ptr<PeerDiscovery> peerDiscovery4_;
     std::unique_ptr<PeerDiscovery> peerDiscovery6_;
+    const std::string pack_type_ {"dht"};
     NetId current_node_netid_;
-    std::map<std::string,std::function<void(std::string&, msgpack::object&&, SockAddr&)>> callbackmap_;
+    std::map<std::string,std::function<void(msgpack::object&&, SockAddr&)>> callbackmap_;
 
 };
 

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -42,6 +42,13 @@ struct Node;
 class SecureDht;
 class PeerDiscovery;
 struct SecureDhtConfig;
+class OPENDHT_PUBLIC NodeInsertionPack{
+public:
+    dht::InfoHash nodeid_;
+    in_port_t node_port_;
+    dht::NetId nid_;
+    MSGPACK_DEFINE(nodeid_, node_port_, nid_)
+};
 
 /**
  * Provides a thread-safe interface to run the (secure) DHT.
@@ -267,6 +274,16 @@ public:
      * Usefull to restart a node and get things running fast without putting load on the network.
      */
     void bootstrap(const InfoHash& id, const SockAddr& address);
+
+    /**
+     * Insert known nodes to the routing table by using the received msgpack
+     */
+    void nodeInsertionCallback(std::string& type, msgpack::object&& sbuf, SockAddr& add);
+
+    /**
+     * Fill up the callback map for Peerdiscovery
+     */
+    void callbackmapFill();
 
     /**
      * Clear the list of bootstrap added using bootstrap(const std::string&, const std::string&).
@@ -541,6 +558,9 @@ private:
     /** PeerDiscovery Parameters */
     std::unique_ptr<PeerDiscovery> peerDiscovery4_;
     std::unique_ptr<PeerDiscovery> peerDiscovery6_;
+    NetId current_node_netid_;
+    std::map<std::string,std::function<void(std::string&, msgpack::object&&, SockAddr&)>> callbackmap_;
+
 };
 
 }

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -271,12 +271,7 @@ public:
     /**
      * Insert known nodes to the routing table by using the received msgpack
      */
-    void nodeInsertionCallback(msgpack::object&& sbuf, SockAddr& add);
-
-    /**
-     * Fill up the callback map for Peerdiscovery
-     */
-    void callbackmapFill();
+    void nodeInsertionCallback(msgpack::object&& sbuf, SockAddr&& add);
 
     /**
      * Clear the list of bootstrap added using bootstrap(const std::string&, const std::string&).

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -544,8 +544,7 @@ private:
     std::string pushToken_;
 
     /** PeerDiscovery Parameters */
-    std::unique_ptr<PeerDiscovery> peerDiscovery4_;
-    std::unique_ptr<PeerDiscovery> peerDiscovery6_;
+    std::unique_ptr<PeerDiscovery> peerDiscovery_;
     NetId current_node_netid_;
 
 };

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -42,13 +42,6 @@ struct Node;
 class SecureDht;
 class PeerDiscovery;
 struct SecureDhtConfig;
-class OPENDHT_PUBLIC NodeInsertionPack{
-public:
-    dht::InfoHash nodeid_;
-    in_port_t node_port_;
-    dht::NetId nid_;
-    MSGPACK_DEFINE(nodeid_, node_port_, nid_)
-};
 
 /**
  * Provides a thread-safe interface to run the (secure) DHT.
@@ -558,9 +551,7 @@ private:
     /** PeerDiscovery Parameters */
     std::unique_ptr<PeerDiscovery> peerDiscovery4_;
     std::unique_ptr<PeerDiscovery> peerDiscovery6_;
-    const std::string pack_type_ {"dht"};
     NetId current_node_netid_;
-    std::map<std::string,std::function<void(msgpack::object&&, SockAddr&)>> callbackmap_;
 
 };
 

--- a/include/opendht/peer_discovery.h
+++ b/include/opendht/peer_discovery.h
@@ -32,19 +32,19 @@ class OPENDHT_PUBLIC PeerDiscovery
 {
 public:
 
-    using PeerDiscoveredPackCallback = std::function<void(std::string&, msgpack::object&&, SockAddr&)>;
+    using PeerDiscoveredPackCallback = std::function<void(msgpack::object&&, SockAddr&)>;
     PeerDiscovery(sa_family_t domain, in_port_t port);
     ~PeerDiscovery();
 
     /**
      * startDiscovery - Keep Listening data from the sender until node is joinned or stop is called
     */
-    void startDiscovery(PeerDiscoveredPackCallback callback);
+    void startDiscovery(const std::string &type, PeerDiscoveredPackCallback callback);
 
     /**
      * startPublish - Keeping sending data until node is joinned or stop is called - msgpack
     */
-    void startPublish(const std::string &type, msgpack::sbuffer && pack_buf, const dht::InfoHash &nodeId);
+    void startPublish(const std::string &type, msgpack::sbuffer && pack_buf);
 
     /**
      * Thread Stopper
@@ -106,7 +106,7 @@ private:
     /**
      * Listener pack thread loop
     */
-    void listenerpack_thread(PeerDiscoveredPackCallback callback);
+    void listenerpack_thread(const std::string &type, PeerDiscoveredPackCallback callback);
 
     /**
      * Listener Parameters Setup
@@ -116,7 +116,7 @@ private:
     /**
      * Sender Parameters Setup
     */
-    void sender_setup(const std::string &type, msgpack::sbuffer && pack_buf, const dht::InfoHash &nodeId);
+    void sender_setup(const std::string &type, msgpack::sbuffer && pack_buf);
 };
 
 }

--- a/include/opendht/peer_discovery.h
+++ b/include/opendht/peer_discovery.h
@@ -84,10 +84,13 @@ public:
     */
 
 private:
+    //dmtx_ for callbackmap_ and drunning_ (write)
     std::mutex dmtx_;
+    //mtx_ for messages_ and lrunning (listen)
     std::mutex mtx_;
     std::condition_variable cv_;
-    bool running_ {false};
+    bool lrunning_ {false};
+    bool drunning_ {false};
     sa_family_t domain_ {AF_UNSPEC};
     int port_;
     int sockfd_ {-1};

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -967,10 +967,14 @@ DhtRunner::bootstrap(const InfoHash& id, const SockAddr& address)
 void 
 DhtRunner::nodeInsertionCallback(msgpack::object&& obj, SockAddr&& add)
 {
-    auto v = obj.as<NodeInsertionPack>();
-    add.setPort(v.node_port_);
-    if(v.nodeid_ != dht_->getNodeId() && current_node_netid_ == v.nid_){
-        bootstrap(v.nodeid_, add);
+    try {
+        auto v = obj.as<NodeInsertionPack>();
+        add.setPort(v.node_port_);
+        if(v.nodeid_ != dht_->getNodeId() && current_node_netid_ == v.nid_){
+            bootstrap(v.nodeid_, add);
+        }
+    } catch(const msgpack::type_error &e){
+        std::cerr << "Msgpack Info Invalid: " << e.what() << '\n';
     }
 }
 

--- a/tests/peerdiscoverytester.cpp
+++ b/tests/peerdiscoverytester.cpp
@@ -29,6 +29,7 @@ void PeerDiscoveryTester::setUp(){}
 void PeerDiscoveryTester::testTransmission_ipv4(){
 
     // Node for getnode id
+    const std::string type {"dht"};
     dht::InfoHash data_n = dht::InfoHash::get("applepin");
     int port = 2222;
     in_port_t port_n = 50000;
@@ -43,13 +44,13 @@ void PeerDiscoveryTester::testTransmission_ipv4(){
         dht::PeerDiscovery test_n(AF_INET, port);
         dht::PeerDiscovery test_s(AF_INET, port);
         try{
-            test_s.startDiscovery([&](std::string& type, msgpack::object&& obj, dht::SockAddr& add){
+            test_s.startDiscovery(type,[&](msgpack::object&& obj, dht::SockAddr& add){
                 auto v = obj.as<dht::NodeInsertionPack>();
                 CPPUNIT_ASSERT_EQUAL(v.node_port_, port_n);
                 CPPUNIT_ASSERT_EQUAL(v.nodeid_, data_n);
             });
 
-            test_n.startPublish("dht", std::move(sbuf),data_n);
+            test_n.startPublish(type, std::move(sbuf));
 
             std::this_thread::sleep_for(std::chrono::seconds(5));
             test_n.stop();
@@ -68,6 +69,7 @@ void PeerDiscoveryTester::testTransmission_ipv4(){
 void PeerDiscoveryTester::testTransmission_ipv6(){
 
     // Node for getnode id
+    const std::string type {"dht"};
     dht::InfoHash data_n = dht::InfoHash::get("applepin");
     int port = 2222;
     in_port_t port_n = 50000;
@@ -82,13 +84,13 @@ void PeerDiscoveryTester::testTransmission_ipv6(){
         dht::PeerDiscovery test_n(AF_INET6, port);
         dht::PeerDiscovery test_s(AF_INET6, port);
         try{
-            test_s.startDiscovery([&](std::string& type, msgpack::object&& obj, dht::SockAddr& add){
+            test_s.startDiscovery(type,[&](msgpack::object&& obj, dht::SockAddr& add){
                 auto v = obj.as<dht::NodeInsertionPack>();
                 CPPUNIT_ASSERT_EQUAL(v.node_port_, port_n);
                 CPPUNIT_ASSERT_EQUAL(v.nodeid_, data_n);
             });
 
-            test_n.startPublish("dht", std::move(sbuf),data_n);
+            test_n.startPublish(type, std::move(sbuf));
 
             std::this_thread::sleep_for(std::chrono::seconds(5));
             test_n.stop();

--- a/tests/peerdiscoverytester.cpp
+++ b/tests/peerdiscoverytester.cpp
@@ -17,8 +17,8 @@
  *  along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "opendht/value.h"
 #include "peerdiscoverytester.h"
-#include "opendht/dhtrunner.h"
 
 namespace test {
 
@@ -52,7 +52,7 @@ void PeerDiscoveryTester::testTransmission_ipv4(){
         dht::PeerDiscovery test_n(AF_INET, port);
         dht::PeerDiscovery test_s(AF_INET, port);
         try{
-            test_s.startDiscovery(type,[&](msgpack::object&& obj, dht::SockAddr& add){
+            test_s.startDiscovery(type,[&](msgpack::object&& obj, dht::SockAddr&& add){
                 auto v = obj.as<NodeInsertion>();
                 CPPUNIT_ASSERT_EQUAL(v.node_port_, port_n);
                 CPPUNIT_ASSERT_EQUAL(v.nodeid_, data_n);
@@ -92,7 +92,7 @@ void PeerDiscoveryTester::testTransmission_ipv6(){
         dht::PeerDiscovery test_n(AF_INET6, port);
         dht::PeerDiscovery test_s(AF_INET6, port);
         try{
-            test_s.startDiscovery(type,[&](msgpack::object&& obj, dht::SockAddr& add){
+            test_s.startDiscovery(type,[&](msgpack::object&& obj, dht::SockAddr&& add){
                 auto v = obj.as<NodeInsertion>();
                 CPPUNIT_ASSERT_EQUAL(v.node_port_, port_n);
                 CPPUNIT_ASSERT_EQUAL(v.nodeid_, data_n);

--- a/tests/peerdiscoverytester.cpp
+++ b/tests/peerdiscoverytester.cpp
@@ -42,7 +42,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(PeerDiscoveryTester);
 
 void PeerDiscoveryTester::setUp(){}
 
-void PeerDiscoveryTester::testTransmission_ipv4(){
+void PeerDiscoveryTester::testTransmission(){
 
     // Node for getnode id
     const std::string type {"dht"};
@@ -66,67 +66,8 @@ void PeerDiscoveryTester::testTransmission_ipv4(){
     msgpack::pack(pbuf,pdd);
 
     try{
-        dht::PeerDiscovery test_n(AF_INET, port);
-        dht::PeerDiscovery test_s(AF_INET, port);
-        try{
-            test_s.startDiscovery(type,[&](msgpack::object&& obj, dht::SockAddr&& add){
-                auto v = obj.as<NodeInsertion>();
-                CPPUNIT_ASSERT_EQUAL(v.node_port_, port_n);
-                CPPUNIT_ASSERT_EQUAL(v.nodeid_, data_n);
-            });
-
-            test_s.startDiscovery(test_type,[&](msgpack::object&& obj, dht::SockAddr&& add){
-                auto v = obj.as<TestPack>();
-                CPPUNIT_ASSERT_EQUAL(v.num, 100);
-                CPPUNIT_ASSERT_EQUAL(v.cha, 'a');
-            });
-
-            test_n.startPublish(type, sbuf);
-            std::this_thread::sleep_for(std::chrono::seconds(5));
-            test_n.startPublish(test_type, pbuf);
-            std::this_thread::sleep_for(std::chrono::seconds(5));
-            test_n.stopPublish(test_type);
-
-            std::this_thread::sleep_for(std::chrono::seconds(10));
-            test_n.stop();
-            test_s.stop();
-            test_n.join();
-            test_s.join();
-        } catch(std::exception &exception){
-            perror(exception.what());
-            CPPUNIT_ASSERT(false);
-        }
-    } catch(std::exception &exception){
-            perror(exception.what());
-    }
-}
-
-void PeerDiscoveryTester::testTransmission_ipv6(){
-
-     // Node for getnode id
-    const std::string type {"dht"};
-    const std::string test_type {"pdd"};
-    dht::InfoHash data_n = dht::InfoHash::get("applepin");
-    int port = 2222;
-    in_port_t port_n = 50000;
-
-    msgpack::sbuffer sbuf;
-    NodeInsertion adc;
-    adc.nid_ = 10;
-    adc.node_port_ = port_n;
-    adc.nodeid_ = data_n;
-    msgpack::pack(sbuf,adc);
-
-    msgpack::sbuffer pbuf;
-    TestPack pdd;
-    pdd.num = 100;
-    pdd.cha = 'a';
-    pdd.str = "apple";
-    msgpack::pack(pbuf,pdd);
-
-    try{
-        dht::PeerDiscovery test_n(AF_INET6, port);
-        dht::PeerDiscovery test_s(AF_INET6, port);
+        dht::PeerDiscovery test_n(port);
+        dht::PeerDiscovery test_s(port);
         try{
             test_s.startDiscovery(type,[&](msgpack::object&& obj, dht::SockAddr&& add){
                 auto v = obj.as<NodeInsertion>();

--- a/tests/peerdiscoverytester.cpp
+++ b/tests/peerdiscoverytester.cpp
@@ -22,6 +22,14 @@
 
 namespace test {
 
+class NodeInsertion{
+public:
+    dht::InfoHash nodeid_;
+    in_port_t node_port_;
+    dht::NetId nid_;
+    MSGPACK_DEFINE(nodeid_, node_port_, nid_)
+};
+
 CPPUNIT_TEST_SUITE_REGISTRATION(PeerDiscoveryTester);
 
 void PeerDiscoveryTester::setUp(){}
@@ -35,7 +43,7 @@ void PeerDiscoveryTester::testTransmission_ipv4(){
     in_port_t port_n = 50000;
     dht::NetId netid = 10;
     msgpack::sbuffer sbuf;
-    dht::NodeInsertionPack adc;
+    NodeInsertion adc;
     adc.nid_ = 10;
     adc.node_port_ = port_n;
     adc.nodeid_ = data_n;
@@ -45,12 +53,12 @@ void PeerDiscoveryTester::testTransmission_ipv4(){
         dht::PeerDiscovery test_s(AF_INET, port);
         try{
             test_s.startDiscovery(type,[&](msgpack::object&& obj, dht::SockAddr& add){
-                auto v = obj.as<dht::NodeInsertionPack>();
+                auto v = obj.as<NodeInsertion>();
                 CPPUNIT_ASSERT_EQUAL(v.node_port_, port_n);
                 CPPUNIT_ASSERT_EQUAL(v.nodeid_, data_n);
             });
 
-            test_n.startPublish(type, std::move(sbuf));
+            test_n.startPublish(type, sbuf);
 
             std::this_thread::sleep_for(std::chrono::seconds(5));
             test_n.stop();
@@ -75,7 +83,7 @@ void PeerDiscoveryTester::testTransmission_ipv6(){
     in_port_t port_n = 50000;
     dht::NetId netid = 10;
     msgpack::sbuffer sbuf;
-    dht::NodeInsertionPack adc;
+    NodeInsertion adc;
     adc.nid_ = 10;
     adc.node_port_ = port_n;
     adc.nodeid_ = data_n;
@@ -85,12 +93,12 @@ void PeerDiscoveryTester::testTransmission_ipv6(){
         dht::PeerDiscovery test_s(AF_INET6, port);
         try{
             test_s.startDiscovery(type,[&](msgpack::object&& obj, dht::SockAddr& add){
-                auto v = obj.as<dht::NodeInsertionPack>();
+                auto v = obj.as<NodeInsertion>();
                 CPPUNIT_ASSERT_EQUAL(v.node_port_, port_n);
                 CPPUNIT_ASSERT_EQUAL(v.nodeid_, data_n);
             });
 
-            test_n.startPublish(type, std::move(sbuf));
+            test_n.startPublish(type, sbuf);
 
             std::this_thread::sleep_for(std::chrono::seconds(5));
             test_n.stop();

--- a/tests/peerdiscoverytester.h
+++ b/tests/peerdiscoverytester.h
@@ -26,11 +26,10 @@
 
 namespace test {
 
-class PeerDiscoveryTester : public CppUnit::TestFixture {
+class OPENDHT_PUBLIC PeerDiscoveryTester : public CppUnit::TestFixture {
 
     CPPUNIT_TEST_SUITE(PeerDiscoveryTester);
-    CPPUNIT_TEST(testTransmission_ipv4);
-    CPPUNIT_TEST(testTransmission_ipv6);
+    CPPUNIT_TEST(testTransmission);
     CPPUNIT_TEST_SUITE_END();
 
  public:
@@ -45,12 +44,7 @@ class PeerDiscoveryTester : public CppUnit::TestFixture {
     /**
      * Test Multicast Transmission Ipv4
      */
-    void testTransmission_ipv4();
-    /**
-     * Test Multicast Transmission Ipv6
-     */
-    void testTransmission_ipv6();
-
+    void testTransmission();
 };
 
 }  // namespace test


### PR DESCRIPTION
Remove the original functions, add the NodeInsertPack msgpack to support the generic transmission need for Jami account & opendht 