### PR TITLE
Fix duplicated, non-functional log message.

### DIFF
--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -76,8 +76,9 @@ Dht::shutdown(ShutdownCallback cb)
     for (auto& str : store)
         *remaining += maintainStorage(str, true, str_donecb);
 
+    DHT_LOG.w("shuting down node: after storage, %u ops", *remaining);
+
     if (!*remaining) {
-        DHT_LOG.w("shuting down node: %u ops remaining", *remaining);
         if (cb) cb();
     }
 }


### PR DESCRIPTION
Inside the if-statement, the log message will always print zero.
Confusingly, its the same message as the one in the loop above it.
Make the message distinct.