### PR TITLE
opendht: restore push subscriptions immediately on reconnect

### DIFF
--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -1251,10 +1251,19 @@ DhtProxyClient::pushNotificationReceived([[maybe_unused]] const std::map<std::st
         // If a push notification is received, the proxy is up and running
         std::lock_guard l(lockCurrentProxyInfos_);
         auto oldStatus = std::max(statusIpv4_, statusIpv6_);
-        if (oldStatus != NodeStatus::Connected)
-            launchConnectedCbs_ = true;
         statusIpv4_ = NodeStatus::Connected;
         statusIpv6_ = NodeStatus::Connected;
+        if (oldStatus != NodeStatus::Connected) {
+            launchConnectedCbs_ = true;
+            // The push itself proves the proxy is reachable — restore subscriptions
+            // immediately without waiting for a getProxyInfos() HTTP round-trip.
+            // This mirrors what onProxyInfos() does on Connected transition, but
+            // avoids the extra network request (critical under Doze/App Standby where
+            // background DNS may be blocked).
+            listenerRestartTimer_->expires_at(std::chrono::steady_clock::now());
+            listenerRestartTimer_->async_wait(
+                std::bind(&DhtProxyClient::restartListeners, this, std::placeholders::_1));
+        }
     }
     auto launchLoop = false;
     try {


### PR DESCRIPTION
When a push notification arrives while the DHT proxy client is Disconnected (e.g. after Android Doze blocks background DNS), arm listenerRestartTimer_ immediately inside pushNotificationReceived() instead of waiting for a successful getProxyInfos() HTTP round-trip.

The push itself proves the proxy is reachable. This mirrors what onProxyInfos() does on a Connected transition but avoids the extra network request that fails under Doze/App Standby when DNS is blocked.

restartListeners() will resubscribe() all listeners whose opstate->ok is false (marked dead by opFailed()), restoring push subscriptions without any additional HTTP overhead.