### PR TITLE
MS Visual Studio .gitignore fix for CMake implicit builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,10 @@ Makefile.in
 # VSCode
 .vscode/*
 
+# Visual Studio
+.vs/
+CMakeSettings.json
+
 # Eclipse CDT
 .cproject
 .project
@@ -78,3 +82,5 @@ doc/Doxyfile
 build
 build_dev
 .DS_Store
+build-*/
+install/


### PR DESCRIPTION
- Addresses review: https://github.com/savoirfairelinux/opendht/pull/750#discussion_r2089277264 in #750 by @aberaud 
- Allows clean clone and build in MS Visual Studio with different settings