### PR TITLE
proxyclient: only restart listeners when connected

### DIFF
--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -264,11 +264,10 @@ public:
     std::vector<unsigned> getNodeMessageStats(bool) override { return {}; }
     void setStorageLimit(size_t) override {}
     void connectivityChanged(sa_family_t) override {
-        restartListeners();
+        getProxyInfos();
     }
     void connectivityChanged() override {
         getProxyInfos();
-        restartListeners();
         loopSignal_();
     }
 
@@ -385,7 +384,7 @@ private:
     /**
      * Relaunch LISTEN requests if the client disconnect/reconnect.
      */
-    void restartListeners();
+    void restartListeners(const asio::error_code &ec);
 
     /**
      * Refresh a listen via a token


### PR DESCRIPTION
restartListeners() must be called only when the proxy is connected. Else, the
client will receive a lot of http errors