### PR TITLE
Handle Expection in NetworkEngine Process or ProcessMessage

### DIFF
--- a/src/network_engine.cpp
+++ b/src/network_engine.cpp
@@ -580,20 +580,27 @@ NetworkEngine::process(std::unique_ptr<ParsedMessage>&& msg, const SockAddr& fro
         }
         case MessageType::Reply:
             if (req) { /* request reply */
-                auto& r = *req;
-                if (r.getType() == MessageType::AnnounceValue
-                 or r.getType() == MessageType::Listen
-                 or r.getType() == MessageType::Refresh) {
-                    r.node->authSuccess();
-                }
-                r.reply_time = scheduler.time();
-
-                deserializeNodes(*msg, from);
-                r.setDone(std::move(*msg));
+                try {
+		    deserializeNodes(*msg, from);
+                    auto& r = *req;
+                    if (r.getType() == MessageType::AnnounceValue
+                        or r.getType() == MessageType::Listen
+                        or r.getType() == MessageType::Refresh) {
+                        r.node->authSuccess();
+                    }
+                    r.reply_time = scheduler.time();
+                    r.setDone(std::move(*msg));
+		} catch (...) {
+                    req->node->authError();
+		}    
                 break;
             } else { /* request socket data */
-                deserializeNodes(*msg, from);
-                rsocket->on_receive(node, std::move(*msg));
+		try {    
+                    deserializeNodes(*msg, from);
+                    rsocket->on_receive(node, std::move(*msg));
+		} catch(DhtProtocolException &ex) {
+                    node->authError();
+                }
             }
             break;
         default:

--- a/src/node_cache.cpp
+++ b/src/node_cache.cpp
@@ -116,7 +116,6 @@ NodeCache::NodeMap::getNode(const InfoHash& id, const SockAddr& addr, time_point
             cleanup_counter = 0;
         }
     } else if (confirm and node->isOld(now)) {
-	// confirm or node->isOld(now) allowed replay or impersonation attacks
         node->update(addr);
     }
     return node;

--- a/src/node_cache.cpp
+++ b/src/node_cache.cpp
@@ -116,6 +116,7 @@ NodeCache::NodeMap::getNode(const InfoHash& id, const SockAddr& addr, time_point
             cleanup_counter = 0;
         }
     } else if (confirm and node->isOld(now)) {
+	// confirm or node->isOld(now) allowed replay or impersonation attacks
         node->update(addr);
     }
     return node;

--- a/src/node_cache.cpp
+++ b/src/node_cache.cpp
@@ -115,7 +115,7 @@ NodeCache::NodeMap::getNode(const InfoHash& id, const SockAddr& addr, time_point
             cleanup();
             cleanup_counter = 0;
         }
-    } else if (confirm or node->isOld(now)) {
+    } else if (confirm and node->isOld(now)) {
         node->update(addr);
     }
     return node;


### PR DESCRIPTION
deserializeNodes can throw DhtProtocolException::WRONG_NODE_INFO_BUF_LEN. However, the process method does not call in try-catch. When deserializeNodes throws DhtProtocolException::WRONG_NODE_INFO_BUF_LEN, the message is wrong, thus, the node will increment authError. 