### PR TITLE
Fix Autotools build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,6 +186,14 @@ AM_COND_IF([PROXY_CLIENT_OR_SERVER], [
 ])
 AC_SUBST(llhttp_lib)
 
+AC_ARG_WITH([liburing], AS_HELP_STRING([--with-liburing], [Build with io_uring support(Linux only)]),[], [with_liburing=no])
+AS_IF([test "x$with_liburing" != "xno"], [
+    CXX_FLAGS="${CXXFLAGS} -DASIO_HAS_IO_URING -DASIO_DISABLE_EPOLL"
+    PKG_CHECK_MODULES([Liburing], [liburing])
+    iouring_lib=", liburing"
+])
+AC_SUBST(iouring_lib)
+
 CXXFLAGS="${CXXFLAGS} -DMSGPACK_NO_BOOST -DMSGPACK_DISABLE_LEGACY_NIL -DMSGPACK_DISABLE_LEGACY_CONVERT"
 
 AC_ARG_ENABLE([tools], AS_HELP_STRING([--disable-tools],[Disable tools (CLI DHT node)]),,build_tools=yes)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES = libopendht.la
 
-libopendht_la_CPPFLAGS = @CPPFLAGS@ -I$(top_srcdir)/include/opendht @Argon2_CFLAGS@ @JsonCpp_CFLAGS@ @MsgPack_CFLAGS@ @OpenSSL_CFLAGS@ @Fmt_CFLAGS@ @Llhttp_CFLAGS@
-libopendht_la_LIBADD   = @Argon2_LIBS@ @JsonCpp_LIBS@ @GnuTLS_LIBS@ @Nettle_LIBS@ @OpenSSL_LIBS@ @Fmt_LIBS@ @Llhttp_LIBS@
+libopendht_la_CPPFLAGS = @CPPFLAGS@ -I$(top_srcdir)/include/opendht @Argon2_CFLAGS@ @JsonCpp_CFLAGS@ @MsgPack_CFLAGS@ @OpenSSL_CFLAGS@ @Fmt_CFLAGS@ @Llhttp_CFLAGS@ @Liburing_CFLAGS@
+libopendht_la_LIBADD   = @Argon2_LIBS@ @JsonCpp_LIBS@ @GnuTLS_LIBS@ @Nettle_LIBS@ @OpenSSL_LIBS@ @Fmt_LIBS@ @Llhttp_LIBS@ @Liburing_LIBS@
 libopendht_la_LDFLAGS  = @LDFLAGS@ -version-number @OPENDHT_MAJOR_VERSION@:@OPENDHT_MINOR_VERSION@:@OPENDHT_PATCH_VERSION@
 libopendht_la_SOURCES  = \
         dht.cpp \


### PR DESCRIPTION
## Changes
* configure.ac: Use pkg-config to test for llhttp. Add --with-liburing flag, tests and substitutions for liburing.
* src/Makefile.am: Add compiler and linker flags for both.
## Description
This is a follow up for https://github.com/savoirfairelinux/opendht/pull/799. Apparently, I made a mistake in that single line patch.
`llhttp` now actually provides a `.pc` entry, so I swapped the existing tests for it for `PKG_CHECK_MODULES` macro. I also added a `--with-liburing` flag for `configure`, and a substitution for `@iouring_lib@`. I've checked the generated `Makefile` and `opendht.pc` when configuring with and without flags for both and they appear to be correct. It also correctly aborts when `--with-liburing` is provided with absent `liburing`. I've succesfully built this commit with `liburing` disabled and I built `dhtnet` against it. 
I've tried to match the behaviour in `CMakeLists.txt` with these changes.