### PR TITLE
unifiedpush: remove unifiedpush parameter

### DIFF
--- a/include/opendht/dht_proxy_server.h
+++ b/include/opendht/dht_proxy_server.h
@@ -66,7 +66,6 @@ struct OPENDHT_PUBLIC ProxyServerConfig {
     std::string address {};
     in_port_t port {8000};
     std::string pushServer {};
-    std::string unifiedPushEndpoint {};
     std::string persistStatePath {};
     dht::crypto::Identity identity {};
     std::string bundleId {};
@@ -426,7 +425,6 @@ private:
     mutable std::atomic<time_point> lastStatsReset_ {time_point::min()};
 
     std::string pushServer_;
-    std::string unifiedPushEndpoint_;
     std::string bundleId_;
 
 #ifdef OPENDHT_PUSH_NOTIFICATIONS

--- a/tools/dhtnode.cpp
+++ b/tools/dhtnode.cpp
@@ -552,7 +552,6 @@ main(int argc, char **argv)
             serverConfig.pushServer = params.pushserver;
             serverConfig.bundleId = params.bundle_id;
             serverConfig.address = params.proxy_address;
-            serverConfig.unifiedPushEndpoint = params.unifiedPushEndpoint;
             if (params.proxyserverssl and params.proxy_id.first and params.proxy_id.second){
                 serverConfig.identity = params.proxy_id;
                 serverConfig.port = params.proxyserverssl;

--- a/tools/tools_common.h
+++ b/tools/tools_common.h
@@ -130,7 +130,6 @@ struct dht_params {
     in_port_t port {0};
     in_port_t proxyserver {0};
     in_port_t proxyserverssl {0};
-    std::string unifiedPushEndpoint {};
     std::string proxyclient {};
     std::string proxy_address {};
     std::string pushserver {};
@@ -226,7 +225,6 @@ static const constexpr struct option long_options[] = {
     {"syslog",                  no_argument      , nullptr, 'L'},
     {"proxyserver",             required_argument, nullptr, 'S'},
     {"proxyserverssl",          required_argument, nullptr, 'e'},
-    {"unifiedpush",             required_argument, nullptr, 'O'},
     {"proxy-addr",              required_argument, nullptr, 'a'},
     {"proxy-certificate",       required_argument, nullptr, 'w'},
     {"proxy-privkey",           required_argument, nullptr, 'K'},
@@ -262,9 +260,6 @@ parseArgs(int argc, char **argv) {
                 else
                     std::cout << "Invalid port: " << port_arg << std::endl;
             }
-            break;
-        case 'O':
-            params.unifiedPushEndpoint = optarg;
             break;
         case 'e': {
                 int port_arg = atoi(optarg);


### PR DESCRIPTION
Because there is multiple unifiedpush endpoint (ntfy.sh is one), we should not pass it as an option to dhtnode, but use the one provided by the user in the token (from unified push library).