### PR TITLE
dht_proxy_server: fix Android push notifications

### DIFF
--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -1107,10 +1107,14 @@ DhtProxyServer::sendPushNotification(const std::string& token, Json::Value&& jso
             notification["tokens"] = std::move(tokens);
             notification["platform"] = type == PushType::Android ? 2 : 1;
             notification["data"] = std::move(json);
-            notification["priority"] = highPriority ? "high" : "normal";
-            if (type == PushType::Android)
-                notification["time_to_live"] = 3600 * 24; // 24 hours
-            else {
+            auto priority = highPriority ? "high" : "normal";
+            if (type == PushType::Android) {
+                Json::Value androidConfig(Json::objectValue);
+                androidConfig["priority"] = priority;
+                androidConfig["ttl"] = "86400s"; // time to live = 24 hours
+                notification["android"] = std::move(androidConfig);
+            } else {
+                notification["priority"] = priority;
                 const auto expiration = std::chrono::system_clock::now() + std::chrono::hours(24);
                 uint32_t exp = std::chrono::duration_cast<std::chrono::seconds>(expiration.time_since_epoch()).count();
                 notification["expiration"] = exp;


### PR DESCRIPTION
This commit updates the format of the push notification requests sent by the DHT proxy server to conform to FCM's HTTP v1 API. (The previously used API was deprecated in 2023, see:
https://firebase.google.com/docs/cloud-messaging/migrate-v1) The "priority" and "ttl" (time to live) options are specific to Android and therefore need to be put in the "android" block, as documented here: https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages