### PR TITLE
Fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,4 +1,6 @@
 name: Windows Build
+permissions:
+  contents: read
 
 on: 
   push:


### PR DESCRIPTION
Fix for [https://github.com/savoirfairelinux/opendht/security/code-scanning/7](https://github.com/savoirfairelinux/opendht/security/code-scanning/7)

To fix the problem, add an explicit `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. The best way to do this is to add a `permissions` block at the root level of the workflow (just after the `name:` and before `on:`), which will apply to all jobs unless overridden. For this workflow, the minimal required permission is `contents: read`, which allows jobs to read repository contents but not write to them. No additional imports or definitions are needed; this is a YAML configuration change.
