### PR TITLE
Add python bindings for TypeValue

### DIFF
--- a/python/opendht_cpp.pxd
+++ b/python/opendht_cpp.pxd
@@ -26,6 +26,14 @@ from libc.string cimport const_char, const_uchar
 ctypedef uint16_t in_port_t
 ctypedef unsigned short int sa_family_t;
 
+cdef extern from "<iostream>" namespace "std::chrono" nogil:
+    cdef cppclass duration[ulong]:
+        duration() except +
+
+    cdef cppclass seconds:
+        duration seconds(uint64_t) except +
+        duration seconds()
+
 cdef extern from "<memory>" namespace "std" nogil:
     cdef cppclass shared_ptr[T]:
         shared_ptr() except +
@@ -131,7 +139,6 @@ cdef extern from "opendht/value.h" namespace "dht::Value":
 cdef extern from "opendht/value.h" namespace "dht::Value::Field":
     cdef Field None
     cdef Field Id
-    cdef Field ValueType
     cdef Field OwnerPk
     cdef Field SeqNum
     cdef Field UserType
@@ -141,7 +148,7 @@ cdef extern from "opendht/value.h" namespace "dht":
     cdef cppclass Value:
         Value() except +
         Value(vector[uint8_t]) except +
-        Value(const uint8_t* dat_ptr, size_t dat_len) except +
+        Value(const uint16_t t, const uint8_t* dat_ptr, size_t dat_len) except +
         string toString() const
         size_t size() const
         uint64_t id
@@ -149,6 +156,12 @@ cdef extern from "opendht/value.h" namespace "dht":
         InfoHash recipient
         vector[uint8_t] data
         string user_type
+
+    cdef cppclass ValueType:
+        ValueType(uint16_t id, string name, seconds expiration) except +
+        uint16_t id
+        string name
+        seconds expiration
 
     cdef cppclass Query:
         Query() except +
@@ -234,6 +247,7 @@ cdef extern from "opendht/dhtrunner.h" namespace "dht":
         void run(const_char*, const_char*, const_char*, Config config)
         void join()
         void shutdown(ShutdownCallback)
+        void registerType(ValueType& value);
         bool isRunning()
         SockAddr getBound(sa_family_t af) const
         string getStorageLog() const


### PR DESCRIPTION
Hi!

I just noticed that there are no python bindings for `TypeValue`. I'd really love to get all the Python bindings completed, but I'm quite short of time (and also I only needed `TypeValue` so I could set the expiration timer for my `Value`s, since it seems that there's no way to do this with the current state of the Python bindings).

I didn't add any tests for this nor did I run the benchmarks. The bindings for TypeValue work just fine, though. It's pretty much the same as in C++:

`node.registerType(dht.ValueType(1, "Name", datetime.timedelta(seconds=30)))`

Probably there are a few things here and there but for the most part it gets the job done.

Signed-off-by: JUAN MÉNDEZ <vpsink@gmail.com>