### PR TITLE
http: handle expect 100-continue on post

### DIFF
--- a/include/opendht/http.h
+++ b/include/opendht/http.h
@@ -221,6 +221,9 @@ public:
     inline const Url& get_url() const {
         return resolver_->get_url();
     };
+    inline std::string& to_string() {
+        return request_;
+    }
 
     void set_certificate(std::shared_ptr<dht::crypto::Certificate> certificate);
     void set_logger(std::shared_ptr<dht::Logger> logger);

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -43,8 +43,10 @@ Url::Url(const std::string& url): url(url)
     const size_t proto_end = url.find("://");
     if (proto_end != std::string::npos){
         addr_begin = proto_end + 3;
-        if (url.substr(0, proto_end) == "https")
+        if (url.substr(0, proto_end) == "https"){
             protocol = "https";
+            service = protocol;
+        }
     }
     // host and service
     size_t addr_size = url.substr(addr_begin).find("/");

--- a/tests/httptester.cpp
+++ b/tests/httptester.cpp
@@ -54,6 +54,20 @@ HttpTester::test_parse_url() {
 }
 
 void
+HttpTester::test_parse_https_url_no_service() {
+    // Arrange
+    std::string url = "https://jami.net/";
+    // Act
+    dht::http::Url parsed (url);
+    // Assert
+    CPPUNIT_ASSERT(parsed.url == url);
+    CPPUNIT_ASSERT(parsed.protocol == "https");
+    CPPUNIT_ASSERT(parsed.host == "jami.net");
+    CPPUNIT_ASSERT(parsed.service == "https");
+    CPPUNIT_ASSERT(parsed.target == "/");
+}
+
+void
 HttpTester::test_parse_url_no_prefix_no_target() {
     // Arrange
     std::string url = "google.com";

--- a/tests/httptester.h
+++ b/tests/httptester.h
@@ -31,6 +31,7 @@ namespace test {
 class HttpTester : public CppUnit::TestFixture {
     CPPUNIT_TEST_SUITE(HttpTester);
     CPPUNIT_TEST(test_parse_url);
+    CPPUNIT_TEST(test_parse_https_url_no_service);
     CPPUNIT_TEST(test_parse_url_no_prefix_no_target);
     CPPUNIT_TEST(test_parse_url_target);
     CPPUNIT_TEST(test_parse_url_query);
@@ -57,6 +58,7 @@ class HttpTester : public CppUnit::TestFixture {
      * Test parse urls
      */
    void test_parse_url();
+   void test_parse_https_url_no_service();
    void test_parse_url_no_prefix_no_target();
    void test_parse_url_target();
    void test_parse_url_query();


### PR DESCRIPTION
> A 100-continue expectation informs recipients that the client is about to send a (presumably large) message body in this request and wishes to receive a 100 (Continue) interim response if the request-line and header fields are not sufficient to cause an immediate success, redirect, or error response.
https://tools.ietf.org/html/rfc7231#section-5.1.1

Adds feature: ```request->set_header_field(restinio::http_field_t::expect, "100-continue");```