### PR TITLE
http: add client identity

### DIFF
--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -53,7 +53,7 @@ public:
     DhtProxyClient();
 
     explicit DhtProxyClient(
-        std::shared_ptr<dht::crypto::Certificate> certificate,
+        std::shared_ptr<dht::crypto::Certificate> serverCA, dht::crypto::Identity clientIdentity,
         std::function<void()> loopSignal, const std::string& serverHost,
         const std::string& pushClientId = "", std::shared_ptr<dht::Logger> logger = {});
 
@@ -327,6 +327,7 @@ private:
      */
     void cancelAllOperations();
 
+    dht::crypto::Identity clientIdentity_;
     std::shared_ptr<dht::crypto::Certificate> serverCertificate_;
     std::pair<std::string, std::string> serverHostService_;
     std::string pushClientId_;

--- a/include/opendht/dht_proxy_server.h
+++ b/include/opendht/dht_proxy_server.h
@@ -322,8 +322,6 @@ private:
     std::thread serverThread_;
     std::unique_ptr<restinio::http_server_t<RestRouterTraitsTls>> httpsServer_;
     std::unique_ptr<restinio::http_server_t<RestRouterTraits>> httpServer_;
-    dht::Blob server_key_;
-    std::string server_certchain_;
 
     // http client
     std::pair<std::string, std::string> pushHostPort_;

--- a/include/opendht/dht_proxy_server.h
+++ b/include/opendht/dht_proxy_server.h
@@ -322,8 +322,8 @@ private:
     std::thread serverThread_;
     std::unique_ptr<restinio::http_server_t<RestRouterTraitsTls>> httpsServer_;
     std::unique_ptr<restinio::http_server_t<RestRouterTraits>> httpServer_;
-    std::unique_ptr<asio::const_buffer> pk_;
-    std::unique_ptr<asio::const_buffer> cc_;
+    dht::Blob server_key_;
+    std::string server_certchain_;
 
     // http client
     std::pair<std::string, std::string> pushHostPort_;

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -63,7 +63,8 @@ public:
         std::string push_token {};
         bool peer_discovery {false};
         bool peer_publish {false};
-        std::shared_ptr<dht::crypto::Certificate> client_cert;
+        std::shared_ptr<dht::crypto::Certificate> server_ca;
+        dht::crypto::Identity client_identity;
     };
 
     struct Context {

--- a/include/opendht/http.h
+++ b/include/opendht/http.h
@@ -119,9 +119,9 @@ private:
     std::unique_ptr<socket_t> socket_;
     std::shared_ptr<asio::ssl::context> ssl_ctx_;
     std::unique_ptr<ssl_socket_t> ssl_socket_;
-    std::unique_ptr<asio::const_buffer> server_ca_;
-    std::unique_ptr<asio::const_buffer> client_key_;
-    std::unique_ptr<asio::const_buffer> client_cert_;
+    std::string server_ca_;
+    dht::Blob client_key_;
+    std::string client_cert_;
 
     asio::ip::tcp::endpoint endpoint_;
 

--- a/include/opendht/http.h
+++ b/include/opendht/http.h
@@ -119,9 +119,6 @@ private:
     std::unique_ptr<socket_t> socket_;
     std::shared_ptr<asio::ssl::context> ssl_ctx_;
     std::unique_ptr<ssl_socket_t> ssl_socket_;
-    std::string server_ca_;
-    dht::Blob client_key_;
-    std::string client_cert_;
 
     asio::ip::tcp::endpoint endpoint_;
 

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -246,18 +246,18 @@ DhtProxyServer::DhtProxyServer(
         SSL_CTX_set_options(tls_context.native_handle(), SSL_OP_NO_RENEGOTIATION); // CVE-2009-3555
 #endif
         // node private key
-        server_key_ = identity.first->serialize();
-        tls_context.use_private_key(asio::const_buffer{server_key_.data(), server_key_.size()},
+        auto key = identity.first->serialize();
+        tls_context.use_private_key(asio::const_buffer{key.data(), key.size()},
                                     asio::ssl::context::file_format::pem, ec);
         if (ec)
             throw std::runtime_error("Error setting node's private key: " + ec.message());
         // certificate chain
-        server_certchain_ = identity.second->toString(true/*chain*/);
-        tls_context.use_certificate_chain(asio::const_buffer{server_certchain_.data(), server_certchain_.size()}, ec);
+        auto certchain = identity.second->toString(true/*chain*/);
+        tls_context.use_certificate_chain(asio::const_buffer{certchain.data(), certchain.size()}, ec);
         if (ec)
             throw std::runtime_error("Error setting certificate chain: " + ec.message());
         if (logger_)
-            logger_->d("[proxy:server] using certificate chain for ssl:\n%s", server_certchain_.c_str());
+            logger_->d("[proxy:server] using certificate chain for ssl:\n%s", certchain.c_str());
         // build http server
         auto settings = restinio::run_on_this_thread_settings_t<RestRouterTraitsTls>();
         addServerSettings(settings);

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -979,7 +979,8 @@ DhtRunner::enableProxy(bool proxify)
         // Init the proxy client
         auto dht_via_proxy = std::unique_ptr<DhtInterface>(
             new DhtProxyClient(
-                config_.client_cert,
+                config_.server_ca,
+                config_.client_identity,
                 [this]{
                     if (config_.threaded) {
                         {

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -107,27 +107,24 @@ Connection::Connection(asio::io_context& ctx, std::shared_ptr<dht::crypto::Certi
     ssl_ctx_->set_default_verify_paths();
     asio::error_code ec;
     if (server_ca){
-        auto ca = server_ca->toString(false/*chain*/);
-        server_ca_ = std::make_unique<asio::const_buffer>(static_cast<const void*>(ca.data()),
-                                                      (std::size_t) ca.size());
-        ssl_ctx_->add_certificate_authority(*server_ca_, ec);
+        server_ca_ = server_ca->toString(false/*chain*/);
+        ssl_ctx_->add_certificate_authority(asio::const_buffer{server_ca_.data(), server_ca_.size()}, ec);
         if (ec)
             throw std::runtime_error("Error adding certificate authority: " + ec.message());
         else if (logger_)
             logger_->d("[http:client]  [connection:%i] certficate authority %s", id_, server_ca->getUID().c_str());
     }
     if (identity.first){
-        auto pk = identity.first->serialize();
-        client_key_ = std::make_unique<asio::const_buffer>(static_cast<void*>(pk.data()), (std::size_t) pk.size());
-        ssl_ctx_->use_private_key(*client_key_, asio::ssl::context::file_format::pem, ec);
+        client_key_ = identity.first->serialize();
+        ssl_ctx_->use_private_key(asio::const_buffer{client_key_.data(), client_key_.size()},
+                                  asio::ssl::context::file_format::pem, ec);
         if (ec)
             throw std::runtime_error("Error setting client private key: " + ec.message());
     }
     if (identity.second){
-        auto c = identity.second->toString(false/*chain*/);
-        client_cert_ = std::make_unique<asio::const_buffer>(static_cast<const void*>(c.data()),
-                                                    (std::size_t) c.size());
-        ssl_ctx_->use_certificate(*client_cert_, asio::ssl::context::file_format::pem, ec);
+        client_cert_ = identity.second->toString(false/*chain*/);
+        ssl_ctx_->use_certificate(asio::const_buffer{client_cert_.data(), client_cert_.size()},
+                                  asio::ssl::context::file_format::pem, ec);
         if (ec)
             throw std::runtime_error("Error adding client certificate: " + ec.message());
         else if (logger_)

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -122,9 +122,8 @@ Connection::Connection(asio::io_context& ctx, std::shared_ptr<dht::crypto::Certi
             throw std::runtime_error("Error setting client private key: " + ec.message());
     }
     if (identity.second){
-        auto cert = identity.second->toString(false/*chain*/);
-        ssl_ctx_->use_certificate(asio::const_buffer{cert.data(), cert.size()},
-                                  asio::ssl::context::file_format::pem, ec);
+        auto cert = identity.second->toString(true/*chain*/);
+        ssl_ctx_->use_certificate_chain(asio::const_buffer{cert.data(), cert.size()}, ec);
         if (ec)
             throw std::runtime_error("Error adding client certificate: " + ec.message());
         else if (logger_)

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -107,23 +107,23 @@ Connection::Connection(asio::io_context& ctx, std::shared_ptr<dht::crypto::Certi
     ssl_ctx_->set_default_verify_paths();
     asio::error_code ec;
     if (server_ca){
-        server_ca_ = server_ca->toString(false/*chain*/);
-        ssl_ctx_->add_certificate_authority(asio::const_buffer{server_ca_.data(), server_ca_.size()}, ec);
+        auto ca = server_ca->toString(false/*chain*/);
+        ssl_ctx_->add_certificate_authority(asio::const_buffer{ca.data(), ca.size()}, ec);
         if (ec)
             throw std::runtime_error("Error adding certificate authority: " + ec.message());
         else if (logger_)
             logger_->d("[http:client]  [connection:%i] certficate authority %s", id_, server_ca->getUID().c_str());
     }
     if (identity.first){
-        client_key_ = identity.first->serialize();
-        ssl_ctx_->use_private_key(asio::const_buffer{client_key_.data(), client_key_.size()},
+        auto key = identity.first->serialize();
+        ssl_ctx_->use_private_key(asio::const_buffer{key.data(), key.size()},
                                   asio::ssl::context::file_format::pem, ec);
         if (ec)
             throw std::runtime_error("Error setting client private key: " + ec.message());
     }
     if (identity.second){
-        client_cert_ = identity.second->toString(false/*chain*/);
-        ssl_ctx_->use_certificate(asio::const_buffer{client_cert_.data(), client_cert_.size()},
+        auto cert = identity.second->toString(false/*chain*/);
+        ssl_ctx_->use_certificate(asio::const_buffer{cert.data(), cert.size()},
                                   asio::ssl::context::file_format::pem, ec);
         if (ec)
             throw std::runtime_error("Error adding client certificate: " + ec.message());

--- a/tests/dhtproxytester.cpp
+++ b/tests/dhtproxytester.cpp
@@ -46,11 +46,12 @@ DhtProxyTester::setUp() {
 
     serverProxy = std::unique_ptr<dht::DhtProxyServer>(
         new dht::DhtProxyServer(
-            ///*http*/dht::crypto::Identity{},
-            /*https*/serverIdentity,
+            //dht::crypto::Identity{}, // http
+            serverIdentity,            // https
             nodeProxy, 8080, /*pushServer*/"127.0.0.1:8090", logger));
 
-    clientConfig.client_cert = serverIdentity.second;
+    clientConfig.server_ca = serverCAIdentity.second;
+    clientConfig.client_identity = dht::crypto::generateIdentity("DhtProxyTester");
     clientConfig.dht_config.node_config.maintain_storage = false;
     clientConfig.threaded = true;
     clientConfig.push_node_id = "dhtnode";


### PR DESCRIPTION
- client test sample: [https_2waystls.cpp](https://github.com/binarytrails/various/blob/master/cpp/opendht/https_2waystls.cpp#L48
)
- server dhtproxy feature: #432
