### PR TITLE
Fix an unused parameter warning in dhtrunnertester

### DIFF
--- a/tests/dhtrunnertester.cpp
+++ b/tests/dhtrunnertester.cpp
@@ -289,7 +289,7 @@ DhtRunnerTester::testIdOps() {
         valueCountEdit++;
         cv.notify_all();
     });
-    node2.listen(key2, [&](const std::vector<std::shared_ptr<dht::Value>>& values, bool expired){
+    node2.listen(key2, [&](const std::vector<std::shared_ptr<dht::Value>>& values, bool /*expired*/){
         for (const auto& v : values) {
             if (v->seq == 0)
                 CPPUNIT_ASSERT_EQUAL("v1"s, dht::unpackMsg<std::string>(v->data));


### PR DESCRIPTION
This change eliminates the following compiler warning without reducing readability:

```
/home/noviv/opendht/tests/dhtrunnertester.cpp: In lambda function: /home/noviv/opendht/tests/dhtrunnertester.cpp:292:89: warning: unused parameter ‘expired’ [-Wunused-parameter]
  292 |     node2.listen(key2, [&](const std::vector<std::shared_ptr<dht::Value>>& values, bool expired){
      |                                                                                    ~~~~~^~~~~~~
```