### PR TITLE
peer discovery: add a timer to schedule `connectivityChanged` 

### DIFF
--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -269,6 +269,10 @@ DhtRunner::run(const Config& config, Context&& context)
                 if (status4 == NodeStatus::Disconnected && status6 == NodeStatus::Disconnected) {
                     peerDiscovery_->connectivityChanged();
                 }
+                else if (status4 != NodeStatus::Connected || status6 != NodeStatus::Connected) {
+                    peerDiscovery_->stopConnectivityChanged();
+                }
+
             });
         }
 #endif


### PR DESCRIPTION
Add a timer to schedule `connectivityChanged` with a maximum interval of one minute. If `connectivityChanged` is called and the node status remains unchanged (still disconnected), it will be called three more times at intervals of 10s, 20s, and 40s. If the status changes during this process, the timer will be canceled.