### PR TITLE
proxyserver: send correct value id to client

### DIFF
--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -1176,7 +1176,7 @@ DhtProxyServer::put(restinio::request_handle_t request,
                                 }
                             }
                             auto response = initHttpResponse(request->create_response());
-                            response.append_body(Json::writeString(jsonBuilder_, value->toJson()) + "\n");
+                            response.append_body(Json::writeString(jsonBuilder_, pp.second.value->toJson()) + "\n");
                             return response.done();
                         }
                     }


### PR DESCRIPTION
when searching for a value to put, the proxy server returned a json with value->id = 0, causing the client to not refreshing correctly the values later (when timeout-ing, the value to refresh is not found).