### PR TITLE
doc: fix dhtnode(1) man page formatting

### DIFF
--- a/doc/dhtnode.1
+++ b/doc/dhtnode.1
@@ -19,7 +19,7 @@
 .SH DESCRIPTION
 Runs an OpenDHT node, with a CLI (default) or as a daemon (with \fB'-d'\fP or \fB'-s'\fP).
 Commands available in the interactive shell are:
-.EE
+.EX
     h, help    Print this help message.
     q, quit    Quit the program.
     log        Start/stop printing DHT logs.
@@ -39,6 +39,7 @@ Commands available in the interactive shell are:
                           private key.
     e [key] [dest] [str]  Put string value at [key], encrypted for [dest] with
                           its public key (if found).
+.EE
 .SH OPTIONS
 .TP
 \fB\-h\fP


### PR DESCRIPTION
This fixes the following lintian issue:
```
    22: warning: macro 'mF' not defined [usr/share/man/man1/dhtnode.1.gz:1]
```