### PR TITLE
Get off of deprecated GCM AES methods

### DIFF
--- a/tests/cryptotester.cpp
+++ b/tests/cryptotester.cpp
@@ -239,6 +239,27 @@ void CryptoTester::testAesEncryption() {
     CPPUNIT_ASSERT(data2 == decrypted2);
 }
 
+void CryptoTester::testAesEncryptionWithMultipleKeySizes() {
+    auto data = std::vector<uint8_t>(rand(), rand());
+
+    // Valid key sizes
+    for (auto key_length : {16, 24, 32}) {
+        auto key = std::vector<uint8_t>(key_length, rand());
+
+        auto encrypted_data = dht::crypto::aesEncrypt(data, key);
+        auto decrypted_data = dht::crypto::aesDecrypt(encrypted_data, key);
+
+        CPPUNIT_ASSERT(data == decrypted_data);
+    }
+
+    // Invalid key sizes
+    for (auto key_length : {12, 28, 36}) {
+        auto key = std::vector<uint8_t>(key_length, rand());
+
+        CPPUNIT_ASSERT_THROW(dht::crypto::aesEncrypt(data, key), dht::crypto::DecryptError);
+    }
+}
+
 void
 CryptoTester::tearDown() {
 

--- a/tests/cryptotester.h
+++ b/tests/cryptotester.h
@@ -34,6 +34,7 @@ class CryptoTester : public CppUnit::TestFixture {
     CPPUNIT_TEST(testCertificateSerialNumber);
     CPPUNIT_TEST(testOcsp);
     CPPUNIT_TEST(testAesEncryption);
+    CPPUNIT_TEST(testAesEncryptionWithMultipleKeySizes);
     CPPUNIT_TEST_SUITE_END();
 
  public:
@@ -69,6 +70,7 @@ class CryptoTester : public CppUnit::TestFixture {
      * Test key streching and aes encryption/decryption
      */
     void testAesEncryption();
+    void testAesEncryptionWithMultipleKeySizes();
 };
 
 }  // namespace test


### PR DESCRIPTION
Multiple compiler warnings note that the `gcm_aes_*` family of functions are deprecated. They have been replaced with `gcm_aes<key_length>_*`. This change uses the correct set of functions based on the given key size. Resolves #571.

Sample compiler warning:
```
/home/noviv/opendht/src/crypto.cpp: In function ‘dht::Blob dht::crypto::aesEncrypt(const uint8_t*, size_t, const dht::Blob&)’: /home/noviv/opendht/src/crypto.cpp:97:20: warning: ‘void nettle_gcm_aes_set_key(gcm_aes_ctx*, size_t, const uint8_t*)’ is deprecated [-Wdeprecated-declarations]
   97 |     gcm_aes_set_key(&aes, key.size(), key.data());
         |                    ^
         In file included from /home/noviv/opendht/src/crypto.cpp:27:
         /usr/include/nettle/gcm.h:276:1: note: declared here
           276 | gcm_aes_set_key(struct gcm_aes_ctx *ctx,
                 | ^~~~~~~~~~~~~~~)
```
https://github.com/gnutls/nettle/commit/6a19845e6f71791ca98765d490ec08e776494bee marked the functions as deprecated.