### PR TITLE
dhtproxyclient: setPushNotification before first permanent put

### DIFF
--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -1062,17 +1062,15 @@ DhtProxyClient::restartListeners()
     for (auto& search : searches_) {
         auto key = search.first;
         for (auto& put : search.second.puts) {
-            if (!*put.second.ok) {
-                doPut(key, put.second.value, [ok = put.second.ok](bool result){
-                    *ok = result;
-                }, time_point::max(), true);
-                if (!put.second.refreshPutTimer){
-                    put.second.refreshPutTimer = std::make_unique<asio::steady_timer>(httpContext_);
-                }
-                put.second.refreshPutTimer->expires_at(std::chrono::steady_clock::now() + proxy::OP_TIMEOUT - proxy::OP_MARGIN);
-                put.second.refreshPutTimer->async_wait(std::bind(&DhtProxyClient::handleRefreshPut, this,
-                                                        std::placeholders::_1, key, put.first));
+            doPut(key, put.second.value, [ok = put.second.ok](bool result){
+                *ok = result;
+            }, time_point::max(), true);
+            if (!put.second.refreshPutTimer) {
+                put.second.refreshPutTimer = std::make_unique<asio::steady_timer>(httpContext_);
             }
+            put.second.refreshPutTimer->expires_at(std::chrono::steady_clock::now() + proxy::OP_TIMEOUT - proxy::OP_MARGIN);
+            put.second.refreshPutTimer->async_wait(std::bind(&DhtProxyClient::handleRefreshPut, this,
+                                                   std::placeholders::_1, key, put.first));
         }
     }
     if (not deviceKey_.empty()) {

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -1114,11 +1114,11 @@ DhtRunner::enableProxy(bool proxify)
                 },
                 config_.proxy_server, config_.push_node_id, logger_)
         );
-        dht_via_proxy_ = std::unique_ptr<SecureDht>(new SecureDht(std::move(dht_via_proxy), config_.dht_config));
 #ifdef OPENDHT_PUSH_NOTIFICATIONS
         if (not config_.push_token.empty())
-            dht_via_proxy_->setPushNotificationToken(config_.push_token);
+            dht_via_proxy->setPushNotificationToken(config_.push_token);
 #endif
+        dht_via_proxy_ = std::unique_ptr<SecureDht>(new SecureDht(std::move(dht_via_proxy), config_.dht_config));
         // add current listeners
         for (auto& l: listeners_)
             l.second.tokenProxyDht = dht_via_proxy_->listen(l.second.hash, l.second.gcb, l.second.f, l.second.w);


### PR DESCRIPTION
When SecureDHT is initialized, a permanent put is done to announce the node
and then the push token is set. This means the the first permanent put will not
get expirations notification because it's considered as a non push device's put.
We should inject the push token as soon as possible.