### PR TITLE
msvc: fix compilation with VS 2019 16.0

### DIFF
--- a/MSVC/opendht.vcxproj
+++ b/MSVC/opendht.vcxproj
@@ -244,6 +244,7 @@ copy ..\include\opendht.h $(OutDir)\include\</Command>
       <DisableSpecificWarnings>4804;4800;4101;4267;4244;4503;4273;</DisableSpecificWarnings>
       <AdditionalOptions>-D_SCL_SECURE_NO_WARNING;%(AdditionalOptions)</AdditionalOptions>
       <ProgramDataBaseFileName>$(OutDir)lib\$(PlatformTarget)\$(TargetName).pdb</ProgramDataBaseFileName>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/include/opendht/sockaddr.h
+++ b/include/opendht/sockaddr.h
@@ -40,6 +40,7 @@ typedef uint16_t in_port_t;
 #include <string>
 #include <memory>
 #include <vector>
+#include <stdexcept>
 #include <stdlib.h>
 
 #include <cstring>


### PR DESCRIPTION
- <stdexcept> is no longer included in <vector> as of vs 2019