### PR TITLE
tests: fix building with GCC11

### DIFF
--- a/tests/threadpooltester.cpp
+++ b/tests/threadpooltester.cpp
@@ -21,6 +21,7 @@
 
 #include "opendht/thread_pool.h"
 #include <atomic>
+#include <thread>
 
 namespace test {
 CPPUNIT_TEST_SUITE_REGISTRATION(ThreadPoolTester);


### PR DESCRIPTION
While building on Arch, we had:
```
/build/opendht/src/opendht-2.3.1/tests/threadpooltester.cpp: In member function ‘void test::ThreadPoolTester::testThreadPool()’:
/build/opendht/src/opendht-2.3.1/tests/threadpooltester.cpp:47:27: error: ‘sleep_for’ is not a member of ‘std::this_thread’
   47 |         std::this_thread::sleep_for(std::chrono::milliseconds(10));
      |                           ^~~~~~~~~
/build/opendht/src/opendht-2.3.1/tests/threadpooltester.cpp: In member function ‘void test::ThreadPoolTester::testExecutor()’:
/build/opendht/src/opendht-2.3.1/tests/threadpooltester.cpp:76:27: error: ‘sleep_for’ is not a member of ‘std::this_thread’
   76 |         std::this_thread::sleep_for(std::chrono::milliseconds(10));
      |                           ^~~~~~~~~
```