### PR TITLE
url_encode: escape url query

### DIFF
--- a/include/opendht/http.h
+++ b/include/opendht/http.h
@@ -330,6 +330,8 @@ private:
 
     void build();
 
+    static std::string url_encode(const std::string& value);
+
     void init_default_headers();
     /**
      * Initialized and wraps the http_parser callbacks with our user defined callbacks.


### PR DESCRIPTION
For routes such as /api/auth/directory/search, when searching for names such as "Léo", jams would not respond to the request
since the URL contained invalid characters defined in RFC3986. `url_encode` turns such characters into their equivalent escaped characters.