### PR TITLE
http: end request on 0 body bytes

### DIFF
--- a/src/http.cpp
+++ b/src/http.cpp
@@ -629,6 +629,8 @@ Request::init_parser()
                 on_body_cb(at, length);
         };
         cbs_->on_message_complete = [this](){
+            if (logger_)
+                logger_->d("[http:client]  [request:%i] response: message complete", id_);
             message_complete_.store(true);
         };
     }
@@ -895,6 +897,11 @@ Request::handle_response_body(const asio::error_code& ec, const size_t bytes)
     }
     if (logger_)
         logger_->d("[http:client]  [request:%i] response body: %i bytes received", id_, bytes);
+
+    if (bytes == 0){
+        terminate(asio::error::eof);
+        return;
+    }
 
     unsigned int content_length;
     auto content_length_it = response_.headers.find(HTTP_HEADER_CONTENT_LENGTH);


### PR DESCRIPTION
the latter ensures that the request will be terminate even if the
http_parser on_message_complete callback is not called with an old
version of dhtproxy using restbed.