### PR TITLE
configure.ac: Fix llhttplib substituion.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -184,7 +184,7 @@ AM_COND_IF([PROXY_CLIENT_OR_SERVER], [
     # llhttp has no pkgconfig, instead we check with:
     AC_CHECK_LIB(llhttp, exit,, AC_MSG_ERROR([Missing llhttp library files]))
     AC_CHECK_HEADERS([llhttp.h], [llhttp_headers=yes; break;])
-    AC_SUBST(http_lib, ["-lllhttp"])
+    AC_SUBST(llhttp_lib, [", liblllhttp"])
     AS_IF([test "x$llhttp_headers" != "xyes"], AC_MSG_ERROR([Missing llhttp headers files]))
 ])
 


### PR DESCRIPTION
## Changes
* configure.ac (@http_lib@): Rename to llhttp_lib, replace the substituted value for a pkg-config module name.
## Description
Currently the macro names for `libhttplib` differ in `opendht.pc.in` and `configure.ac`. This changes them to match the earlier change, and also adjusts the value substituted in by Autoconf to match the one expected from current formatting in `opendht.pc.in`. This doesn't fix the build, though, since the macro for `liburing` is also never substituted.