### PR TITLE
net: add updateValues to replace Listen operations

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -445,7 +445,7 @@ private:
     void reportedAddr(const SockAddr&);
 
     // Storage
-    void storageAddListener(const InfoHash& id, const Sp<Node>& node, size_t tid, Query&& = {});
+    void storageAddListener(const InfoHash& id, const Sp<Node>& node, size_t tid, Query&& = {}, int version = 0);
     bool storageStore(const InfoHash& id, const Sp<Value>& value, time_point created, const SockAddr& sa = {}, bool permanent = false);
     bool storageErase(const InfoHash& id, Value::Id vid);
     bool storageRefresh(const InfoHash& id, Value::Id vid);
@@ -600,10 +600,17 @@ private:
             const InfoHash& hash,
             const Blob& token,
             size_t socket_id,
-            const Query& query);
+            const Query& query,
+            int version = 0);
     void onListenDone(const Sp<Node>& status,
             net::RequestAnswer& a,
             Sp<Search>& sr);
+    /* when we receive an update request */
+    net::RequestAnswer onUpdate(Sp<Node> node,
+            const InfoHash& hash,
+            const Blob& token,
+            const std::vector<Sp<Value>>& v,
+            const time_point& created);
     /* when we receive an announce request */
     net::RequestAnswer onAnnounce(Sp<Node> node,
             const InfoHash& hash,

--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -605,12 +605,6 @@ private:
     void onListenDone(const Sp<Node>& status,
             net::RequestAnswer& a,
             Sp<Search>& sr);
-    /* when we receive an update request */
-    net::RequestAnswer onUpdate(Sp<Node> node,
-            const InfoHash& hash,
-            const Blob& token,
-            const std::vector<Sp<Value>>& v,
-            const time_point& created);
     /* when we receive an announce request */
     net::RequestAnswer onAnnounce(Sp<Node> node,
             const InfoHash& hash,

--- a/include/opendht/network_engine.h
+++ b/include/opendht/network_engine.h
@@ -445,6 +445,7 @@ public:
      * @param values      The values.
      * @param created     Time id.
      * @param token       A security token.
+     * @param sid         The socket id.
      * @param on_done     Request callback when the request is completed.
      * @param on_expired  Request callback when the request expires.
      *
@@ -455,6 +456,7 @@ public:
                                  const std::vector<Sp<Value>>& values,
                                  time_point created,
                                  const Blob& token,
+                                 const size_t& sid,
                                  RequestCb&& on_done,
                                  RequestExpiredCb&& on_expired);
 

--- a/include/opendht/network_engine.h
+++ b/include/opendht/network_engine.h
@@ -363,6 +363,37 @@ public:
                            RequestExpiredCb&& on_expired,
                            SocketCb&& socket_cb);
     /**
+     * Send a "updateValues" request to a given node.
+     *
+     * @param n           The node.
+     * @param hash        The storage's hash.
+     * @param query       The query describing filters.
+     * @param token       A security token.
+     * @param previous    The previous request "updateValues" sent to this node.
+     * @param socket      **UNUSED** The socket for further response.
+     *
+     *                    For backward compatibility purpose, sendUpdateValues has to
+     *                    handle creation of the socket. Therefor, you cannot
+     *                    use openSocket yourself. TODO: Once we don't support
+     *                    the old "updateValues" negociation, sendUpdateValues shall not
+     *                    create the socket itself.
+     *
+     * @param on_done     Request callback when the request is completed.
+     * @param on_expired  Request callback when the request expires.
+     * @param socket_cb   Callback to execute each time new updates arrive on
+     *                    the socket.
+     *
+     * @return the request with information concerning its success.
+     */
+    Sp<Request> sendUpdateValues(Sp<Node> n,
+                                 const InfoHash& hash,
+                                 const Query& query,
+                                 const Blob& token,
+                                 Sp<Request> previous,
+                                 RequestCb&& on_done,
+                                 RequestExpiredCb&& on_expired,
+                                 SocketCb&& socket_cb);
+    /**
      * Send a "announce" request to a given node.
      *
      * @param n           The node.
@@ -490,12 +521,13 @@ private:
     void sendRequest(const Sp<Request>& request);
 
     struct MessageStats {
-        unsigned ping    {0};
-        unsigned find    {0};
-        unsigned get     {0};
-        unsigned put     {0};
-        unsigned listen  {0};
-        unsigned refresh {0};
+        unsigned ping          {0};
+        unsigned find          {0};
+        unsigned get           {0};
+        unsigned put           {0};
+        unsigned listen        {0};
+        unsigned updateValues  {0};
+        unsigned refresh       {0};
     };
 
 

--- a/include/opendht/network_engine.h
+++ b/include/opendht/network_engine.h
@@ -250,28 +250,11 @@ public:
      * @param nodes       The ipv4 closest nodes.
      * @param nodes6      The ipv6 closest nodes.
      * @param values      The values to send.
+     * @param version     If version = 1, a request will be used to answer to the listener
      */
     void tellListener(Sp<Node> n, Tid socket_id, const InfoHash& hash, want_t want, const Blob& ntoken,
             std::vector<Sp<Node>>&& nodes, std::vector<Sp<Node>>&& nodes6,
-            std::vector<Sp<Value>>&& values, const Query& q);
-
-    /**
-     * Sends values (with closest nodes) to a listener (if version == 1)
-     * 
-     * @note  This deprecates tellListener
-     * @param n           The node
-     * @param socket_id   Socket id linked to the listener
-     * @param hash        The hash watched by the listener
-     * @param want        Wether to send ipv4 and/or ipv6 nodes.
-     * @param ntoken      Listen security token.
-     * @param nodes       The ipv4 closest nodes.
-     * @param nodes6      The ipv6 closest nodes.
-     * @param values      The values to send.
-     * @param q           The query
-     */
-    void updateValues(Sp<Node> n, Tid socket_id, const InfoHash& hash, want_t want, const Blob& ntoken,
-            std::vector<Sp<Node>>&& nodes, std::vector<Sp<Node>>&& nodes6,
-            std::vector<Sp<Value>>&& values, const Query& q);
+            std::vector<Sp<Value>>&& values, const Query& q, int version);
 
     void tellListenerRefreshed(Sp<Node> n, Tid socket_id, const InfoHash& hash, const Blob& ntoken, const std::vector<Value::Id>& values);
     void tellListenerExpired(Sp<Node> n, Tid socket_id, const InfoHash& hash, const Blob& ntoken, const std::vector<Value::Id>& values);

--- a/include/opendht/network_engine.h
+++ b/include/opendht/network_engine.h
@@ -120,7 +120,6 @@ struct RequestAnswer {
  * @param onGetValues    callback for "get values" request.
  * @param onListen       callback for "listen" request.
  * @param onAnnounce     callback for "announce" request.
- * @param onUpdate       callback for "update" request.
  * @param onRefresh      callback for "refresh" request.
  */
 class NetworkEngine final
@@ -198,20 +197,6 @@ private:
             const std::vector<Sp<Value>>&,
             const time_point&)> onAnnounce {};
     /**
-     * Called on update request.
-     *
-     * @param node (type: Sp<Node>) the requesting node.
-     * @param h (type: InfoHash) hash of the value of interest.
-     * @param token (type: Blob) security token.
-     * @param values (type: std::vector<Sp<Value>>) values to store.
-     * @param created (type: time_point) time when the value was created.
-     */
-    std::function<RequestAnswer(Sp<Node>,
-            const InfoHash&,
-            const Blob&,
-            const std::vector<Sp<Value>>&,
-            const time_point&)> onUpdate {};
-    /**
      * Called on refresh request.
      *
      * @param node (type: Sp<Node>) the requesting node.
@@ -244,7 +229,6 @@ public:
             decltype(NetworkEngine::onGetValues)&& onGetValues,
             decltype(NetworkEngine::onListen)&& onListen,
             decltype(NetworkEngine::onAnnounce)&& onAnnounce,
-            decltype(NetworkEngine::onAnnounce)&& onUpdate,
             decltype(NetworkEngine::onRefresh)&& onRefresh);
 
     ~NetworkEngine();
@@ -272,18 +256,18 @@ public:
             std::vector<Sp<Value>>&& values, const Query& q);
 
     /**
-     * Sends values (with closest nodes) to a listener.
+     * Sends values (with closest nodes) to a listener (if version == 1)
      * 
-     * @note  This deprecate tellListener
-     * @param sa          The address of the listener.
-     * @param sslen       The length of the sockaddr structure.
-     * @param socket_id  The tid to use to write to the request socket.
-     * @param hash        The hash key of the value.
+     * @note  This deprecates tellListener
+     * @param n           The node
+     * @param socket_id   Socket id linked to the listener
+     * @param hash        The hash watched by the listener
      * @param want        Wether to send ipv4 and/or ipv6 nodes.
      * @param ntoken      Listen security token.
      * @param nodes       The ipv4 closest nodes.
      * @param nodes6      The ipv6 closest nodes.
      * @param values      The values to send.
+     * @param q           The query
      */
     void updateValues(Sp<Node> n, Tid socket_id, const InfoHash& hash, want_t want, const Blob& ntoken,
             std::vector<Sp<Node>>&& nodes, std::vector<Sp<Node>>&& nodes6,
@@ -446,8 +430,6 @@ public:
      * @param created     Time id.
      * @param token       A security token.
      * @param sid         The socket id.
-     * @param on_done     Request callback when the request is completed.
-     * @param on_expired  Request callback when the request expires.
      *
      * @return the request with information concerning its success.
      */
@@ -456,9 +438,7 @@ public:
                                  const std::vector<Sp<Value>>& values,
                                  time_point created,
                                  const Blob& token,
-                                 const size_t& sid,
-                                 RequestCb&& on_done,
-                                 RequestExpiredCb&& on_expired);
+                                 const size_t& sid);
 
     /**
      * Parses a message and calls appropriate callbacks.

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -1200,13 +1200,8 @@ Dht::storageChanged(const InfoHash& id, Storage& st, ValueStorage& v, bool newVa
                 std::vector<Sp<Value>> vals {};
                 vals.push_back(v.data);
                 Blob ntoken = makeToken(node_listeners.first->getAddr(), false);
-                if (l.second.version == 1) {
-                    network_engine.updateValues(node_listeners.first, l.first, id, 0, ntoken, {}, {},
-                            std::move(vals), l.second.query);
-                } else {
-                    network_engine.tellListener(node_listeners.first, l.first, id, 0, ntoken, {}, {},
-                            std::move(vals), l.second.query);
-                }
+                network_engine.tellListener(node_listeners.first, l.first, id, 0, ntoken, {}, {},
+                        std::move(vals), l.second.query, l.second.version);
             }
         }
     }
@@ -1280,7 +1275,7 @@ Dht::storageAddListener(const InfoHash& id, const Sp<Node>& node, size_t socket_
         if (not vals.empty()) {
             network_engine.tellListener(node, socket_id, id, WANT4 | WANT6, makeToken(node->getAddr(), false),
                     dht4.buckets.findClosestNodes(id, now, TARGET_NODES), dht6.buckets.findClosestNodes(id, now, TARGET_NODES),
-                    std::move(vals), query);
+                    std::move(vals), query, version);
         }
         node_listeners.emplace(socket_id, Listener {now, std::forward<Query>(query), version});
     }

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -605,7 +605,7 @@ Dht::searchSynchedNodeListen(const Sp<Search>& sr, SearchNode& n)
             });
         }
         auto prev_req = r != n.listenStatus.end() ? r->second.req : nullptr;
-        auto new_req = network_engine.sendListen(n.node, sr->id, *query, n.token, prev_req,
+        auto new_req = network_engine.sendUpdateValues(n.node, sr->id, *query, n.token, prev_req,
             [this,ws,query](const net::Request& req, net::RequestAnswer&& answer) mutable
             { /* on done */
                 if (auto sr = ws.lock()) {

--- a/src/listener.h
+++ b/src/listener.h
@@ -30,8 +30,9 @@ namespace dht {
 struct Listener {
     time_point time;
     Query query;
+    int version;
 
-    Listener(time_point t, Query&& q) : time(t), query(std::move(q)) {}
+    Listener(time_point t, Query&& q, int version = 0) : time(t), query(std::move(q)), version(version) {}
 
     void refresh(time_point t, Query&& q) {
         time = t;

--- a/src/net.h
+++ b/src/net.h
@@ -31,7 +31,8 @@ enum class MessageType {
     Refresh,
     Listen,
     ValueData,
-    ValueUpdate
+    ValueUpdate,
+    UpdateValues
 };
 
 } /* namespace net */

--- a/src/net.h
+++ b/src/net.h
@@ -32,7 +32,7 @@ enum class MessageType {
     Listen,
     ValueData,
     ValueUpdate,
-    UpdateValues
+    UpdateValue
 };
 
 } /* namespace net */

--- a/src/network_engine.cpp
+++ b/src/network_engine.cpp
@@ -622,6 +622,7 @@ NetworkEngine::process(std::unique_ptr<ParsedMessage>&& msg, const SockAddr& fro
                 if (logIncoming_ and logger_)
                     logger_->d(msg->info_hash, node->id, "[node %s] got 'listen' request for %s", node->toString().c_str(), msg->info_hash.toString().c_str());
                 ++in_stats.listen;
+                printf("@@@@ msg->socket_id %u\n", msg->socket_id);
                 RequestAnswer answer = onListen(node, msg->info_hash, msg->token, msg->socket_id, std::move(msg->query), msg->version);
                 auto nnodes = bufferNodes(from.getFamily(), msg->info_hash, msg->want, answer.nodes4, answer.nodes6);
                 sendListenConfirmation(from, msg->tid);
@@ -1067,13 +1068,12 @@ NetworkEngine::sendListen(Sp<Node> n,
             logger_->e(hash, "[node %s] unable to get a valid socket for listen. Aborting listen", n->toString().c_str());
         return {};
     }
-
     msgpack::sbuffer buffer;
     msgpack::packer<msgpack::sbuffer> pk(&buffer);
     pk.pack_map(5+(config.network?1:0));
 
     auto has_query = not query.where.empty() or not query.select.empty();
-    pk.pack(KEY_A); pk.pack_map(4 + has_query);
+    pk.pack(KEY_A); pk.pack_map(5 + has_query);
       pk.pack(KEY_REQ_ID);    pk.pack(myid);
       pk.pack(KEY_VERSION);   pk.pack(1);
       pk.pack(KEY_REQ_H);     pk.pack(hash);

--- a/src/network_engine.cpp
+++ b/src/network_engine.cpp
@@ -1212,12 +1212,14 @@ NetworkEngine::sendUpdateValues(Sp<Node> n,
     TransId sid (socket_id);
     msgpack::sbuffer buffer;
     msgpack::packer<msgpack::sbuffer> pk(&buffer);
-    pk.pack_map(7+(config.network?1:0));
+    pk.pack_map(5+(config.network?1:0));
 
-    pk.pack(KEY_VERSION);   pk.pack(1);
-    pk.pack(KEY_A); pk.pack_map((created < scheduler.time() ? 5 : 4));
+    pk.pack(KEY_A); pk.pack_map((created < scheduler.time() ? 7 : 6));
       pk.pack(KEY_REQ_ID);     pk.pack(myid);
+      pk.pack(KEY_VERSION);    pk.pack(1);
       pk.pack(KEY_REQ_H);      pk.pack(infohash);
+      pk.pack(KEY_REQ_SID);   pk.pack_bin(sid.size());
+                              pk.pack_bin_body((const char*)sid.data(), sid.size());
       auto v = packValueHeader(buffer, values);
       if (created < scheduler.time()) {
           pk.pack(KEY_REQ_CREATION);
@@ -1226,8 +1228,6 @@ NetworkEngine::sendUpdateValues(Sp<Node> n,
       pk.pack(KEY_REQ_TOKEN);  pk.pack(token);
 
     pk.pack(KEY_Q);   pk.pack(QUERY_UPDATE);
-    pk.pack(KEY_REQ_SID);   pk.pack_bin(sid.size());
-                            pk.pack_bin_body((const char*)sid.data(), sid.size());
     pk.pack(KEY_TID); pk.pack_bin(tid.size());
                       pk.pack_bin_body((const char*)tid.data(), tid.size());
     pk.pack(KEY_Y);   pk.pack(KEY_Q);

--- a/src/parsed_message.h
+++ b/src/parsed_message.h
@@ -54,11 +54,12 @@ static const std::string KEY_REQ_EXPIRED {"exp"};
 static const std::string KEY_REQ_REFRESHED {"re"};
 static const std::string KEY_REQ_FIELDS {"fileds"};
 static const std::string KEY_REQ_WANT {"w"};
+static const std::string KEY_VERSION {"ve"};
 
 static const std::string QUERY_PING {"ping"};
 static const std::string QUERY_FIND {"find"};
 static const std::string QUERY_GET {"get"};
-static const std::string QUERY_UPDATE_VALUES {"updateValues"};
+static const std::string QUERY_UPDATE {"update"};
 static const std::string QUERY_PUT {"put"};
 static const std::string QUERY_LISTEN {"listen"};
 static const std::string QUERY_REFRESH {"refresh"};
@@ -114,6 +115,7 @@ struct ParsedMessage {
     uint16_t error_code;
     /* reported address by the distant node */
     std::string ua;
+    int version {0};
     SockAddr addr;
     void msgpack_unpack(const msgpack::object& o);
 
@@ -225,8 +227,8 @@ ParsedMessage::msgpack_unpack(const msgpack::object& msg)
         type = MessageType::AnnounceValue;
     else if (parsed.q == QUERY_REFRESH)
         type = MessageType::Refresh;
-    else if (parsed.q == QUERY_UPDATE_VALUES)
-        type = MessageType::UpdateValues;
+    else if (parsed.q == QUERY_UPDATE)
+        type = MessageType::UpdateValue;
     else
         throw msgpack::type_error();
 
@@ -298,6 +300,8 @@ ParsedMessage::msgpack_unpack(const msgpack::object& msg)
             parsedReq.fields = &o.val;
         else if (key == KEY_REQ_WANT)
             parsedReq.want = &o.val;
+        else if (key == KEY_VERSION)
+            version = o.val.as<int>();
     }
 
     if (parsedReq.sa) {

--- a/src/parsed_message.h
+++ b/src/parsed_message.h
@@ -58,6 +58,7 @@ static const std::string KEY_REQ_WANT {"w"};
 static const std::string QUERY_PING {"ping"};
 static const std::string QUERY_FIND {"find"};
 static const std::string QUERY_GET {"get"};
+static const std::string QUERY_UPDATE_VALUES {"updateValues"};
 static const std::string QUERY_PUT {"put"};
 static const std::string QUERY_LISTEN {"listen"};
 static const std::string QUERY_REFRESH {"refresh"};
@@ -224,6 +225,8 @@ ParsedMessage::msgpack_unpack(const msgpack::object& msg)
         type = MessageType::AnnounceValue;
     else if (parsed.q == QUERY_REFRESH)
         type = MessageType::Refresh;
+    else if (parsed.q == QUERY_UPDATE_VALUES)
+        type = MessageType::UpdateValues;
     else
         throw msgpack::type_error();
 

--- a/src/search.h
+++ b/src/search.h
@@ -222,7 +222,7 @@ struct Dht::SearchNode {
                                      answer.refreshed_values,
                                      answer.expired_values, types, scheduler.time());
             scheduler.edit(l->second.cacheExpirationJob, next);
-        }
+        } 
     }
 
     void onListenSynced(const Sp<Query>& q, bool synced = true) {

--- a/src/search.h
+++ b/src/search.h
@@ -222,7 +222,7 @@ struct Dht::SearchNode {
                                      answer.refreshed_values,
                                      answer.expired_values, types, scheduler.time());
             scheduler.edit(l->second.cacheExpirationJob, next);
-        } 
+        }
     }
 
     void onListenSynced(const Sp<Query>& q, bool synced = true) {

--- a/tests/dhtrunnertester.cpp
+++ b/tests/dhtrunnertester.cpp
@@ -175,10 +175,7 @@ DhtRunnerTester::testListenLotOfBytes() {
     unsigned putCount(0);
     unsigned putOkCount(0);
 
-    std::string data {};
-    for (int i = 0; i < 10000; ++i) {
-        data += "a";
-    }
+    std::string data(10000, 'a');
 
     auto foo = dht::InfoHash::get("foo");
     constexpr unsigned N = 50;

--- a/tests/dhtrunnertester.h
+++ b/tests/dhtrunnertester.h
@@ -32,6 +32,7 @@ class DhtRunnerTester : public CppUnit::TestFixture {
     CPPUNIT_TEST(testConstructors);
     CPPUNIT_TEST(testGetPut);
     CPPUNIT_TEST(testListen);
+    CPPUNIT_TEST(testListenLotOfBytes);
     CPPUNIT_TEST_SUITE_END();
 
     dht::DhtRunner node1 {};

--- a/tests/dhtrunnertester.h
+++ b/tests/dhtrunnertester.h
@@ -57,6 +57,10 @@ class DhtRunnerTester : public CppUnit::TestFixture {
      * Test listen method
      */
     void testListen();
+    /**
+     * Test listen method with lot of datas
+     */
+    void testListenLotOfBytes();
 };
 
 }  // namespace test


### PR DESCRIPTION
Actually, packets are not retransmitted for listen operations. This
leads to some problems when they are already several values present
at one hash. Ideally, packets should be transmitted inside a request
to avoid packet loss and get all datas.

This patch breaks the compatibility with previous versions