### PR TITLE
implement connectivity change in peer discovery

### DIFF
--- a/include/opendht/peer_discovery.h
+++ b/include/opendht/peer_discovery.h
@@ -82,6 +82,8 @@ public:
     bool stopPublish(const std::string &type);
     bool stopPublish(sa_family_t domain, const std::string &type);
 
+    void connectivityChanged();
+
 private:
     class DomainPeerDiscovery;
     std::unique_ptr<DomainPeerDiscovery> peerDiscovery4_;

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -1032,6 +1032,10 @@ DhtRunner::connectivityChanged()
     std::lock_guard<std::mutex> lck(storage_mtx);
     pending_ops_prio.emplace([=](SecureDht& dht) {
         dht.connectivityChanged();
+#ifdef OPENDHT_PEER_DISCOVERY
+        if (peerDiscovery_)
+            peerDiscovery_->connectivityChanged();
+#endif
     });
     cv.notify_all();
 }

--- a/src/peer_discovery.cpp
+++ b/src/peer_discovery.cpp
@@ -133,8 +133,7 @@ PeerDiscovery::DomainPeerDiscovery::loopListener()
             msgpack::object obj = rcv.get();
 
             if (obj.type == msgpack::type::STR) {
-                auto s = obj.as<std::string>();
-		if (!strcmp(s.c_str(), "q"))
+	        if (lrunning_ and obj.as<std::string>() == "q")
                     publish(receiveFrom_);
             } else if (obj.type == msgpack::type::MAP) {
                 for (unsigned i = 0; i < obj.via.map.size; i++) {
@@ -248,8 +247,7 @@ PeerDiscovery::DomainPeerDiscovery::stopPublish(const std::string& type)
 void
 PeerDiscovery::DomainPeerDiscovery::stopDiscovery()
 {
-    if (drunning_)
-        drunning_ = false;
+    drunning_ = false;
 }
 
 void

--- a/src/peer_discovery.cpp
+++ b/src/peer_discovery.cpp
@@ -133,7 +133,7 @@ PeerDiscovery::DomainPeerDiscovery::loopListener()
             msgpack::object obj = rcv.get();
 
             if (obj.type == msgpack::type::STR) {
-	        if (lrunning_ and obj.as<std::string>() == "q")
+                if (lrunning_ and obj.as<std::string>() == "q")
                     publish(receiveFrom_);
             } else if (obj.type == msgpack::type::MAP) {
                 for (unsigned i = 0; i < obj.via.map.size; i++) {

--- a/src/peer_discovery.cpp
+++ b/src/peer_discovery.cpp
@@ -66,13 +66,13 @@ private:
     bool drunning_ {false};
 
     void loopListener();
-    void query(const asio::ip::udp::endpoint peer);
+    void query(const asio::ip::udp::endpoint& peer);
     void reloadMessages();
 
     void stopDiscovery();
     void stopPublish();
 
-    void publish(const asio::ip::udp::endpoint peer);
+    void publish(const asio::ip::udp::endpoint& peer);
 
     void reDiscover();
 };
@@ -167,10 +167,10 @@ PeerDiscovery::DomainPeerDiscovery::loopListener()
 }
 
 void
-PeerDiscovery::DomainPeerDiscovery::query(const asio::ip::udp::endpoint peer)
+PeerDiscovery::DomainPeerDiscovery::query(const asio::ip::udp::endpoint& peer)
 {
-    std::lock_guard<std::mutex> lck(mtx_);
-    if (not lrunning_)
+    std::lock_guard<std::mutex> lck(dmtx_);
+    if (not drunning_)
         return;
 
     msgpack::sbuffer pbuf_request;
@@ -188,7 +188,7 @@ PeerDiscovery::DomainPeerDiscovery::query(const asio::ip::udp::endpoint peer)
 }
 
 void
-PeerDiscovery::DomainPeerDiscovery::publish(const asio::ip::udp::endpoint peer)
+PeerDiscovery::DomainPeerDiscovery::publish(const asio::ip::udp::endpoint& peer)
 {
     std::lock_guard<std::mutex> lck(mtx_);
     if (not lrunning_)
@@ -293,6 +293,7 @@ PeerDiscovery::DomainPeerDiscovery::reDiscover()
         logger_->w("can't multicast on %s: %s",
                 sockAddrSend_.address().to_string().c_str(),
                 ec.message().c_str());
+    query(sockAddrSend_);
 }
 
 void


### PR DESCRIPTION
this makes peer discovery pub/sub on connectivity change, it aims to
make peer discovery more energy efficient.

also, stop echo'ing.

TODO:
in its current implementation however, peer_discovery operates in the
dark; it doesn't know routes available to it (v4 vs v6); nor does it
know of the state of the link(s) (UP vs. DOWN) and therefore it merely
tries to, on connectivity change, (re)pub/sub on previous ip version
routes.

IDEA:
open an interface to kernel so that peer discovery, and perhaps others,
can learn about the routes available to them.