### PR TITLE
Fix use of OPENDHT_SYSTEMD_UNIT_FILE_LOCATION

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -39,8 +39,14 @@ endif ()
 install (TARGETS dhtnode dhtscanner dhtchat RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 if (OPENDHT_SYSTEMD)
-    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} systemd --variable=systemdsystemunitdir
-                    OUTPUT_VARIABLE SYSTEMD_UNIT_INSTALL_DIR)
+    if (NOT DEFINED OPENDHT_SYSTEMD_UNIT_FILE_LOCATION)
+        execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} systemd --variable=systemdsystemunitdir
+                        OUTPUT_VARIABLE SYSTEMD_UNIT_INSTALL_DIR)
+        message("-- Using Systemd unit installation directory by pkg-config: " ${SYSTEMD_UNIT_INSTALL_DIR})
+    else()
+        message("-- Using Systemd unit installation directory requested: " ${OPENDHT_SYSTEMD_UNIT_FILE_LOCATION})
+        set(SYSTEMD_UNIT_INSTALL_DIR ${OPENDHT_SYSTEMD_UNIT_FILE_LOCATION})
+    endif()
     string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_UNIT_INSTALL_DIR "${SYSTEMD_UNIT_INSTALL_DIR}")
     set (systemdunitdir "${SYSTEMD_UNIT_INSTALL_DIR}")
 


### PR DESCRIPTION
For some reason 1778f640482aff728a35cc1f1591e010e1558524 (PR #524 from @atraczyk) reverted part of 4d70c214b0b69deb0ca4bffbf3056131b013378d (PR #510 from @doronbehar).

The commit from this PR fixes that.