### PR TITLE
cmake: fix incorrectly linking to libatomic on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,10 @@ find_package(Doxygen)
 option (OPENDHT_DOCUMENTATION "Create and install the HTML based API documentation (requires Doxygen)" ${DOXYGEN_FOUND})
 
 # Dependencies
+if (NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+    link_libraries (atomic)
+endif ()
+
 list (APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 if (NOT MSVC)
     set (THREADS_PREFER_PTHREAD_FLAG TRUE)

--- a/cmake/DetermineGCCCompatible.cmake
+++ b/cmake/DetermineGCCCompatible.cmake
@@ -1,0 +1,13 @@
+# Determine if the compiler has GCC-compatible command-line syntax.
+
+if(NOT DEFINED LLVM_COMPILER_IS_GCC_COMPATIBLE)
+  if(CMAKE_COMPILER_IS_GNUCXX)
+    set(LLVM_COMPILER_IS_GCC_COMPATIBLE ON)
+  elseif( MSVC )
+    set(LLVM_COMPILER_IS_GCC_COMPATIBLE OFF)
+  elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" )
+    set(LLVM_COMPILER_IS_GCC_COMPATIBLE ON)
+  elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel" )
+    set(LLVM_COMPILER_IS_GCC_COMPATIBLE ON)
+  endif()
+endif()


### PR DESCRIPTION
Context: #598

This PR contains changes:
- Updates `CheckAtomic.cmake` to the latest.
- Includes `DetermineGCCCompatible.cmake` to set `LLVM_COMPILER_IS_GCC_COMPATIBLE` variable correctly.
- Links to `libatomic` for all targets `if (NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)`.

Compilation passes on macOS and RISC-V arch.