### PR TITLE
Fix/ttls

### DIFF
--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -1265,11 +1265,7 @@ DhtProxyClient::resubscribe(const InfoHash& key, const size_t token, Listener& l
         logger_->d("[proxy:client] [resubscribe] [search %s]", key.to_c_str());
 
     auto opstate = listener.opstate;
-    opstate->stop = true;
-    if (listener.request){
-        listener.request.reset();
-    }
-    opstate->stop = false;
+    listener.request.reset(); // This will update ok to false
     opstate->ok = true;
 
     restinio::http_request_header_t header;

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -1004,7 +1004,13 @@ DhtProxyServer::sendPushNotification(const std::string& token, Json::Value&& jso
         notification["platform"] = type == PushType::Android ? 2 : 1;
         notification["data"] = std::move(json);
         notification["priority"] = highPriority ? "high" : "normal";
-        notification["time_to_live"] = 3600 * 24; // 24 hours
+        if (type == PushType::Android)
+            notification["time_to_live"] = 3600 * 24; // 24 hours
+        else {
+            const auto expiration = std::chrono::system_clock::now() + std::chrono::hours(24);
+            uint32_t exp = std::chrono::duration_cast<std::chrono::seconds>(expiration.time_since_epoch()).count();
+            notification["expiration"] = exp;
+        }
 
         Json::Value notifications(Json::arrayValue);
         notifications[0] = notification;

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -1004,7 +1004,7 @@ DhtProxyServer::sendPushNotification(const std::string& token, Json::Value&& jso
         notification["platform"] = type == PushType::Android ? 2 : 1;
         notification["data"] = std::move(json);
         notification["priority"] = highPriority ? "high" : "normal";
-        notification["time_to_live"] = 600;
+        notification["time_to_live"] = 3600 * 24; // 24 hours
 
         Json::Value notifications(Json::arrayValue);
         notifications[0] = notification;


### PR DESCRIPTION
 dht_proxy_server: increase ttl for push to 24 hours

If the android device is offline during more than 10 minutes, it
can misses push notifications and cause an incorrect state with
values not expired even if the re-subscribe is correct.



 proxyclient: do not play with stop when resubscribing

At this point we do not care for the request. Subscribes are
instantaneous, so the request will be terminated at this point.
Changing the stop status can cause some push notifications to be
dropped if coming at this moment.

