### PR TITLE
Gnutls version handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,8 +185,7 @@ else ()
     add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS
                     -D_CRT_SECURE_NO_WARNINGS
                     -DWIN32_LEAN_AND_MEAN
-                    -DSTATIC_GETOPT
-                    -DGNUTLS_INTERNAL_BUILD)
+                    -DSTATIC_GETOPT)
     set(DISABLE_MSC_WARNINGS "/wd4101 /wd4244 /wd4267 /wd4273 /wd4804 /wd4834 /wd4996")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DISABLE_MSC_WARNINGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -1501,7 +1501,22 @@ OcspResponse::getCertificateStatus() const
 {
     int ret;
     unsigned int status;
+    // MSVC/vcpkg GnuTLS cast workaround
+#if _WIN32 && (GNUTLS_VERSION_NUMBER >= 0x030807)
+    ret = gnutls_ocsp_resp_get_single(response, 
+                                      0, 
+                                      NULL, 
+                                      NULL, 
+                                      NULL, 
+                                      NULL, 
+                                      reinterpret_cast<gnutls_ocsp_cert_status_t*>(& status), 
+                                      NULL, 
+                                      NULL, 
+                                      NULL, 
+                                      NULL);
+#else
     ret = gnutls_ocsp_resp_get_single(response, 0, NULL, NULL, NULL, NULL, &status, NULL, NULL, NULL, NULL);
+#endif
     if (ret < 0)
         throw CryptoException(gnutls_strerror(ret));
     return (gnutls_ocsp_cert_status_t) status;
@@ -1559,8 +1574,23 @@ OcspResponse::verifyDirect(const Certificate& crt, const Blob& nonce)
         throw CryptoException(gnutls_strerror(ret));
 
     // Check certificate revocation status
-    unsigned status_ocsp;
+    unsigned int status_ocsp;
+    // MSVC/vcpkg GnuTLS cast workaround
+#if _WIN32 && (GNUTLS_VERSION_NUMBER >= 0x030807)
+    ret = gnutls_ocsp_resp_get_single(response, 
+                                      0, 
+                                      NULL, 
+                                      NULL, 
+                                      NULL, 
+                                      NULL, 
+                                      reinterpret_cast<gnutls_ocsp_cert_status_t*>(& status_ocsp), 
+                                      NULL, 
+                                      NULL, 
+                                      NULL, 
+                                      NULL);
+#else
     ret = gnutls_ocsp_resp_get_single(response, 0, NULL, NULL, NULL, NULL, &status_ocsp, NULL, NULL, NULL, NULL);
+#endif
     if (ret < 0)
         throw CryptoException(gnutls_strerror(ret));
     return (gnutls_ocsp_cert_status_t)status_ocsp;


### PR DESCRIPTION
- Added GnuTLS version handler directives for versions 3.8.7 and later
      https://github.com/savoirfairelinux/opendht/pull/750#discussion_r2089284896
- Removed `GNUTLS_INTERNAL_BUILD` definition to avoid problems with `gnutls_free()`
      function (https://github.com/savoirfairelinux/opendht/pull/750#issuecomment-2832005765)
     https://github.com/ShiftMediaProject/gnutls/blob/f78e2e673e84601283fb5ec353bfdd53204becd2/SMP/gnutls/gnutls.h#L2286