### PR TITLE
proxy_client: reset correct opstate

### DIFF
--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -1272,7 +1272,8 @@ DhtProxyClient::resubscribe(const InfoHash& key, const size_t token, Listener& l
     if (listener.request){
         listener.request.reset();
     }
-    opstate.reset(new OperationState());
+    opstate->stop = false;
+    opstate->ok = true;
 
     restinio::http_request_header_t header;
     header.method(restinio::http_method_subscribe());


### PR DESCRIPTION
opstate is captured by value in callbacks. So reset(new OpState())
will only reset the new one and previously captured will be stopped
forever.