### PR TITLE
make crypto error messages more readable

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -1152,12 +1152,19 @@ loadIdentity(const std::string &path,const std::string &privkey_password)
     pkStream.close();
     // Create a certificate
     gnutls_x509_crt_t gnuCert;
-    if (gnutls_x509_crt_init(&gnuCert) != GNUTLS_E_SUCCESS)
+    if (gnutls_x509_crt_init(&gnuCert))
         throw std::runtime_error("Failed to initialize gnutls certificate struct");
     gnutls_datum_t crtContent {nullptr, 0};
+
     // Read the certificate file
-    gnutls_load_file((path + ".crt").c_str(), &crtContent);
-    gnutls_x509_crt_import(gnuCert, &crtContent, GNUTLS_X509_FMT_PEM);
+    int err = gnutls_load_file((path + ".crt").c_str(), &crtContent);
+    if (err)
+        throw CryptoException(gnutls_strerror(err));
+
+    err = gnutls_x509_crt_import(gnuCert, &crtContent, GNUTLS_X509_FMT_PEM);
+    if (err)
+        throw CryptoException(gnutls_strerror(err));
+
     auto cert = std::make_shared<Certificate>(gnuCert);
     return {std::move(key), std::move(cert)};
 }
@@ -1204,31 +1211,47 @@ Certificate::generate(const PrivateKey& key, const std::string& name, const Iden
     auto pk_id = pk.getId();
     const std::string uid_str = pk_id.toString();
 
-    gnutls_x509_crt_set_subject_key_id(cert, &pk_id, sizeof(pk_id));
-    gnutls_x509_crt_set_dn_by_oid(cert, GNUTLS_OID_X520_COMMON_NAME, 0, name.data(), name.length());
-    gnutls_x509_crt_set_dn_by_oid(cert, GNUTLS_OID_LDAP_UID, 0, uid_str.data(), uid_str.length());
+    int err = gnutls_x509_crt_set_subject_key_id(cert, &pk_id, sizeof(pk_id));
+    if(err) {
+        throw CryptoException(std::string("Error when setting subject key id ") + gnutls_strerror(err));
+    }
+
+    err = gnutls_x509_crt_set_dn_by_oid(cert, GNUTLS_OID_X520_COMMON_NAME, 0, name.data(), name.length());
+    if(err) {
+        throw CryptoException(std::string("Error when setting subject key id ") + gnutls_strerror(err));
+    }
+    err = gnutls_x509_crt_set_dn_by_oid(cert, GNUTLS_OID_LDAP_UID, 0, uid_str.data(), uid_str.length());
+    if(err) {
+        throw CryptoException(std::string("Error when setting dn by oid ") + gnutls_strerror(err));
+    }
 
     setRandomSerial(cert);
 
     unsigned key_usage = 0;
     if (is_ca) {
-        gnutls_x509_crt_set_ca_status(cert, 1);
+        err = gnutls_x509_crt_set_ca_status(cert, 1);
+        if(err) {
+            throw CryptoException(std::string("Error when setting ca status ") + gnutls_strerror(err));
+        }
         key_usage |= GNUTLS_KEY_KEY_CERT_SIGN | GNUTLS_KEY_CRL_SIGN;
     } else {
         key_usage |= GNUTLS_KEY_DIGITAL_SIGNATURE | GNUTLS_KEY_DATA_ENCIPHERMENT;
     }
-    gnutls_x509_crt_set_key_usage(cert, key_usage);
+    err = gnutls_x509_crt_set_key_usage(cert, key_usage);
+    if(err) {
+        throw CryptoException(std::string("Error when setting ca status ") + gnutls_strerror(err));
+    }
 
     if (ca.first && ca.second) {
         if (not ca.second->isCA()) {
             throw CryptoException("Signing certificate must be CA");
         }
-        if (int err = gnutls_x509_crt_privkey_sign(cert, ca.second->cert, ca.first->key, pk.getPreferredDigest(), 0)) {
+        if (err = gnutls_x509_crt_privkey_sign(cert, ca.second->cert, ca.first->key, pk.getPreferredDigest(), 0)) {
             throw CryptoException(std::string("Error when signing certificate ") + gnutls_strerror(err));
         }
         ret.issuer = ca.second;
     } else {
-        if (int err = gnutls_x509_crt_privkey_sign(cert, cert, key.key, pk.getPreferredDigest(), 0)) {
+        if (err = gnutls_x509_crt_privkey_sign(cert, cert, key.key, pk.getPreferredDigest(), 0)) {
             throw CryptoException(std::string("Error when signing certificate ") + gnutls_strerror(err));
         }
     }


### PR DESCRIPTION
Add verifications to gnutls calls and throw expcetion with readable messages.
For example, if call loadIdentity and crt file has name different of private key exception message was
Can't get certificate public key ID: ASN1 parser: Value was not found.

However, the real problem is that crt file was not found. Now, for the same problem the exception message will be: Error while reading file.