### PR TITLE
CMakePresets.json - remove UNIX preset for convenience

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,11 +10,6 @@
           "OPENDHT_PROXY_CLIENT": true,
           "OPENDHT_C": true
         }
-      },
-      {
-        "name": "unix",
-        "generator": "Ninja",
-        "binaryDir": "${sourceDir}/build"
       }
     ]
   }


### PR DESCRIPTION
It is better to remove UNIX preset here, for the most users who prefer GNU Make generator