### PR TITLE
complicate node spoofing

### DIFF
--- a/include/opendht/node.h
+++ b/include/opendht/node.h
@@ -89,6 +89,9 @@ struct Node {
     bool isRemovable(const time_point& now) const {
         return isExpired() and isOld(now);
     }
+    bool isUpgradeable(const time_point& now) const {
+        return time + NODE_UPDATE_TIME < now;
+    }
 
     NodeExport exportNode() const {
         NodeExport ne;
@@ -150,6 +153,9 @@ struct Node {
 
     /* The time after which we consider a node to be expirable. */
     static constexpr const std::chrono::minutes NODE_EXPIRE_TIME {10};
+
+    /* The time after which we consider a node to be upgradeable. */
+    static constexpr const std::chrono::minutes NODE_UPDATE_TIME {1};
 
     /* Time for a request to timeout */
     static constexpr const std::chrono::seconds MAX_RESPONSE_TIME {1};

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -28,6 +28,7 @@ namespace dht {
 
 constexpr std::chrono::minutes Node::NODE_EXPIRE_TIME;
 constexpr std::chrono::minutes Node::NODE_GOOD_TIME;
+constexpr std::chrono::minutes Node::NODE_UPDATE_TIME;
 constexpr std::chrono::seconds Node::MAX_RESPONSE_TIME;
 
 Node::Node(const InfoHash& id, const SockAddr& addr, std::mt19937_64& rd, bool client)

--- a/src/node_cache.cpp
+++ b/src/node_cache.cpp
@@ -115,7 +115,7 @@ NodeCache::NodeMap::getNode(const InfoHash& id, const SockAddr& addr, time_point
             cleanup();
             cleanup_counter = 0;
         }
-    } else if (confirm or node->isOld(now)) {
+    } else if ((confirm and node->isUpgradeable(now)) or node->isOld(now)) {
         node->update(addr);
     }
     return node;


### PR DESCRIPTION
DHT allows the impersonation attack because method getNode updates the node's addr in following case: node A (IP address 1.1.1.1) has InfoHash 8ffe0d18748cfc04d1bc0a2e8c3a548e06f3f794 and sends a Ping to node B (IP address 2.2.2.2), then node B sends neighborhood maintenance to 1.1.1.1. Thus, a malicious node (IP Address 3.3.3.3) discovers the InfoHash 8ffe0d18748cfc04d1bc0a2e8c3a548e06f3f794 from Node A and sends DHT packets to Node B.

Thus, when node B receives a message, it will update the node A address. Then, it will send the neighborhood maintenance to 3.3.3.3 instead 1.1.1.1.
With this change, node A will update the node addr when node B sends a confirmation after 1 minute or it is old. When node B is not old, node A updates the node addr with its actual addr.