### PR TITLE
value: preserve priority when encrypting

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -271,6 +271,7 @@ Value::encrypt(const crypto::PrivateKey& from, const crypto::PublicKey& to)
     setRecipient(to.getId());
     sign(from);
     Value nv {id};
+    nv.priority = priority;
     nv.setCypher(to.encrypt(getToEncrypt()));
     return nv;
 }


### PR DESCRIPTION
All encrypted values put on the DHT currently have the default priority of 0 because the priority information is ignored by the Value::encrypt function.