### PR TITLE
Generalization of CMake build presets for MSVC

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -65,7 +65,8 @@
         "VCPKG_TARGET_TRIPLET": "x64-windows-release",
         "VCPKG_OVERLAY_TRIPLETS": "x64-windows-release;x64-windows-rel;x64-windows",
         "BUILD_TESTING": false,
-        "OPENDHT_CPACK": true
+        "OPENDHT_CPACK": true,
+        "OPENDHT_C": false
       }
     },
     {
@@ -90,7 +91,8 @@
         "VCPKG_TARGET_TRIPLET": "x64-windows-static-release",
         "VCPKG_OVERLAY_TRIPLETS": "x64-windows-static-release;x64-windows-static-rel;x64-windows-static",
         "BUILD_TESTING": false,
-        "OPENDHT_CPACK": true
+        "OPENDHT_CPACK": true,
+        "OPENDHT_C": false
       }
     },
     {
@@ -115,7 +117,8 @@
         "VCPKG_TARGET_TRIPLET": "x64-windows-release",
         "VCPKG_OVERLAY_TRIPLETS": "x64-windows-release;x64-windows-rel;x64-windows",
         "BUILD_TESTING": false,
-        "OPENDHT_CPACK": true
+        "OPENDHT_CPACK": true,
+        "OPENDHT_C": false
       }
     },
     {
@@ -140,7 +143,8 @@
         "VCPKG_TARGET_TRIPLET": "x64-windows-static-release",
         "VCPKG_OVERLAY_TRIPLETS": "x64-windows-static-release;x64-windows-static-rel;x64-windows-static",
         "BUILD_TESTING": false,
-        "OPENDHT_CPACK": true
+        "OPENDHT_CPACK": true,
+        "OPENDHT_C": false
       }
     },
     {


### PR DESCRIPTION
- Generalised MSVC build with root presets.
- Separated build pipelines into 'minimal' and 'full' variants.
- Added `VCPKG_MANIFEST_MODE` to handle local `vcpkg` installation.
- Inspected `VCPKG_TARGET_TRIPLET` and added `VCPKG_OVERLAY_TRIPLETS` as fallback options.
- Removed `VCPKG_LIBRARY_LINKAGE` as this variable is a [vcpkg CLI triplet parameter](https://learn.microsoft.com/en-us/vcpkg/users/triplets#vcpkg_library_linkage), not a CMake one: https://github.com/savoirfairelinux/opendht/pull/750#issuecomment-2976747247.