### PR TITLE
replace CPPFLAGS += ...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,12 +21,10 @@ AS_IF([test "x$enable_debug" = "xyes"],
       [CXXFLAGS="${CXXFLAGS} -g -Og -Wno-return-type -Wall -Wextra -Wnon-virtual-dtor -Wno-deprecated -pedantic-errors"],
       [CXXFLAGS="${CXXFLAGS} -O3 -Wno-deprecated -pedantic-errors -fvisibility=hidden"])
 
-save_CPPFLAGS="${CPPFLAGS}"
-CPPFLAGS="${save_CPPFLAGS} -DOPENDHT_BUILD"
+CPPFLAGS="${CPPFLAGS} -DOPENDHT_BUILD"
 AM_CONDITIONAL([OPENDHT_SHARED], [test "x$enable_shared" != xno])
 AM_COND_IF(OPENDHT_SHARED, [
-    save_CPPFLAGS="${CPPFLAGS}"
-    CPPFLAGS="${save_CPPFLAGS} -Dopendht_EXPORTS"
+  CPPFLAGS="${CPPFLAGS} -Dopendht_EXPORTS"
 ])
 
 AM_PROG_AR
@@ -149,8 +147,7 @@ AS_IF([test "x$with_jsoncpp" != "xno"],
       [have_jsoncpp=no])
 AS_IF([test "x$have_jsoncpp" = "xyes"], [
     AC_MSG_NOTICE([Using JsonCpp])
-    save_CPPFLAGS="${CPPFLAGS}"
-    CPPFLAGS="${save_CPPFLAGS} -DOPENDHT_JSONCPP"
+    CPPFLAGS="${CPPFLAGS} -DOPENDHT_JSONCPP"
     AC_SUBST(jsoncpp_lib, [", jsoncpp"])
 ], [
     AC_MSG_NOTICE([Not using JsonCpp])
@@ -197,14 +194,8 @@ AM_COND_IF([ENABLE_TOOLS], [
 
 AM_COND_IF(ENABLE_PROXY_SERVER, AC_DEFINE([OPENDHT_PROXY_SERVER], [], [Building with proxy server]))
 AM_COND_IF(ENABLE_PROXY_CLIENT, AC_DEFINE([OPENDHT_PROXY_CLIENT], [], [Building with proxy client]))
-AM_COND_IF(ENABLE_PUSH_NOTIFICATIONS, [
-    save_CPPFLAGS="${CPPFLAGS}"
-    CPPFLAGS="${save_CPPFLAGS} -DOPENDHT_PUSH_NOTIFICATIONS"
-], [])
-AM_COND_IF(ENABLE_PROXY_SERVER_IDENTITY, [
-    save_CPPFLAGS="${CPPFLAGS}"
-    CPPFLAGS="${save_CPPFLAGS} -DOPENDHT_PROXY_SERVER_IDENTITY"
-], [])
+AM_COND_IF(ENABLE_PUSH_NOTIFICATIONS, [CPPFLAGS="${CPPFLAGS} -DOPENDHT_PUSH_NOTIFICATIONS"], [])
+AM_COND_IF(ENABLE_PROXY_SERVER_IDENTITY, [CPPFLAGS="${CPPFLAGS} -DOPENDHT_PROXY_SERVER_IDENTITY"], [])
 
 dnl Configure setup.py if we build the python module
 AC_SUBST(CURRENT_SOURCE_DIR, ".")

--- a/configure.ac
+++ b/configure.ac
@@ -21,10 +21,12 @@ AS_IF([test "x$enable_debug" = "xyes"],
       [CXXFLAGS="${CXXFLAGS} -g -Og -Wno-return-type -Wall -Wextra -Wnon-virtual-dtor -Wno-deprecated -pedantic-errors"],
       [CXXFLAGS="${CXXFLAGS} -O3 -Wno-deprecated -pedantic-errors -fvisibility=hidden"])
 
-CPPFLAGS+=" -DOPENDHT_BUILD"
+save_CPPFLAGS="${CPPFLAGS}"
+CPPFLAGS="${save_CPPFLAGS} -DOPENDHT_BUILD"
 AM_CONDITIONAL([OPENDHT_SHARED], [test "x$enable_shared" != xno])
 AM_COND_IF(OPENDHT_SHARED, [
-  CPPFLAGS+=" -Dopendht_EXPORTS"
+    save_CPPFLAGS="${CPPFLAGS}"
+    CPPFLAGS="${save_CPPFLAGS} -Dopendht_EXPORTS"
 ])
 
 AM_PROG_AR
@@ -147,7 +149,8 @@ AS_IF([test "x$with_jsoncpp" != "xno"],
       [have_jsoncpp=no])
 AS_IF([test "x$have_jsoncpp" = "xyes"], [
     AC_MSG_NOTICE([Using JsonCpp])
-    CPPFLAGS+=" -DOPENDHT_JSONCPP"
+    save_CPPFLAGS="${CPPFLAGS}"
+    CPPFLAGS="${save_CPPFLAGS} -DOPENDHT_JSONCPP"
     AC_SUBST(jsoncpp_lib, [", jsoncpp"])
 ], [
     AC_MSG_NOTICE([Not using JsonCpp])
@@ -194,8 +197,14 @@ AM_COND_IF([ENABLE_TOOLS], [
 
 AM_COND_IF(ENABLE_PROXY_SERVER, AC_DEFINE([OPENDHT_PROXY_SERVER], [], [Building with proxy server]))
 AM_COND_IF(ENABLE_PROXY_CLIENT, AC_DEFINE([OPENDHT_PROXY_CLIENT], [], [Building with proxy client]))
-AM_COND_IF(ENABLE_PUSH_NOTIFICATIONS, [CPPFLAGS+=" -DOPENDHT_PUSH_NOTIFICATIONS"], [])
-AM_COND_IF(ENABLE_PROXY_SERVER_IDENTITY, [CPPFLAGS+=" -DOPENDHT_PROXY_SERVER_IDENTITY"], [])
+AM_COND_IF(ENABLE_PUSH_NOTIFICATIONS, [
+    save_CPPFLAGS="${CPPFLAGS}"
+    CPPFLAGS="${save_CPPFLAGS} -DOPENDHT_PUSH_NOTIFICATIONS"
+], [])
+AM_COND_IF(ENABLE_PROXY_SERVER_IDENTITY, [
+    save_CPPFLAGS="${CPPFLAGS}"
+    CPPFLAGS="${save_CPPFLAGS} -DOPENDHT_PROXY_SERVER_IDENTITY"
+], [])
 
 dnl Configure setup.py if we build the python module
 AC_SUBST(CURRENT_SOURCE_DIR, ".")


### PR DESCRIPTION
configure.ac uses += operator such as `CPPFLAGS+=" -DOPENDHT_JSONCPP"`, this is bash extension.
In Linux, /bin/sh points bash or alternative, not genuine sh. So OpenBSD's /bin/sh cannot set CPPFLAGS correctly and fails to build tools due to building not-linkable (always -fvisibility=hidden) object.
Here is remedy, please do not use += operator in configure.ac.

