### PR TITLE
http/Request: fix destruction issue in multiple call

### DIFF
--- a/include/opendht/http.h
+++ b/include/opendht/http.h
@@ -266,6 +266,13 @@ public:
 private:
     using OnCompleteCb = std::function<void()>;
 
+    Response response_ {};
+    std::string request_;
+    std::atomic<bool> message_complete_ {false};
+    std::atomic<bool> finishing_ {false};
+    std::unique_ptr<http_parser> parser_;
+    std::unique_ptr<http_parser_settings> parser_s_;
+
     struct Callbacks {
         Callbacks(){}
 
@@ -278,6 +285,7 @@ private:
 
         OnStateChangeCb on_state_change;
     };
+
 
     void notify_state_change(const State state);
 
@@ -328,13 +336,6 @@ private:
     static unsigned int ids_;
     std::shared_ptr<Connection> conn_;
     std::shared_ptr<Resolver> resolver_;
-
-    Response response_ {};
-    std::string request_;
-    std::atomic<bool> message_complete_ {false};
-    std::atomic<bool> finishing_ {false};
-    std::unique_ptr<http_parser> parser_;
-    std::unique_ptr<http_parser_settings> parser_s_;
 
     std::shared_ptr<dht::Logger> logger_;
 };

--- a/include/opendht/http.h
+++ b/include/opendht/http.h
@@ -190,7 +190,7 @@ private:
 
 struct Response
 {
-    unsigned int status_code;
+    unsigned int status_code = 0;
     std::map<std::string, std::string> headers;
     std::string body;
 };
@@ -266,8 +266,8 @@ public:
 private:
     using OnCompleteCb = std::function<void()>;
 
-    Response response_ {};
     std::string request_;
+    std::unique_ptr<Response> response_;
     std::atomic<bool> message_complete_ {false};
     std::atomic<bool> finishing_ {false};
     std::unique_ptr<http_parser> parser_;
@@ -323,7 +323,7 @@ private:
 
     std::mutex cbs_mutex_;
     Callbacks cbs_;
-    State state_;
+    std::unique_ptr<State> state_;
 
     dht::crypto::Identity client_identity_;
     std::shared_ptr<dht::crypto::Certificate> server_ca_;

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -860,7 +860,7 @@ Request::post()
 void
 Request::terminate(const asio::error_code& ec)
 {
-    if (finishing_.exchange(true))
+    if (finishing_ and finishing_.exchange(true))
         return;
 
     if (ec != asio::error::eof and ec != asio::error::operation_aborted and logger_)
@@ -871,7 +871,6 @@ Request::terminate(const asio::error_code& ec)
         response_.status_code = 200;
     else
         response_.status_code = 0;
-
     if (logger_)
         logger_->d("[http:client]  [request:%i] done", id_);
     notify_state_change(State::DONE);


### PR DESCRIPTION
Attempt to fix this bug on a phone:
```
2019-11-08 10:13:17.605 11166-11211/cx.ring A/libc: Fatal signal 11 (SIGSEGV), code 1, fault addr 0x10 in tid 11211 (DRing)
2019-11-08 10:13:17.706 11223-11223/? A/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG: Build fingerprint: 'samsung/gts210vewifixx/gts210vewifi:7.0/NRD90M/T813XXS2BSJ3:user/release-keys'
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG: Revision: '4'
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG: ABI: 'arm64'
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG: pid: 11166, tid: 11211, name: DRing  >>> cx.ring <<<
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG: signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x10
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x0   0000007f8ffe16c0  x1   0000007f7bc8ed00  x2   0000000000000001  x3   0000007f7bc8ed00
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x4   0000000000000004  x5   0000000000000008  x6   0000007f7c204fd0  x7   0000007f95fe9d00
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x8   0000000000000000  x9   0000000000000001  x10  0000000000000008  x11  0000000000000000
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x12  0000000000000001  x13  0000000000000001  x14  0000007f8fcd59f0  x15  0000000000000008
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x16  0000007f7f53f9a8  x17  0000007fa4745f08  x18  00000000725693c4  x19  0000007f95eb0f20
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x20  0000007f7c205080  x21  0000007f7c205110  x22  0000007f95e26438  x23  0000007f7f560fd8
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x24  0000007f7f5494d0  x25  00000000000fd000  x26  051897e4a1ba046d  x27  0000000000000000
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x28  0000007f8fd24b90  x29  0000007f7c204f00  x30  0000007f7e089948
2019-11-08 10:13:17.708 11223-11223/? A/DEBUG:     sp   0000007f7c204ec0  pc   0000007f7deab518  pstate 0000000060000000
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG: backtrace:
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #00 pc 0000000000322518  /data/app/cx.ring-2/lib/arm64/libring.so
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #01 pc 0000000000500944  /data/app/cx.ring-2/lib/arm64/libring.so
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #02 pc 000000000050050c  /data/app/cx.ring-2/lib/arm64/libring.so
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #03 pc 00000000005002dc  /data/app/cx.ring-2/lib/arm64/libring.so
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #04 pc 0000000000975f34  /data/app/cx.ring-2/lib/arm64/libring.so (dht::http::Request::terminate(std::__ndk1::error_code const&)+348)
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #05 pc 00000000009894c0  /data/app/cx.ring-2/lib/arm64/libring.so (asio::detail::read_until_delim_string_op<asio::basic_stream_socket<asio::ip::tcp>, asio::basic_streambuf_ref<std::__ndk1::allocator<char> >, std::__ndk1::function<void (std::__ndk1::error_code const&, unsigned long)> >::operator()(std::__ndk1::error_code const&, unsigned long, int)+660)
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #06 pc 0000000000989ae4  /data/app/cx.ring-2/lib/arm64/libring.so (asio::detail::reactive_socket_recv_op<asio::mutable_buffers_1, asio::detail::read_until_delim_string_op<asio::basic_stream_socket<asio::ip::tcp>, asio::basic_streambuf_ref<std::__ndk1::allocator<char> >, std::__ndk1::function<void (std::__ndk1::error_code const&, unsigned long)> > >::do_complete(void*, asio::detail::scheduler_operation*, std::__ndk1::error_code const&, unsigned long)+296)
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #07 pc 00000000005e72f4  /data/app/cx.ring-2/lib/arm64/libring.so (asio::detail::scheduler_operation::complete(void*, std::__ndk1::error_code const&, unsigned long)+80)
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #08 pc 00000000005e6a74  /data/app/cx.ring-2/lib/arm64/libring.so (asio::detail::scheduler::do_run_one(asio::detail::conditionally_enabled_mutex::scoped_lock&, asio::detail::scheduler_thread_info&, std::__ndk1::error_code const&)+512)
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #09 pc 00000000005e6620  /data/app/cx.ring-2/lib/arm64/libring.so (asio::detail::scheduler::run(std::__ndk1::error_code&)+208)
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #10 pc 0000000000959a30  /data/app/cx.ring-2/lib/arm64/libring.so
```
```
2019-11-08 10:13:17.605 11166-11211/cx.ring A/libc: Fatal signal 11 (SIGSEGV), code 1, fault addr 0x10 in tid 11211 (DRing)
2019-11-08 10:13:17.706 11223-11223/? A/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG: Build fingerprint: 'samsung/gts210vewifixx/gts210vewifi:7.0/NRD90M/T813XXS2BSJ3:user/release-keys'
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG: Revision: '4'
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG: ABI: 'arm64'
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG: pid: 11166, tid: 11211, name: DRing  >>> cx.ring <<<
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG: signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x10
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x0   0000007f8ffe16c0  x1   0000007f7bc8ed00  x2   0000000000000001  x3   0000007f7bc8ed00
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x4   0000000000000004  x5   0000000000000008  x6   0000007f7c204fd0  x7   0000007f95fe9d00
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x8   0000000000000000  x9   0000000000000001  x10  0000000000000008  x11  0000000000000000
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x12  0000000000000001  x13  0000000000000001  x14  0000007f8fcd59f0  x15  0000000000000008
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x16  0000007f7f53f9a8  x17  0000007fa4745f08  x18  00000000725693c4  x19  0000007f95eb0f20
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x20  0000007f7c205080  x21  0000007f7c205110  x22  0000007f95e26438  x23  0000007f7f560fd8
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x24  0000007f7f5494d0  x25  00000000000fd000  x26  051897e4a1ba046d  x27  0000000000000000
2019-11-08 10:13:17.707 11223-11223/? A/DEBUG:     x28  0000007f8fd24b90  x29  0000007f7c204f00  x30  0000007f7e089948
2019-11-08 10:13:17.708 11223-11223/? A/DEBUG:     sp   0000007f7c204ec0  pc   0000007f7deab518  pstate 0000000060000000
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG: backtrace:
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #00 pc 0000000000322518  /data/app/cx.ring-2/lib/arm64/libring.so
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #01 pc 0000000000500944  /data/app/cx.ring-2/lib/arm64/libring.so
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #02 pc 000000000050050c  /data/app/cx.ring-2/lib/arm64/libring.so
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #03 pc 00000000005002dc  /data/app/cx.ring-2/lib/arm64/libring.so
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #04 pc 0000000000975f34  /data/app/cx.ring-2/lib/arm64/libring.so (_ZN3dht4http7Request9terminateERKNSt6__ndk110error_codeE+348)
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #05 pc 00000000009894c0  /data/app/cx.ring-2/lib/arm64/libring.so (_ZN4asio6detail26read_until_delim_string_opINS_19basic_stream_socketINS_2ip3tcpEEENS_19basic_streambuf_refINSt6__ndk19allocatorIcEEEENS7_8functionIFvRKNS7_10error_codeEmEEEEclESE_mi+660)
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #06 pc 0000000000989ae4  /data/app/cx.ring-2/lib/arm64/libring.so (_ZN4asio6detail23reactive_socket_recv_opINS_17mutable_buffers_1ENS0_26read_until_delim_string_opINS_19basic_stream_socketINS_2ip3tcpEEENS_19basic_streambuf_refINSt6__ndk19allocatorIcEEEENS9_8functionIFvRKNS9_10error_codeEmEEEEEE11do_completeEPvPNS0_19scheduler_operationESG_m+296)
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #07 pc 00000000005e72f4  /data/app/cx.ring-2/lib/arm64/libring.so (_ZN4asio6detail19scheduler_operation8completeEPvRKNSt6__ndk110error_codeEm+80)
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #08 pc 00000000005e6a74  /data/app/cx.ring-2/lib/arm64/libring.so (_ZN4asio6detail9scheduler10do_run_oneERNS0_27conditionally_enabled_mutex11scoped_lockERNS0_21scheduler_thread_infoERKNSt6__ndk110error_codeE+512)
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #09 pc 00000000005e6620  /data/app/cx.ring-2/lib/arm64/libring.so (_ZN4asio6detail9scheduler3runERNSt6__ndk110error_codeE+208)
2019-11-08 10:13:17.719 11223-11223/? A/DEBUG:     #10 pc 0000000000959a30  /data/app/cx.ring-2/lib/arm64/libring.so
```