### PR TITLE
http: use local cache to store pre-decoded certs

### DIFF
--- a/src/http.cpp
+++ b/src/http.cpp
@@ -108,7 +108,7 @@ Connection::Connection(asio::io_context& ctx, const bool ssl, std::shared_ptr<dh
 #ifdef __ANDROID__
         ssl_ctx_->add_verify_path("/system/etc/security/cacerts");
 #elif defined(WIN32) || defined(__APPLE__)
-        addSystemCaCertificates(ssl_ctx_->native_handle(), l);
+        PEMCache::instance(l).fillX509Store(ssl_ctx_->native_handle());
 #else
         ssl_ctx_->set_default_verify_paths();
 #endif
@@ -131,8 +131,8 @@ Connection::Connection(asio::io_context& ctx, std::shared_ptr<dht::crypto::Certi
     ssl_ctx_->set_verify_mode(asio::ssl::verify_peer | asio::ssl::verify_fail_if_no_peer_cert);
 #ifdef __ANDROID__
     ssl_ctx_->add_verify_path("/system/etc/security/cacerts");
-#elif WIN32
-    addSystemCaCertificates(ssl_ctx_->native_handle(), l);
+#elif WIN32 || defined(__APPLE__)
+    PEMCache::instance(l).fillX509Store(ssl_ctx_->native_handle());
 #else
     ssl_ctx_->set_default_verify_paths();
 #endif


### PR DESCRIPTION
- pre-decode certs from DER->PEM and store them so http connections
  can add them the ssl context x509 store
- fixes the windows build by adding the crypto/x509 header