### PR TITLE
value: fix build without jsoncpp

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -239,6 +239,21 @@ Value::toJson() const
     return val;
 }
 
+uint64_t
+unpackId(const Json::Value& json, const std::string& key) {
+    uint64_t ret = 0;
+    try {
+        const auto& t = json[key];
+        if (t.isString()) {
+            ret = std::stoull(t.asString());
+        } else {
+            ret = t.asLargestUInt();
+        }
+    } catch (...) {}
+    return ret;
+}
+#endif
+
 bool
 Value::checkSignature()
 {
@@ -273,21 +288,6 @@ Value::decrypt(const crypto::PrivateKey& key)
     }
     return decryptedValue;
 }
-
-uint64_t
-unpackId(const Json::Value& json, const std::string& key) {
-    uint64_t ret = 0;
-    try {
-        const auto& t = json[key];
-        if (t.isString()) {
-            ret = std::stoull(t.asString());
-        } else {
-            ret = t.asLargestUInt();
-        }
-    } catch (...) {}
-    return ret;
-}
-#endif
 
 bool
 FieldValue::operator==(const FieldValue& vfd) const


### PR DESCRIPTION
Seen in Homebrew (https://github.com/Homebrew/homebrew-core/pull/101711) where we haven't added optional `jsoncpp` features

Issue was that `checkSignature` and `decrypt` were added inside the `#ifdef OPENDHT_JSONCPP`, so they weren't getting compiled resulting in
```
Undefined symbols for architecture x86_64:
    "dht::Value::checkSignature()", referenced from:
        dht::SecureDht::checkValue(std::__1::shared_ptr<dht::Value> const&) in securedht.cpp.o
        std::__1::__function::__func<dht::SecureDht::secureType(dht::ValueType&&)::$_3, std::__1::allocator<dht::SecureDht::secureType(dht::ValueType&&)::$_3>, bool (dht::Hash<20ul>, std::__1::shared_ptr<dht::Value>&, dht::Hash<20ul> const&, dht::SockAddr const&)>::operator()(dht::Hash<20ul>&&, std::__1::shared_ptr<dht::Value>&, dht::Hash<20ul> const&, dht::SockAddr const&) in securedht.cpp.o
        std::__1::__function::__func<dht::SecureDht::secureType(dht::ValueType&&)::$_4, std::__1::allocator<dht::SecureDht::secureType(dht::ValueType&&)::$_4>, bool (dht::Hash<20ul>, std::__1::shared_ptr<dht::Value> const&, std::__1::shared_ptr<dht::Value>&, dht::Hash<20ul> const&, dht::SockAddr const&)>::operator()(dht::Hash<20ul>&&, std::__1::shared_ptr<dht::Value> const&, std::__1::shared_ptr<dht::Value>&, dht::Hash<20ul> const&, dht::SockAddr const&) in securedht.cpp.o
    "dht::Value::decrypt(dht::crypto::PrivateKey const&)", referenced from:
        dht::SecureDht::checkValue(std::__1::shared_ptr<dht::Value> const&) in securedht.cpp.o
  ld: symbol(s) not found for architecture x86_64
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
  make[2]: *** [libopendht.2.4.4.dylib] Error 1
  make[1]: *** [CMakeFiles/opendht.dir/all] Error 2
  make[1]: *** Waiting for unfinished jobs....
```

---

Building Homebrew formula for v2.4.4 with the patch worked for me.