### PR TITLE
thread_pool: Add TaskSet

### DIFF
--- a/include/opendht/thread_pool.h
+++ b/include/opendht/thread_pool.h
@@ -59,6 +59,10 @@ public:
         return get(std::move(cb));
     }
 
+    void onThreadCreated(std::function<void(void)>&& cb) {
+        onThreadCreated_ = std::move(cb);
+    }
+
     void stop();
     void join();
 
@@ -69,7 +73,7 @@ private:
     unsigned readyThreads_ {0};
     std::mutex lock_ {};
     std::condition_variable cv_ {};
-
+    std::function<void(void)> onThreadCreated_;
     const unsigned maxThreads_;
     bool running_ {true};
 };

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -74,6 +74,9 @@ ThreadPool::run(std::function<void()>&& cb)
         threads_.emplace_back(new ThreadState());
         auto& t = *threads_.back();
         t.thread = std::thread([&]() {
+            if (onThreadCreated_) {
+                onThreadCreated_();
+            }
             while (t.run) {
                 std::function<void()> task;
 


### PR DESCRIPTION
TaskSet is a way to wait for children tasks to terminate before continuing
execution of the parent.

Quick example:
```c++
std::atomic<int> cnt = 0;

{
        TaskSet ts;

        for (size_t i=0; i<1024; ++i) {

                dht::ThreadPool::computation().run([]{
                        cnt += 1;
                }, ts); // Note we've marked to run this in `ts`
        }

}  // ts go out of scope .. waiting for jobs

assert(cnt == 1024); // Sync with jobs
```

A TaskSet consists of a remaining counter and a condition variable.  When the
TaskSet get destroyed, its owner has to wait for all the remaining jobs to be
done.

By default, task are added to the threadpool's TaskSet.  Which means that when a
ThreadPool get destroyed, all jobs added to it has to completed, except if
::join() is called.

Signed-off-by: Olivier Dion <olivier.dion@savoirfairelinux.>