### PR TITLE
Support `risc-v` architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,6 +320,9 @@ if (OPENDHT_STATIC)
             PUBLIC ${CMAKE_THREAD_LIBS_INIT} ${GNUTLS_LIBRARIES} ${Nettle_STATIC_LIBRARIES}
                    ${Jsoncpp_STATIC_LIBRARIES} ${FMT_LIBRARY} ${HTTP_PARSER_LIBRARY}
                    ${OPENSSL_STATIC_LIBRARIES})
+        if (NOT HAVE_CXX_ATOMICS_RISC_V_WITHOUT_LIB)
+            target_link_libraries(opendht-static PUBLIC "atomic")
+        endif ()
     else ()
         if (OPENDHT_TOOLS)
             function (add_obj_lib name libfile)
@@ -393,6 +396,9 @@ if (OPENDHT_SHARED)
             PRIVATE ${GNUTLS_LIBRARIES} ${Nettle_LIBRARIES}
                     ${Jsoncpp_LIBRARIES}
                     ${FMT_LIBRARY} ${HTTP_PARSER_LIBRARY} ${argon2_LIBRARIES})
+        if (NOT HAVE_CXX_ATOMICS_RISC_V_WITHOUT_LIB)
+            target_link_libraries(opendht PUBLIC "atomic")
+        endif ()
     endif ()
 
     install (TARGETS opendht DESTINATION ${CMAKE_INSTALL_LIBDIR} EXPORT opendht)
@@ -497,6 +503,9 @@ if (OPENDHT_TESTS)
        ${GNUTLS_LIBRARIES}
        ${Jsoncpp_LIBRARIES}
     )
+    if (NOT HAVE_CXX_ATOMICS_RISC_V_WITHOUT_LIB)
+        target_link_libraries(opendht_unit_tests "atomic")
+    endif ()
     if (OPENDHT_PROXY_OPENSSL)
         target_link_libraries(opendht_unit_tests ${OPENSSL_LIBRARIES})
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,8 +320,8 @@ if (OPENDHT_STATIC)
             PUBLIC ${CMAKE_THREAD_LIBS_INIT} ${GNUTLS_LIBRARIES} ${Nettle_STATIC_LIBRARIES}
                    ${Jsoncpp_STATIC_LIBRARIES} ${FMT_LIBRARY} ${HTTP_PARSER_LIBRARY}
                    ${OPENSSL_STATIC_LIBRARIES})
-        if (NOT HAVE_CXX_ATOMICS_RISC_V_WITHOUT_LIB)
-            target_link_libraries(opendht-static PUBLIC "atomic")
+        if (NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+            target_link_libraries(opendht-static PUBLIC atomic)
         endif ()
     else ()
         if (OPENDHT_TOOLS)
@@ -396,8 +396,8 @@ if (OPENDHT_SHARED)
             PRIVATE ${GNUTLS_LIBRARIES} ${Nettle_LIBRARIES}
                     ${Jsoncpp_LIBRARIES}
                     ${FMT_LIBRARY} ${HTTP_PARSER_LIBRARY} ${argon2_LIBRARIES})
-        if (NOT HAVE_CXX_ATOMICS_RISC_V_WITHOUT_LIB)
-            target_link_libraries(opendht PUBLIC "atomic")
+        if (NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+            target_link_libraries(opendht PUBLIC atomic)
         endif ()
     endif ()
 
@@ -503,8 +503,8 @@ if (OPENDHT_TESTS)
        ${GNUTLS_LIBRARIES}
        ${Jsoncpp_LIBRARIES}
     )
-    if (NOT HAVE_CXX_ATOMICS_RISC_V_WITHOUT_LIB)
-        target_link_libraries(opendht_unit_tests "atomic")
+    if (NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+        target_link_libraries(opendht_unit_tests atomic)
     endif ()
     if (OPENDHT_PROXY_OPENSSL)
         target_link_libraries(opendht_unit_tests ${OPENSSL_LIBRARIES})

--- a/cmake/CheckAtomic.cmake
+++ b/cmake/CheckAtomic.cmake
@@ -12,8 +12,12 @@ function(check_working_cxx_atomics varname)
   CHECK_CXX_SOURCE_COMPILES("
 #include <atomic>
 std::atomic<int> x;
+std::atomic<short> y;
+std::atomic<char> z;
 int main() {
-  return x;
+  ++z;
+  ++y;
+  return ++x;
 }
 " ${varname})
   set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
@@ -34,22 +38,6 @@ int main() {
   set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
 endfunction(check_working_cxx_atomics64)
 
-function(check_working_cxx_atomics_for_risc_v varname)
-  set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
-  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11")
-  CHECK_CXX_SOURCE_COMPILES("
-#include <atomic>
-std::atomic<uint8_t> x;
-std::atomic<uint16_t> y;
-int main() {
-  x++;
-  y++;
-  return 0;
-}
-" ${varname})
-  set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
-endfunction(check_working_cxx_atomics_for_risc_v)
-
 # This isn't necessary on MSVC, so avoid command-line switch annoyance
 # by only running on GCC-like hosts.
 if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
@@ -57,15 +45,10 @@ if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
   check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITHOUT_LIB)
   # If not, check if the library exists, and atomics work with it.
   if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
-    check_library_exists(atomic __atomic_fetch_add_4 "" HAVE_LIBATOMIC)
-    if( HAVE_LIBATOMIC )
-      list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
-      check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITH_LIB)
-      if (NOT HAVE_CXX_ATOMICS_WITH_LIB)
-	message(FATAL_ERROR "Host compiler must support std::atomic!")
-      endif()
-    else()
-      message(FATAL_ERROR "Host compiler appears to require libatomic, but cannot find it.")
+    list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+    check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITH_LIB)
+    if (NOT HAVE_CXX_ATOMICS_WITH_LIB)
+      message(FATAL_ERROR "Host compiler must support std::atomic!")
     endif()
   endif()
 endif()
@@ -79,31 +62,10 @@ endif()
 
 # If not, check if the library exists, and atomics work with it.
 if(NOT HAVE_CXX_ATOMICS64_WITHOUT_LIB)
-  check_library_exists(atomic __atomic_load_8 "" HAVE_CXX_LIBATOMICS64)
-  if(HAVE_CXX_LIBATOMICS64)
-    list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
-    check_working_cxx_atomics64(HAVE_CXX_ATOMICS64_WITH_LIB)
-    if (NOT HAVE_CXX_ATOMICS64_WITH_LIB)
-      message(FATAL_ERROR "Host compiler must support 64-bit std::atomic!")
-    endif()
-  else()
-    message(FATAL_ERROR "Host compiler appears to require libatomic for 64-bit operations, but cannot find it.")
-  endif()
-endif()
-
-# Check for RISC-V atomic operations.
-if(MSVC)
-  set(HAVE_CXX_ATOMICS_RISC_V_WITHOUT_LIB True)
-else()
-  check_working_cxx_atomics_for_risc_v(HAVE_CXX_ATOMICS_RISC_V_WITHOUT_LIB)
-endif()
-
-# If not, check if the library exists, and atomics work with it.
-if(NOT HAVE_CXX_ATOMICS_RISC_V_WITHOUT_LIB)
   list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
-  check_working_cxx_atomics_for_risc_v(HAVE_CXX_ATOMICS_RISC_V_WITH_LIB)
-  if (NOT HAVE_CXX_ATOMICS_RISC_V_WITH_LIB)
-    message(FATAL_ERROR "Host compiler must support RISC-V std::atomic!")
+  check_working_cxx_atomics64(HAVE_CXX_ATOMICS64_WITH_LIB)
+  if (NOT HAVE_CXX_ATOMICS64_WITH_LIB)
+    message(FATAL_ERROR "Host compiler must support 64-bit std::atomic!")
   endif()
 endif()
 

--- a/cmake/CheckAtomic.cmake
+++ b/cmake/CheckAtomic.cmake
@@ -38,6 +38,7 @@ int main() {
   set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
 endfunction(check_working_cxx_atomics64)
 
+
 # This isn't necessary on MSVC, so avoid command-line switch annoyance
 # by only running on GCC-like hosts.
 if (LLVM_COMPILER_IS_GCC_COMPATIBLE)


### PR DESCRIPTION
Currently this project cannot be compiled for `risc-v` architecture, `gcc` compiler raises an error:

```
/usr/bin/ld: libopendht.so.2.3.5: undefined reference to `__atomic_exchange_1'
```

This is because the `risc-v` architecture does not support 1-byte and 2-byte lock-free atomic operations.

By passing the `-latomic` option, `gcc` will statically link the `libatomic` library. Inside that library, the `std::atomic<bool>` used in the project will fallback to the mutex implementation, which is allowed by C++ standard.

Ref: https://github.com/riscv-collab/riscv-gnu-toolchain/issues/183#issuecomment-253721765