### PR TITLE
dhtrunner: fix context.logger handling

### DIFF
--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -129,7 +129,7 @@ DhtRunner::run(const Config& config, Context&& context)
         cv.notify_all();
     });
 
-    auto dht = std::unique_ptr<DhtInterface>(new Dht(std::move(context.sock), SecureDht::getConfig(config.dht_config)));
+    auto dht = std::unique_ptr<DhtInterface>(new Dht(std::move(context.sock), SecureDht::getConfig(config.dht_config), context.logger ? *context.logger : Logger{}));
     dht_ = std::unique_ptr<SecureDht>(new SecureDht(std::move(dht), config.dht_config));
 
 #ifdef OPENDHT_PROXY_CLIENT


### PR DESCRIPTION
This is a patch to get DHT logs when running `DHTLOGLEVEL=3 ./bin/dring -pcd`