### PR TITLE
proxyserver: add support for UnifiedPush standard

### DIFF
--- a/include/opendht/dht_proxy_server.h
+++ b/include/opendht/dht_proxy_server.h
@@ -40,7 +40,8 @@ namespace dht {
 enum class PushType {
     None = 0,
     Android,
-    iOS
+    iOS,
+    UnifiedPush
 };
 }
 MSGPACK_ADD_ENUM(dht::PushType)
@@ -65,6 +66,7 @@ struct OPENDHT_PUBLIC ProxyServerConfig {
     std::string address {};
     in_port_t port {8000};
     std::string pushServer {};
+    std::string unifiedPushEndpoint {};
     std::string persistStatePath {};
     dht::crypto::Identity identity {};
     std::string bundleId {};
@@ -424,6 +426,7 @@ private:
     mutable std::atomic<time_point> lastStatsReset_ {time_point::min()};
 
     std::string pushServer_;
+    std::string unifiedPushEndpoint_;
     std::string bundleId_;
 
 #ifdef OPENDHT_PUSH_NOTIFICATIONS

--- a/tools/dhtnode.cpp
+++ b/tools/dhtnode.cpp
@@ -43,7 +43,7 @@ void print_version() {
 }
 
 void print_usage() {
-    std::cout << "Usage: dhtnode [-v [-l logfile]] [-i] [-d] [-n network_id] [-p local_port] [-b bootstrap_host[:port]] [--proxyserver local_port] [--proxyserverssl local_port] [--bundleid bundleid]" << std::endl << std::endl;
+    std::cout << "Usage: dhtnode [-v [-l logfile]] [-i] [-d] [-n network_id] [-p local_port] [-b bootstrap_host[:port]] [--proxyserver local_port] [--proxyserverssl local_port] [--bundleid bundleid] [--openpush endpoint]" << std::endl << std::endl;
     print_info();
 }
 
@@ -552,6 +552,7 @@ main(int argc, char **argv)
             serverConfig.pushServer = params.pushserver;
             serverConfig.bundleId = params.bundle_id;
             serverConfig.address = params.proxy_address;
+            serverConfig.unifiedPushEndpoint = params.unifiedPushEndpoint;
             if (params.proxyserverssl and params.proxy_id.first and params.proxy_id.second){
                 serverConfig.identity = params.proxy_id;
                 serverConfig.port = params.proxyserverssl;

--- a/tools/tools_common.h
+++ b/tools/tools_common.h
@@ -130,6 +130,7 @@ struct dht_params {
     in_port_t port {0};
     in_port_t proxyserver {0};
     in_port_t proxyserverssl {0};
+    std::string unifiedPushEndpoint {};
     std::string proxyclient {};
     std::string proxy_address {};
     std::string pushserver {};
@@ -225,6 +226,7 @@ static const constexpr struct option long_options[] = {
     {"syslog",                  no_argument      , nullptr, 'L'},
     {"proxyserver",             required_argument, nullptr, 'S'},
     {"proxyserverssl",          required_argument, nullptr, 'e'},
+    {"unifiedpush",             required_argument, nullptr, 'O'},
     {"proxy-addr",              required_argument, nullptr, 'a'},
     {"proxy-certificate",       required_argument, nullptr, 'w'},
     {"proxy-privkey",           required_argument, nullptr, 'K'},
@@ -243,7 +245,7 @@ parseArgs(int argc, char **argv) {
     int opt;
     std::string privkey;
     std::string proxy_privkey;
-    while ((opt = getopt_long(argc, argv, "hidsvDUPp:n:b:f:l:", long_options, nullptr)) != -1) {
+    while ((opt = getopt_long(argc, argv, "hidsvODUPp:n:b:f:l:", long_options, nullptr)) != -1) {
         switch (opt) {
         case 'p': {
                 int port_arg = atoi(optarg);
@@ -260,6 +262,9 @@ parseArgs(int argc, char **argv) {
                 else
                     std::cout << "Invalid port: " << port_arg << std::endl;
             }
+            break;
+        case 'O':
+            params.unifiedPushEndpoint = optarg;
             break;
         case 'e': {
                 int port_arg = atoi(optarg);


### PR DESCRIPTION
Make the proxy able to support the UnifiedPush platform, so that applications using the proxy server can use any UnifiedPush provider.

Documentation: https://unifiedpush.org/

How to test:
+ Install a UnifiedPush provider on a device (e.g. https://ntfy.sh)
+ Run dhtnode with a proxyserver and --unifiedpush https://ntfy.sh
+ Subscribe to a random topic on ntfy (e.g. "dhtproxytest")
+ Subscribe to a hash on the DHT: curl -X SUBSCRIBE http://my.dht.proxy:8000/key/foo \ -d '{"key":"dhtproxytest", "platform":"unifiedpush"}'
+ Send data on the subscribed hash

Note: the topic should be completely random.