### PR TITLE
docker: fix old deps & patch ssl renegotiation only if supported

### DIFF
--- a/docker/DockerfileDeps
+++ b/docker/DockerfileDeps
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
 RUN echo "*** Installing libfmt ***" \
     && wget https://github.com/fmtlib/fmt/archive/5.3.0.tar.gz \
     && tar -xzf 5.3.0.tar.gz && cd fmt-5.3.0/ \
-    && cmake -DCMAKE_INSTALL_PREFIX=/usr . \
+    && cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=On . \
     && make -j8 && make install \
     && cd ../ && rm -rf fmt*
 

--- a/docker/DockerfileDeps
+++ b/docker/DockerfileDeps
@@ -3,31 +3,45 @@ MAINTAINER Adrien Béraud <adrien.beraud@savoirfairelinux.com>
 RUN apt-get update && apt-get install -y \
         build-essential cmake git wget libncurses5-dev libreadline-dev nettle-dev \
         libgnutls28-dev libuv1-dev cython3 python3-dev libcppunit-dev libjsoncpp-dev \
-    && apt-get clean
-
-RUN echo "*** Installing libssl, libasio & libhttp-parser ***" \
-    && apt-get update && apt-get install -y libasio-dev libssl-dev libhttp-parser-dev \
+        autotools-dev autoconf libasio-dev \
     && apt-get clean
 
 RUN echo "*** Installing libfmt ***" \
     && wget https://github.com/fmtlib/fmt/archive/5.3.0.tar.gz \
-    && tar -xzf 5.3.0.tar.gz && cd fmt-5.3.0/ && ls -l \
-    && cmake -j8 -DCMAKE_INSTALL_PREFIX=/usr . \
-    && make install
+    && tar -xzf 5.3.0.tar.gz && cd fmt-5.3.0/ \
+    && cmake -DCMAKE_INSTALL_PREFIX=/usr . \
+    && make -j8 && make install \
+    && cd ../ && rm -rf fmt*
+
+# libhttp-parser-dev is 2.1-2 which is too old
+RUN echo "*** Building nodejs/http_parser dependency ***" \
+    && wget https://github.com/nodejs/http-parser/archive/v2.9.2.tar.gz \
+    && tar xvf v2.9.2.tar.gz && cd http-parser-2.9.2/ \
+    && PREFIX=/usr make -j8 && make install \
+    && cd ../ && rm -rf http-parser*
+
+# libaio (1.10.6-3) is too old
+RUN echo "** Building a recent version of asio ***" \
+    && wget https://github.com/chriskohlhoff/asio/archive/asio-1-12-2.tar.gz \
+    && tar -xvf asio-1-12-2.tar.gz && cd asio-asio-1-12-2/asio \
+    && ./autogen.sh && ./configure --prefix=/usr --without-boost \
+    && make install \
+    && cd ../../ && rm -rf asio*
 
 #patch for https://github.com/Stiffstream/restinio-conan-example/issues/2
-RUN apt-get update && apt-get install -y python3-pip \
-    && pip3 install --upgrade cmake
+RUN apt-get update && apt-get install -y python3-pip && pip3 install --upgrade cmake
 
 RUN echo "*** Downloading RESTinio ***" \
     && mkdir restinio && cd restinio \
-    && wget https://github.com/Stiffstream/restinio/archive/v.0.5.1.1.tar.gz \
-    && ls -l && tar -xzf v.0.5.1.1.tar.gz \
-    && cd restinio-v.0.5.1.1/dev \
+    && wget https://github.com/Stiffstream/restinio/archive/v.0.5.1.2.tar.gz \
+    && ls -l && tar -xzf v.0.5.1.2.tar.gz \
+    && cd restinio-v.0.5.1.2/dev \
     && cmake -DCMAKE_INSTALL_PREFIX=/usr -DRESTINIO_TEST=OFF -DRESTINIO_SAMPLE=OFF \
              -DRESTINIO_INSTALL_SAMPLES=OFF -DRESTINIO_BENCH=OFF -DRESTINIO_INSTALL_BENCHES=OFF \
              -DRESTINIO_FIND_DEPS=ON -DRESTINIO_ALLOW_SOBJECTIZER=Off -DRESTINIO_USE_BOOST_ASIO=none . \
+    && make -j8 && make install \
     && cd ../../ && rm -rf restinio*
+
 
 # build restbed from sources
 RUN git clone --recursive https://github.com/corvusoft/restbed.git \

--- a/docker/DockerfileDepsLlvm
+++ b/docker/DockerfileDepsLlvm
@@ -1,34 +1,49 @@
 FROM ubuntu:16.04
 MAINTAINER Adrien Béraud <adrien.beraud@savoirfairelinux.com>
 RUN apt-get update \
-    && apt-get install -y llvm llvm-dev clang make cmake git wget libncurses5-dev libreadline-dev nettle-dev libgnutls28-dev libuv1-dev libmsgpack-dev libjsoncpp-dev libasio-dev cython3 python3-dev python3-setuptools libcppunit-dev python3-pip \
+    && apt-get install -y llvm llvm-dev clang make cmake git wget libncurses5-dev libreadline-dev \
+       nettle-dev libgnutls28-dev libuv1-dev libmsgpack-dev libjsoncpp-dev libasio-dev cython3 python3-dev \
+       python3-setuptools libcppunit-dev python3-pip \
+       autotools-dev autoconf libasio-dev \
     && apt-get remove -y gcc g++ && apt-get autoremove -y && apt-get clean
 
 ENV CC cc
 ENV CXX c++
 
-RUN echo "*** Installing libssl, libasio & libhttp-parser ***" \
-    && apt-get update && apt-get install -y libasio-dev libssl-dev libhttp-parser-dev \
-    && apt-get clean
-
 RUN echo "*** Installing libfmt ***" \
     && wget https://github.com/fmtlib/fmt/archive/5.3.0.tar.gz \
-    && tar -xzf 5.3.0.tar.gz && cd fmt-5.3.0/ && ls -l \
-    && cmake -j8 -DCMAKE_INSTALL_PREFIX=/usr . \
-    && make install
+    && tar -xzf 5.3.0.tar.gz && cd fmt-5.3.0/ \
+    && cmake -DCMAKE_INSTALL_PREFIX=/usr . \
+    && make -j8 && make install \
+    && cd ../ && rm -rf fmt*
+
+# libhttp-parser-dev is 2.1-2 which is too old
+RUN echo "*** Building nodejs/http_parser dependency ***" \
+    && wget https://github.com/nodejs/http-parser/archive/v2.9.2.tar.gz \
+    && tar xvf v2.9.2.tar.gz && cd http-parser-2.9.2/ \
+    && PREFIX=/usr make -j8 && make install \
+    && cd ../ && rm -rf http-parser*
+
+# libaio (1.10.6-3) is too old
+RUN echo "** Building a recent version of asio ***" \
+    && wget https://github.com/chriskohlhoff/asio/archive/asio-1-12-2.tar.gz \
+    && tar -xvf asio-1-12-2.tar.gz && cd asio-asio-1-12-2/asio \
+    && ./autogen.sh && ./configure --prefix=/usr --without-boost \
+    && make install \
+    && cd ../../ && rm -rf asio*
 
 #patch for https://github.com/Stiffstream/restinio-conan-example/issues/2
-RUN apt-get update && apt-get install -y python3-pip \
-    && pip3 install --upgrade cmake
+RUN apt-get update && apt-get install -y python3-pip && pip3 install --upgrade cmake
 
 RUN echo "*** Downloading RESTinio ***" \
     && mkdir restinio && cd restinio \
-    && wget https://github.com/Stiffstream/restinio/archive/v.0.5.1.1.tar.gz \
-    && ls -l && tar -xzf v.0.5.1.1.tar.gz \
-    && cd restinio-v.0.5.1.1/dev \
+    && wget https://github.com/Stiffstream/restinio/archive/v.0.5.1.2.tar.gz \
+    && ls -l && tar -xzf v.0.5.1.2.tar.gz \
+    && cd restinio-v.0.5.1.2/dev \
     && cmake -DCMAKE_INSTALL_PREFIX=/usr -DRESTINIO_TEST=OFF -DRESTINIO_SAMPLE=OFF \
              -DRESTINIO_INSTALL_SAMPLES=OFF -DRESTINIO_BENCH=OFF -DRESTINIO_INSTALL_BENCHES=OFF \
              -DRESTINIO_FIND_DEPS=ON -DRESTINIO_ALLOW_SOBJECTIZER=Off -DRESTINIO_USE_BOOST_ASIO=none . \
+    && make -j8 && make install \
     && cd ../../ && rm -rf restinio*
 
 # build restbed from sources

--- a/docker/DockerfileDepsLlvm
+++ b/docker/DockerfileDepsLlvm
@@ -13,7 +13,7 @@ ENV CXX c++
 RUN echo "*** Installing libfmt ***" \
     && wget https://github.com/fmtlib/fmt/archive/5.3.0.tar.gz \
     && tar -xzf 5.3.0.tar.gz && cd fmt-5.3.0/ \
-    && cmake -DCMAKE_INSTALL_PREFIX=/usr . \
+    && cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=On . \
     && make -j8 && make install \
     && cd ../ && rm -rf fmt*
 

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -125,7 +125,9 @@ DhtProxyServer::DhtProxyServer(
         if (ec)
             throw std::runtime_error("Error setting tls context options: " + ec.message());
         // add more security options
+#ifdef SSL_OP_NO_RENEGOTIATION
         SSL_CTX_set_options(tls_context.native_handle(), SSL_OP_NO_RENEGOTIATION); // CVE-2009-3555
+#endif
         // node private key
         auto pk = identity.first->serialize();
         pk_ = std::make_unique<asio::const_buffer>(static_cast<void*>(pk.data()), (std::size_t) pk.size());


### PR DESCRIPTION
Tested after cleaning the containers & images to avoid cache:
 ```docker rm $(docker ps -a -q) && docker rmi $(docker images -q)```.

Launched with: ```docker build . -t opendht_restinio -f DockerfileDeps```.

OpenDHT builds & the tests pass with:
```cmake -DCMAKE_INSTALL_PREFIX=/usr -DOPENDHT_PYTHON=On -DOPENDHT_LTO=On -DOPENDHT_TESTS=ON -DOPENDHT_PROXY_CLIENT=On -DOPENDHT_PROXY_SERVER=On -DOPENDHT_PROXY_OPENSSL=On ../```

NOTE: Until the PR #423 changes to build by default with ```-DOPENDHT_PROXY_OPENSSL=On```, as requested, you should build with it to run the ```opendht_unit_tests``` since the tests are run in https.