### PR TITLE
thread_pool: Add `onThreadCreated` method

### DIFF
--- a/include/opendht/thread_pool.h
+++ b/include/opendht/thread_pool.h
@@ -59,6 +59,10 @@ public:
         return get(std::move(cb));
     }
 
+    void onThreadCreated(std::function<void(void)>&& cb) {
+        onThreadCreated_ = std::move(cb);
+    }
+
     void stop();
     void join();
 
@@ -69,7 +73,7 @@ private:
     unsigned readyThreads_ {0};
     std::mutex lock_ {};
     std::condition_variable cv_ {};
-
+    std::function<void(void)> onThreadCreated_;
     const unsigned maxThreads_;
     bool running_ {true};
 };

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -74,6 +74,9 @@ ThreadPool::run(std::function<void()>&& cb)
         threads_.emplace_back(new ThreadState());
         auto& t = *threads_.back();
         t.thread = std::thread([&]() {
+            if (onThreadCreated_) {
+                onThreadCreated_();
+            }
             while (t.run) {
                 std::function<void()> task;
 


### PR DESCRIPTION
Allows callback on thread creation.

Example:
```c++
dht::ThreadPool::io().onThreadCreated([] {
        sip_utils::register_thead();
});
```