### PR TITLE
dhtrunner: remove support for running both dht and proxy client

### DIFF
--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -263,7 +263,7 @@ public:
     void dumpTables() const override {}
     std::vector<unsigned> getNodeMessageStats(bool) override { return {}; }
     void setStorageLimit(size_t) override {}
-    virtual size_t getStorageLimit() const { return 0; }
+    virtual size_t getStorageLimit() const override { return 0; }
     void connectivityChanged(sa_family_t) override {
         getProxyInfos();
     }

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -437,7 +437,6 @@ public:
     /**
      * Start or stop the proxy
      * @param proxify if we want to use the proxy
-     * @param deviceKey non empty to enable push notifications
      */
     void enableProxy(bool proxify);
 
@@ -474,11 +473,8 @@ private:
     DoneCallback bindOpDoneCallback(DoneCallback&& cb);
     DoneCallbackSimple bindOpDoneCallback(DoneCallbackSimple&& cb);
 
-    /** Local DHT instance */
+    /** DHT instance */
     std::unique_ptr<SecureDht> dht_;
-
-    /** Proxy client instance */
-    std::unique_ptr<SecureDht> dht_via_proxy_;
 
     /** true if we are currently using a proxy */
     std::atomic_bool use_proxy {false};
@@ -491,17 +487,6 @@ private:
      * reset dht clients
      */
     void resetDht();
-    /**
-     * @return the current active DHT
-     */
-    SecureDht* activeDht() const;
-
-    /**
-     * Store current listeners and translates global tokens for each client.
-     */
-    struct Listener;
-    std::map<size_t, Listener> listeners_;
-    size_t listener_token_ {1};
 
     mutable std::mutex dht_mtx {};
     std::thread dht_thread {};

--- a/src/network_engine.cpp
+++ b/src/network_engine.cpp
@@ -415,7 +415,7 @@ NetworkEngine::processMessage(const uint8_t *buf, size_t buflen, SockAddr f)
         return;
     }
 
-    std::unique_ptr<ParsedMessage> msg {new ParsedMessage};
+    auto msg = std::make_unique<ParsedMessage>();
     try {
         msgpack::unpacked msg_res = msgpack::unpack((const char*)buf, buflen);
         msg->msgpack_unpack(msg_res.get());

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -296,8 +296,8 @@ Value::decrypt(const crypto::PrivateKey& key)
         decrypted = true;
         if (isEncrypted()) {
             auto decryptedBlob = key.decrypt(cypher);
-            std::unique_ptr<Value> v {new Value(id)};
             auto msg = msgpack::unpack((const char*)decryptedBlob.data(), decryptedBlob.size());
+            auto v = std::make_unique<Value>(id);
             v->msgpack_unpack_body(msg.get());
             if (v->recipient != key.getPublicKey().getId())
                 throw crypto::DecryptError("Recipient mismatch");


### PR DESCRIPTION
If configured to run as a proxy client, no port will be bound and the local dht node
won't be instantiated.

Trying to use the proxy if not compiled will now trigger an exception.