### PR TITLE
infohash: remove optimization due to weird warnings

### DIFF
--- a/include/opendht/infohash.h
+++ b/include/opendht/infohash.h
@@ -103,11 +103,8 @@ public:
     static constexpr inline Hash zero() noexcept { return Hash{}; }
 
     bool operator==(const Hash& h) const {
-        auto a = reinterpret_cast<const uint32_t*>(data_.data());
-        auto b = reinterpret_cast<const uint32_t*>(h.data_.data());
-        constexpr unsigned n = N / sizeof(uint32_t);
-        for (unsigned i=0; i < n; i++)
-            if (a[i] != b[i])
+        for (unsigned i=0; i < N; i++)
+            if (data_[i] != h.data_[i])
                 return false;
         return true;
     }


### PR DESCRIPTION
Current operator== creates a very weird warning about using an
uninitialized value (no warning without the reinterpret_cast).