### PR TITLE
proxy_client: reconnect account if local ip changes

### DIFF
--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -344,6 +344,8 @@ private:
     NodeStatus statusIpv6_ {NodeStatus::Disconnected};
     NodeStats stats4_ {};
     NodeStats stats6_ {};
+    SockAddr localAddrv4_;
+    SockAddr localAddrv6_;
     SockAddr publicAddressV4_;
     SockAddr publicAddressV6_;
     std::atomic_bool launchConnectedCbs_ {false};

--- a/include/opendht/http.h
+++ b/include/opendht/http.h
@@ -114,6 +114,8 @@ public:
     void async_read(size_t bytes, BytesHandlerCb cb);
     void async_read_some(size_t bytes, BytesHandlerCb cb);
 
+    const asio::ip::address& local_address() const;
+
     void timeout(const std::chrono::seconds timeout, HandlerCb cb = {});
     void close();
 
@@ -141,6 +143,8 @@ private:
     asio::streambuf write_buf_;
     asio::streambuf read_buf_;
     std::istream istream_;
+
+    asio::ip::address local_address_;
 
     std::unique_ptr<asio::steady_timer> timeout_timer_;
     std::shared_ptr<dht::Logger> logger_;

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -569,9 +569,10 @@ Connection::async_connect(std::vector<asio::ip::tcp::endpoint>&& endpoints, Conn
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
-    ConnectHandlerCb wcb = [&base, cb=std::move(cb)](const asio::error_code& ec, const asio::ip::tcp::endpoint& endpoint) {
+    ConnectHandlerCb wcb = [this, &base, cb=std::move(cb)](const asio::error_code& ec, const asio::ip::tcp::endpoint& endpoint) {
         if (!ec) {
             auto socket = base.native_handle();
+            local_address_ = base.local_endpoint().address();
             // Once connected, set a keep alive on the TCP socket with 30 seconds delay
             // This will generate broken pipes as soon as possible.
             // Note this needs to be done once connected to have a valid native_handle()
@@ -725,6 +726,12 @@ Connection::async_read_some(size_t bytes, BytesHandlerCb cb)
     };
     if (ssl_socket_)  ssl_socket_->async_read_some(buf, onEnd);
     else              socket_->async_read_some(buf, onEnd);
+}
+
+const asio::ip::address&
+Connection::local_address() const
+{
+    return local_address_;
 }
 
 void


### PR DESCRIPTION
When switching between two network interfaces, local address will
change but not the public ip. This generally cause the client to
not correctly updates its candidates.
In this patch, we inject in the proxy client the local candidates
and use it to check if the network changed.