### PR TITLE
ci: use lukka/run-vcpkg@v11 for Windows build caching

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -9,148 +9,41 @@ on:
     branches: [ main, master ]
 
 env:
-  VCPKG_VERSION: "2026.01.16"
-  VCPKG_INSTALLATION_ROOT: "C:\\vcpkg"
   VCPKG_DISABLE_METRICS: "1"
-  VCPKG_INSTALLED_DIR: ${{ github.workspace }}\vcpkg_installed
-  VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}\vcpkg_binary_cache
 
 jobs:
-  prepare-dependencies:
-    name: Prepare Windows Dependencies
-    runs-on: windows-latest
-    outputs:
-      vcpkg_cache_key: ${{ steps.generate_cache_key.outputs.key }}
-    strategy:
-      matrix:
-        arch: [x64]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Set up MSVC
-        uses: microsoft/setup-msbuild@v3
-
-      - name: Generate Cache Key
-        id: generate_cache_key
-        shell: pwsh
-        run: |
-          $key_value = "${{ runner.os }}-vcpkg-${{ env.VCPKG_VERSION }}-${{ matrix.arch }}-shared-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}-${{ hashFiles('.github/workflows/windows-build.yml') }}"
-          echo "key=$key_value" >> $env:GITHUB_OUTPUT
-
-      - name: Cache vcpkg installed packages
-        id: cache-vcpkg
-        uses: actions/cache@v5
-        with:
-          path: |
-            ${{ env.VCPKG_INSTALLED_DIR }}
-            ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          key: ${{ steps.generate_cache_key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-${{ env.VCPKG_VERSION }}-${{ matrix.arch }}-shared-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
-            ${{ runner.os }}-vcpkg-${{ env.VCPKG_VERSION }}-${{ matrix.arch }}-shared-
-
-      - name: Setup vcpkg and install dependencies
-        if: steps.cache-vcpkg.outputs.cache-hit != 'true'
-        run: |
-          New-Item -Path "${{ env.VCPKG_INSTALLED_DIR }}" -ItemType Directory -Force
-          New-Item -Path "${{ env.VCPKG_DEFAULT_BINARY_CACHE }}" -ItemType Directory -Force
-          vcpkg install `
-            --recurse `
-            --clean-after-build `
-            --triplet=${{ matrix.arch }}-windows `
-            --x-install-root=${{ env.VCPKG_INSTALLED_DIR }} `
-            --x-feature=test
-        shell: pwsh
-
-  prepare-static-dependencies:
-    name: Prepare Windows Static Dependencies
-    runs-on: windows-latest
-    outputs:
-      vcpkg_static_cache_key: ${{ steps.generate_static_cache_key.outputs.key }}
-    strategy:
-      matrix:
-        arch: [x64]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Set up MSVC
-        uses: microsoft/setup-msbuild@v3
-
-      - name: Generate Cache Key for Static Libs
-        id: generate_static_cache_key
-        shell: pwsh
-        run: |
-          $key_value = "${{ runner.os }}-vcpkg-${{ env.VCPKG_VERSION }}-${{ matrix.arch }}-static-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}-${{ hashFiles('.github/workflows/windows-build.yml') }}"
-          echo "key=$key_value" >> $env:GITHUB_OUTPUT
-
-      - name: Cache vcpkg static installed packages
-        id: cache-vcpkg-static
-        uses: actions/cache@v5
-        with:
-          path: |
-            ${{ env.VCPKG_INSTALLED_DIR }}
-            ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          key: ${{ steps.generate_static_cache_key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-${{ env.VCPKG_VERSION }}-${{ matrix.arch }}-static-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
-            ${{ runner.os }}-vcpkg-${{ env.VCPKG_VERSION }}-${{ matrix.arch }}-static-
-
-      - name: Setup vcpkg and install static dependencies
-        if: steps.cache-vcpkg-static.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          New-Item -Path "${{ env.VCPKG_INSTALLED_DIR }}" -ItemType Directory -Force
-          New-Item -Path "${{ env.VCPKG_DEFAULT_BINARY_CACHE }}" -ItemType Directory -Force
-          vcpkg install `
-            --recurse `
-            --clean-after-build `
-            --triplet=${{ matrix.arch }}-windows-static-release `
-            --x-install-root=${{ env.VCPKG_INSTALLED_DIR }} `
-            --x-feature=test
-
   build-windows:
-    name: Windows MSVC Build
+    name: Windows MSVC (${{ matrix.arch }}-windows, ${{ matrix.build_type }}, C++${{ matrix.cxx_standard }})
     runs-on: windows-latest
-    needs: prepare-dependencies
-    
     strategy:
+      fail-fast: false
       matrix:
         build_type: [Debug, Release]
         arch: [x64]
         cxx_standard: [17, 20, 23]
+    env:
+      VCPKG_DEFAULT_TRIPLET: ${{ matrix.arch }}-windows
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up MSVC
-        uses: microsoft/setup-msbuild@v3
+        uses: microsoft/setup-msbuild@v2
 
-      - name: Restore vcpkg installed packages
-        id: cache-vcpkg-restore
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ${{ env.VCPKG_INSTALLED_DIR }}
-            ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          key: ${{ needs.prepare-dependencies.outputs.vcpkg_cache_key }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-${{ env.VCPKG_VERSION }}-${{ matrix.arch }}-shared-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
-            ${{ runner.os }}-vcpkg-${{ env.VCPKG_VERSION }}-${{ matrix.arch }}-shared-
+      # run-vcpkg downloads & bootstraps vcpkg (commit from vcpkg-configuration.json
+      # baseline), then sets VCPKG_ROOT and VCPKG_BINARY_SOURCES to use GitHub
+      # Actions cache for Binary Caching. No manual cache step needed.
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
 
       - name: Configure CMake
         shell: pwsh
         run: |
-          mkdir build -ErrorAction SilentlyContinue
           cmake -B build `
             -S . `
-            -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_INSTALLATION_ROOT }}/scripts/buildsystems/vcpkg.cmake `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-windows `
-            -DVCPKG_INSTALLED_DIR=${{ env.VCPKG_INSTALLED_DIR }} `
             -DVCPKG_MANIFEST_FEATURES=test `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} `
             -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} `
@@ -167,21 +60,15 @@ jobs:
             -A ${{ matrix.arch }}
 
       - name: Build
-        run: |
-          cmake --build build --config ${{ matrix.build_type }} --parallel 4
-          # Copy vcpkg installed libraries to the build directory
-          Copy-Item -Path "${{ env.VCPKG_INSTALLED_DIR }}\${{ matrix.arch }}-windows\lib\*.lib" -Destination "build" -Force
-          Copy-Item -Path "${{ env.VCPKG_INSTALLED_DIR }}\${{ matrix.arch }}-windows\bin\*.dll" -Destination "build" -Force
+        run: cmake --build build --config ${{ matrix.build_type }} --parallel 4
 
       - name: Test
         if: matrix.build_type == 'Release'
-        run: |
-          cd build
-          ctest --build-config ${{ matrix.build_type }} --output-on-failure --parallel 4
+        run: ctest --test-dir build --build-config ${{ matrix.build_type }} --output-on-failure
 
       - name: Upload build artifacts
         if: matrix.build_type == 'Release'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: opendht-windows-${{ matrix.arch }}-cxx${{ matrix.cxx_standard }}-${{ matrix.build_type }}
           path: |
@@ -191,43 +78,34 @@ jobs:
           retention-days: 7
 
   build-windows-static:
-    name: Windows Static MSVC Build
+    name: Windows Static MSVC (${{ matrix.arch }}-windows-static-release, ${{ matrix.build_type }}, C++${{ matrix.cxx_standard }})
     runs-on: windows-latest
-    needs: prepare-static-dependencies
     strategy:
+      fail-fast: false
       matrix:
         build_type: [Release]
         arch: [x64]
         cxx_standard: [17, 20, 23]
+    env:
+      VCPKG_DEFAULT_TRIPLET: ${{ matrix.arch }}-windows-static-release
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up MSVC
-        uses: microsoft/setup-msbuild@v3
+        uses: microsoft/setup-msbuild@v2
 
-      - name: Restore vcpkg static installed packages
-        id: cache-vcpkg-static-restore
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ${{ env.VCPKG_INSTALLED_DIR }}
-            ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          key: ${{ needs.prepare-static-dependencies.outputs.vcpkg_static_cache_key }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-${{ env.VCPKG_VERSION }}-${{ matrix.arch }}-static-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json') }}
-            ${{ runner.os }}-vcpkg-${{ env.VCPKG_VERSION }}-${{ matrix.arch }}-static-
-      
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+
       - name: Configure CMake for Static Build
         shell: pwsh
         run: |
-          mkdir build -ErrorAction SilentlyContinue
           cmake -B build `
             -S . `
-            -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_INSTALLATION_ROOT }}/scripts/buildsystems/vcpkg.cmake `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-windows-static-release `
-            -DVCPKG_INSTALLED_DIR=${{ env.VCPKG_INSTALLED_DIR }} `
             -DVCPKG_MANIFEST_FEATURES=test `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} `
             -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} `
@@ -245,18 +123,13 @@ jobs:
             -A ${{ matrix.arch }}
 
       - name: Build Static
-        shell: pwsh
-        run: |
-          cmake --build build --config ${{ matrix.build_type }} --parallel 4
+        run: cmake --build build --config ${{ matrix.build_type }} --parallel 4
 
       - name: Test Static Build
-        shell: pwsh
-        run: |
-          cd build
-          ctest --build-config ${{ matrix.build_type }} --output-on-failure --parallel 4
+        run: ctest --test-dir build --build-config ${{ matrix.build_type }} --output-on-failure
 
       - name: Upload static build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: opendht-windows-static-${{ matrix.arch }}-cxx${{ matrix.cxx_standard }}-${{ matrix.build_type }}
           path: |
@@ -275,7 +148,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup MinGW
         uses: msys2/setup-msys2@v2

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -38,12 +38,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: microsoft/setup-msbuild@v2
-      - name: Setup vcpkg and install packages
+      - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
+      - name: Install vcpkg packages (with retry)
+        uses: nick-fields/retry@v3
         with:
-          runVcpkgInstall: true
-          vcpkgJsonGlob: 'vcpkg.json'
-          runVcpkgFormatString: '[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--triplet`, `x64-windows-static-release`, `--x-feature=test`]'
+          timeout_minutes: 60
+          max_attempts: 3
+          shell: pwsh
+          command: >-
+            & "$env:VCPKG_ROOT/vcpkg.exe" install
+            --recurse
+            --clean-after-build
+            --triplet=x64-windows-static-release
+            --x-feature=test
+            --x-manifest-root=.
 
   build-windows:
     name: Windows MSVC (${{ matrix.arch }}-windows, ${{ matrix.build_type }}, C++${{ matrix.cxx_standard }})
@@ -67,8 +76,12 @@ jobs:
 
       # run-vcpkg sets VCPKG_ROOT and VCPKG_BINARY_SOURCES.
       # Packages are already in the binary cache from the vcpkg-shared job.
-      - name: Setup vcpkg
+      - name: Setup vcpkg and restore packages from cache
         uses: lukka/run-vcpkg@v11
+        with:
+          runVcpkgInstall: true
+          vcpkgJsonGlob: 'vcpkg.json'
+          runVcpkgFormatString: '[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--triplet`, `${{ matrix.arch }}-windows`, `--x-feature=test`]'
 
       - name: Configure CMake
         shell: pwsh
@@ -130,8 +143,12 @@ jobs:
       - name: Set up MSVC
         uses: microsoft/setup-msbuild@v2
 
-      - name: Setup vcpkg
+      - name: Setup vcpkg and restore packages from cache
         uses: lukka/run-vcpkg@v11
+        with:
+          runVcpkgInstall: true
+          vcpkgJsonGlob: 'vcpkg.json'
+          runVcpkgFormatString: '[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--triplet`, `${{ matrix.arch }}-windows-static-release`, `--x-feature=test`]'
 
       - name: Configure CMake for Static Build
         shell: pwsh

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -31,7 +31,9 @@ jobs:
         id: vcpkg-key
         shell: pwsh
         run: |
-          $hash = (Get-FileHash vcpkg.json -Algorithm SHA256).Hash.Substring(0, 16)
+          $combined = (Get-FileHash vcpkg.json -Algorithm SHA256).Hash + (Get-FileHash vcpkg-configuration.json -Algorithm SHA256).Hash
+          $bytes = [System.Text.Encoding]::UTF8.GetBytes($combined)
+          $hash = (([System.Security.Cryptography.SHA256]::Create().ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') }) -join '').Substring(0, 16)
           echo "key=vcpkg-x64-windows-$hash-${{ runner.os }}" >> $env:GITHUB_OUTPUT
 
       - name: Restore vcpkg_installed from cache
@@ -81,7 +83,9 @@ jobs:
         id: vcpkg-key
         shell: pwsh
         run: |
-          $hash = (Get-FileHash vcpkg.json -Algorithm SHA256).Hash.Substring(0, 16)
+          $combined = (Get-FileHash vcpkg.json -Algorithm SHA256).Hash + (Get-FileHash vcpkg-configuration.json -Algorithm SHA256).Hash
+          $bytes = [System.Text.Encoding]::UTF8.GetBytes($combined)
+          $hash = (([System.Security.Cryptography.SHA256]::Create().ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') }) -join '').Substring(0, 16)
           echo "key=vcpkg-x64-windows-static-release-$hash-${{ runner.os }}" >> $env:GITHUB_OUTPUT
 
       - name: Restore vcpkg_installed from cache
@@ -141,7 +145,9 @@ jobs:
         id: vcpkg-key
         shell: pwsh
         run: |
-          $hash = (Get-FileHash vcpkg.json -Algorithm SHA256).Hash.Substring(0, 16)
+          $combined = (Get-FileHash vcpkg.json -Algorithm SHA256).Hash + (Get-FileHash vcpkg-configuration.json -Algorithm SHA256).Hash
+          $bytes = [System.Text.Encoding]::UTF8.GetBytes($combined)
+          $hash = (([System.Security.Cryptography.SHA256]::Create().ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') }) -join '').Substring(0, 16)
           echo "key=vcpkg-x64-windows-$hash-${{ runner.os }}" >> $env:GITHUB_OUTPUT
 
       - name: Restore vcpkg_installed from cache
@@ -234,7 +240,9 @@ jobs:
         id: vcpkg-key
         shell: pwsh
         run: |
-          $hash = (Get-FileHash vcpkg.json -Algorithm SHA256).Hash.Substring(0, 16)
+          $combined = (Get-FileHash vcpkg.json -Algorithm SHA256).Hash + (Get-FileHash vcpkg-configuration.json -Algorithm SHA256).Hash
+          $bytes = [System.Text.Encoding]::UTF8.GetBytes($combined)
+          $hash = (([System.Security.Cryptography.SHA256]::Create().ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') }) -join '').Substring(0, 16)
           echo "key=vcpkg-x64-windows-static-release-$hash-${{ runner.os }}" >> $env:GITHUB_OUTPUT
 
       - name: Restore vcpkg_installed from cache

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -12,61 +12,9 @@ env:
   VCPKG_DISABLE_METRICS: "1"
 
 jobs:
-  # Pre-warm the vcpkg binary cache for x64-windows triplet.
-  # Subsequent matrix jobs will find packages already in cache.
-  vcpkg-shared:
-    name: Install vcpkg deps (x64-windows)
-    runs-on: windows-latest
-    env:
-      VCPKG_DEFAULT_TRIPLET: x64-windows
-    steps:
-      - uses: actions/checkout@v4
-      - uses: microsoft/setup-msbuild@v2
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
-      - name: Install vcpkg packages (with retry)
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          shell: pwsh
-          command: >-
-            & "$env:VCPKG_ROOT/vcpkg.exe" install
-            --recurse
-            --clean-after-build
-            --triplet=x64-windows
-            --x-feature=test
-            --x-manifest-root=.
-
-  # Pre-warm the vcpkg binary cache for x64-windows-static-release triplet.
-  vcpkg-static:
-    name: Install vcpkg deps (x64-windows-static-release)
-    runs-on: windows-latest
-    env:
-      VCPKG_DEFAULT_TRIPLET: x64-windows-static-release
-    steps:
-      - uses: actions/checkout@v4
-      - uses: microsoft/setup-msbuild@v2
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
-      - name: Install vcpkg packages (with retry)
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          shell: pwsh
-          command: >-
-            & "$env:VCPKG_ROOT/vcpkg.exe" install
-            --recurse
-            --clean-after-build
-            --triplet=x64-windows-static-release
-            --x-feature=test
-            --x-manifest-root=.
-
   build-windows:
     name: Windows MSVC (${{ matrix.arch }}-windows, ${{ matrix.build_type }}, C++${{ matrix.cxx_standard }})
     runs-on: windows-latest
-    needs: vcpkg-shared
     strategy:
       fail-fast: false
       matrix:
@@ -83,14 +31,22 @@ jobs:
       - name: Set up MSVC
         uses: microsoft/setup-msbuild@v2
 
-      # run-vcpkg sets VCPKG_ROOT and VCPKG_BINARY_SOURCES.
-      # Packages are already in the binary cache from the vcpkg-shared job.
-      - name: Setup vcpkg and restore packages from cache
+      - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
+
+      - name: Install vcpkg packages (with retry)
+        uses: nick-fields/retry@v3
         with:
-          runVcpkgInstall: true
-          vcpkgJsonGlob: 'vcpkg.json'
-          runVcpkgFormatString: '[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--triplet`, `${{ matrix.arch }}-windows`, `--x-feature=test`]'
+          timeout_minutes: 60
+          max_attempts: 3
+          shell: pwsh
+          command: >-
+            & "$env:VCPKG_ROOT/vcpkg.exe" install
+            --recurse
+            --clean-after-build
+            --triplet=${{ matrix.arch }}-windows
+            --x-feature=test
+            --x-manifest-root=.
 
       - name: Configure CMake
         shell: pwsh
@@ -99,6 +55,7 @@ jobs:
             -S . `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-windows `
+            -DVCPKG_MANIFEST_INSTALL=OFF `
             -DVCPKG_MANIFEST_FEATURES=test `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} `
             -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} `
@@ -135,7 +92,6 @@ jobs:
   build-windows-static:
     name: Windows Static MSVC (${{ matrix.arch }}-windows-static-release, ${{ matrix.build_type }}, C++${{ matrix.cxx_standard }})
     runs-on: windows-latest
-    needs: vcpkg-static
     strategy:
       fail-fast: false
       matrix:
@@ -152,12 +108,22 @@ jobs:
       - name: Set up MSVC
         uses: microsoft/setup-msbuild@v2
 
-      - name: Setup vcpkg and restore packages from cache
+      - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
+
+      - name: Install vcpkg packages (with retry)
+        uses: nick-fields/retry@v3
         with:
-          runVcpkgInstall: true
-          vcpkgJsonGlob: 'vcpkg.json'
-          runVcpkgFormatString: '[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--triplet`, `${{ matrix.arch }}-windows-static-release`, `--x-feature=test`]'
+          timeout_minutes: 60
+          max_attempts: 3
+          shell: pwsh
+          command: >-
+            & "$env:VCPKG_ROOT/vcpkg.exe" install
+            --recurse
+            --clean-after-build
+            --triplet=${{ matrix.arch }}-windows-static-release
+            --x-feature=test
+            --x-manifest-root=.
 
       - name: Configure CMake for Static Build
         shell: pwsh
@@ -166,6 +132,7 @@ jobs:
             -S . `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-windows-static-release `
+            -DVCPKG_MANIFEST_INSTALL=OFF `
             -DVCPKG_MANIFEST_FEATURES=test `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} `
             -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} `

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -22,12 +22,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: microsoft/setup-msbuild@v2
-      - name: Setup vcpkg and install packages
+      - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
+      - name: Install vcpkg packages (with retry)
+        uses: nick-fields/retry@v3
         with:
-          runVcpkgInstall: true
-          vcpkgJsonGlob: 'vcpkg.json'
-          runVcpkgFormatString: '[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--triplet`, `x64-windows`, `--x-feature=test`]'
+          timeout_minutes: 60
+          max_attempts: 3
+          shell: pwsh
+          command: >-
+            & "$env:VCPKG_ROOT/vcpkg.exe" install
+            --recurse
+            --clean-after-build
+            --triplet=x64-windows
+            --x-feature=test
+            --x-manifest-root=.
 
   # Pre-warm the vcpkg binary cache for x64-windows-static-release triplet.
   vcpkg-static:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -12,9 +12,41 @@ env:
   VCPKG_DISABLE_METRICS: "1"
 
 jobs:
+  # Pre-warm the vcpkg binary cache for x64-windows triplet.
+  # Subsequent matrix jobs will find packages already in cache.
+  vcpkg-shared:
+    name: Install vcpkg deps (x64-windows)
+    runs-on: windows-latest
+    env:
+      VCPKG_DEFAULT_TRIPLET: x64-windows
+    steps:
+      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@v2
+      - name: Setup vcpkg and install packages
+        uses: lukka/run-vcpkg@v11
+        with:
+          runVcpkgInstall: true
+          runVcpkgFormatString: '[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--triplet`, `x64-windows`, `--x-feature=test`]'
+
+  # Pre-warm the vcpkg binary cache for x64-windows-static-release triplet.
+  vcpkg-static:
+    name: Install vcpkg deps (x64-windows-static-release)
+    runs-on: windows-latest
+    env:
+      VCPKG_DEFAULT_TRIPLET: x64-windows-static-release
+    steps:
+      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@v2
+      - name: Setup vcpkg and install packages
+        uses: lukka/run-vcpkg@v11
+        with:
+          runVcpkgInstall: true
+          runVcpkgFormatString: '[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--triplet`, `x64-windows-static-release`, `--x-feature=test`]'
+
   build-windows:
     name: Windows MSVC (${{ matrix.arch }}-windows, ${{ matrix.build_type }}, C++${{ matrix.cxx_standard }})
     runs-on: windows-latest
+    needs: vcpkg-shared
     strategy:
       fail-fast: false
       matrix:
@@ -31,9 +63,8 @@ jobs:
       - name: Set up MSVC
         uses: microsoft/setup-msbuild@v2
 
-      # run-vcpkg downloads & bootstraps vcpkg (commit from vcpkg-configuration.json
-      # baseline), then sets VCPKG_ROOT and VCPKG_BINARY_SOURCES to use GitHub
-      # Actions cache for Binary Caching. No manual cache step needed.
+      # run-vcpkg sets VCPKG_ROOT and VCPKG_BINARY_SOURCES.
+      # Packages are already in the binary cache from the vcpkg-shared job.
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
 
@@ -80,6 +111,7 @@ jobs:
   build-windows-static:
     name: Windows Static MSVC (${{ matrix.arch }}-windows-static-release, ${{ matrix.build_type }}, C++${{ matrix.cxx_standard }})
     runs-on: windows-latest
+    needs: vcpkg-static
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -22,31 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: microsoft/setup-msbuild@v2
-      - name: Setup vcpkg
+      - name: Setup vcpkg and install packages
         uses: lukka/run-vcpkg@v11
-      - name: Install packages (with retry on download failure)
-        shell: pwsh
-        run: |
-          $maxAttempts = 3
-          for ($i = 1; $i -le $maxAttempts; $i++) {
-            Write-Host "vcpkg install attempt $i/$maxAttempts..."
-            & "$env:VCPKG_ROOT/vcpkg" install `
-              --recurse `
-              --clean-after-build `
-              --x-install-root="$env:VCPKG_INSTALLED_DIR" `
-              --triplet=x64-windows `
-              --x-feature=test
-            if ($LASTEXITCODE -eq 0) {
-              Write-Host "vcpkg install succeeded on attempt $i"
-              exit 0
-            }
-            if ($i -lt $maxAttempts) {
-              Write-Host "vcpkg install failed (exit $LASTEXITCODE), retrying in 30s..."
-              Start-Sleep -Seconds 30
-            }
-          }
-          Write-Host "vcpkg install failed after $maxAttempts attempts"
-          exit 1
+        with:
+          runVcpkgInstall: true
+          vcpkgJsonGlob: 'vcpkg.json'
+          runVcpkgFormatString: '[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--triplet`, `x64-windows`, `--x-feature=test`]'
 
   # Pre-warm the vcpkg binary cache for x64-windows-static-release triplet.
   vcpkg-static:
@@ -57,31 +38,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: microsoft/setup-msbuild@v2
-      - name: Setup vcpkg
+      - name: Setup vcpkg and install packages
         uses: lukka/run-vcpkg@v11
-      - name: Install packages (with retry on download failure)
-        shell: pwsh
-        run: |
-          $maxAttempts = 3
-          for ($i = 1; $i -le $maxAttempts; $i++) {
-            Write-Host "vcpkg install attempt $i/$maxAttempts..."
-            & "$env:VCPKG_ROOT/vcpkg" install `
-              --recurse `
-              --clean-after-build `
-              --x-install-root="$env:VCPKG_INSTALLED_DIR" `
-              --triplet=x64-windows-static-release `
-              --x-feature=test
-            if ($LASTEXITCODE -eq 0) {
-              Write-Host "vcpkg install succeeded on attempt $i"
-              exit 0
-            }
-            if ($i -lt $maxAttempts) {
-              Write-Host "vcpkg install failed (exit $LASTEXITCODE), retrying in 30s..."
-              Start-Sleep -Seconds 30
-            }
-          }
-          Write-Host "vcpkg install failed after $maxAttempts attempts"
-          exit 1
+        with:
+          runVcpkgInstall: true
+          vcpkgJsonGlob: 'vcpkg.json'
+          runVcpkgFormatString: '[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--triplet`, `x64-windows-static-release`, `--x-feature=test`]'
 
   build-windows:
     name: Windows MSVC (${{ matrix.arch }}-windows, ${{ matrix.build_type }}, C++${{ matrix.cxx_standard }})

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -172,6 +172,17 @@ jobs:
             --x-feature=test
             --x-manifest-root=.
 
+      - name: Debug - list vcpkg_installed
+        shell: pwsh
+        run: |
+          echo "cache-hit: ${{ steps.cache-restore.outputs.cache-hit }}"
+          echo "vcpkg_installed contents:"
+          if (Test-Path vcpkg_installed) {
+            Get-ChildItem vcpkg_installed -Recurse -Depth 3 | Select-Object FullName | head -50
+          } else {
+            echo "vcpkg_installed directory does not exist!"
+          }
+
       - name: Configure CMake
         shell: pwsh
         run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -48,13 +48,14 @@ jobs:
           timeout_minutes: 60
           max_attempts: 3
           shell: pwsh
-          command: >-
-            & "$env:VCPKG_ROOT/vcpkg.exe" install
-            --recurse
-            --clean-after-build
-            --triplet=x64-windows
-            --x-feature=test
-            --x-manifest-root=.
+          command: |
+            & "$env:VCPKG_ROOT/vcpkg.exe" install `
+              --recurse `
+              --clean-after-build `
+              --triplet=x64-windows `
+              --x-feature=test `
+              --x-manifest-root=.
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Save vcpkg_installed to cache
         if: steps.cache-restore.outputs.cache-hit != 'true'
@@ -97,13 +98,14 @@ jobs:
           timeout_minutes: 60
           max_attempts: 3
           shell: pwsh
-          command: >-
-            & "$env:VCPKG_ROOT/vcpkg.exe" install
-            --recurse
-            --clean-after-build
-            --triplet=x64-windows-static-release
-            --x-feature=test
-            --x-manifest-root=.
+          command: |
+            & "$env:VCPKG_ROOT/vcpkg.exe" install `
+              --recurse `
+              --clean-after-build `
+              --triplet=x64-windows-static-release `
+              --x-feature=test `
+              --x-manifest-root=.
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Save vcpkg_installed to cache
         if: steps.cache-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,6 +1,7 @@
 name: Windows Build
 permissions:
   contents: read
+  actions: write  # required for vcpkg GHA asset caching (X_VCPKG_ASSET_SOURCES)
 
 on: 
   push:
@@ -10,6 +11,9 @@ on:
 
 env:
   VCPKG_DISABLE_METRICS: "1"
+  # Cache vcpkg downloaded source archives in GitHub Actions cache to avoid
+  # flaky downloads from GNU FTP and Savannah mirrors.
+  X_VCPKG_ASSET_SOURCES: "x-gha,readwrite"
 
 jobs:
   # Pre-warm the vcpkg binary cache for x64-windows triplet.

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -12,9 +12,110 @@ env:
   VCPKG_DISABLE_METRICS: "1"
 
 jobs:
+  # Pre-warm the vcpkg binary cache for x64-windows triplet.
+  # Builds all packages once and saves them to the GHA binary cache.
+  # Subsequent runs will restore from the binary cache (< 1 min).
+  vcpkg-shared:
+    name: Install vcpkg deps (x64-windows)
+    runs-on: windows-latest
+    env:
+      VCPKG_DEFAULT_TRIPLET: x64-windows
+    steps:
+      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@v2
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+
+      - name: Compute vcpkg cache key
+        id: vcpkg-key
+        shell: pwsh
+        run: |
+          $hash = (Get-FileHash vcpkg.json -Algorithm SHA256).Hash.Substring(0, 16)
+          echo "key=vcpkg-x64-windows-$hash-${{ runner.os }}" >> $env:GITHUB_OUTPUT
+
+      - name: Restore vcpkg_installed from cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: vcpkg_installed
+          key: ${{ steps.vcpkg-key.outputs.key }}
+
+      - name: Install vcpkg packages (with retry)
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          shell: pwsh
+          command: >-
+            & "$env:VCPKG_ROOT/vcpkg.exe" install
+            --recurse
+            --clean-after-build
+            --triplet=x64-windows
+            --x-feature=test
+            --x-manifest-root=.
+
+      - name: Save vcpkg_installed to cache
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: vcpkg_installed
+          key: ${{ steps.vcpkg-key.outputs.key }}
+
+  # Pre-warm the vcpkg binary cache for x64-windows-static-release triplet.
+  vcpkg-static:
+    name: Install vcpkg deps (x64-windows-static-release)
+    runs-on: windows-latest
+    env:
+      VCPKG_DEFAULT_TRIPLET: x64-windows-static-release
+    steps:
+      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@v2
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+
+      - name: Compute vcpkg cache key
+        id: vcpkg-key
+        shell: pwsh
+        run: |
+          $hash = (Get-FileHash vcpkg.json -Algorithm SHA256).Hash.Substring(0, 16)
+          echo "key=vcpkg-x64-windows-static-release-$hash-${{ runner.os }}" >> $env:GITHUB_OUTPUT
+
+      - name: Restore vcpkg_installed from cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: vcpkg_installed
+          key: ${{ steps.vcpkg-key.outputs.key }}
+
+      - name: Install vcpkg packages (with retry)
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          shell: pwsh
+          command: >-
+            & "$env:VCPKG_ROOT/vcpkg.exe" install
+            --recurse
+            --clean-after-build
+            --triplet=x64-windows-static-release
+            --x-feature=test
+            --x-manifest-root=.
+
+      - name: Save vcpkg_installed to cache
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: vcpkg_installed
+          key: ${{ steps.vcpkg-key.outputs.key }}
+
   build-windows:
     name: Windows MSVC (${{ matrix.arch }}-windows, ${{ matrix.build_type }}, C++${{ matrix.cxx_standard }})
     runs-on: windows-latest
+    needs: vcpkg-shared
     strategy:
       fail-fast: false
       matrix:
@@ -34,7 +135,22 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
 
-      - name: Install vcpkg packages (with retry)
+      - name: Compute vcpkg cache key
+        id: vcpkg-key
+        shell: pwsh
+        run: |
+          $hash = (Get-FileHash vcpkg.json -Algorithm SHA256).Hash.Substring(0, 16)
+          echo "key=vcpkg-x64-windows-$hash-${{ runner.os }}" >> $env:GITHUB_OUTPUT
+
+      - name: Restore vcpkg_installed from cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: vcpkg_installed
+          key: ${{ steps.vcpkg-key.outputs.key }}
+
+      - name: Install vcpkg packages if cache miss (with retry)
+        if: steps.cache-restore.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 60
@@ -92,6 +208,7 @@ jobs:
   build-windows-static:
     name: Windows Static MSVC (${{ matrix.arch }}-windows-static-release, ${{ matrix.build_type }}, C++${{ matrix.cxx_standard }})
     runs-on: windows-latest
+    needs: vcpkg-static
     strategy:
       fail-fast: false
       matrix:
@@ -111,7 +228,22 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
 
-      - name: Install vcpkg packages (with retry)
+      - name: Compute vcpkg cache key
+        id: vcpkg-key
+        shell: pwsh
+        run: |
+          $hash = (Get-FileHash vcpkg.json -Algorithm SHA256).Hash.Substring(0, 16)
+          echo "key=vcpkg-x64-windows-static-release-$hash-${{ runner.os }}" >> $env:GITHUB_OUTPUT
+
+      - name: Restore vcpkg_installed from cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: vcpkg_installed
+          key: ${{ steps.vcpkg-key.outputs.key }}
+
+      - name: Install vcpkg packages if cache miss (with retry)
+        if: steps.cache-restore.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 60
@@ -275,7 +407,7 @@ jobs:
 
       - name: Upload MinGW artifacts
         if: matrix.build_type == 'Release'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: opendht-windows-mingw-${{ matrix.build_type }}
           path: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -176,11 +176,18 @@ jobs:
         shell: pwsh
         run: |
           echo "cache-hit: ${{ steps.cache-restore.outputs.cache-hit }}"
+          echo "GITHUB_WORKSPACE: $env:GITHUB_WORKSPACE"
           echo "vcpkg_installed contents:"
           if (Test-Path vcpkg_installed) {
-            Get-ChildItem vcpkg_installed -Recurse -Depth 3 | Select-Object FullName | head -50
+            Get-ChildItem vcpkg_installed -Recurse -Depth 3 | Select-Object -ExpandProperty FullName | Select-Object -First 50
           } else {
             echo "vcpkg_installed directory does not exist!"
+          }
+          echo "argon2 check:"
+          if (Test-Path "vcpkg_installed/x64-windows/share/unofficial-argon2") {
+            echo "argon2 FOUND"
+          } else {
+            echo "argon2 NOT FOUND"
           }
 
       - name: Configure CMake
@@ -190,6 +197,7 @@ jobs:
             -S . `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-windows `
+            -DVCPKG_INSTALLED_DIR="${{ github.workspace }}/vcpkg_installed" `
             -DVCPKG_MANIFEST_INSTALL=OFF `
             -DVCPKG_MANIFEST_FEATURES=test `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} `
@@ -285,6 +293,7 @@ jobs:
             -S . `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-windows-static-release `
+            -DVCPKG_INSTALLED_DIR="${{ github.workspace }}/vcpkg_installed" `
             -DVCPKG_MANIFEST_INSTALL=OFF `
             -DVCPKG_MANIFEST_FEATURES=test `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} `

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -172,24 +172,6 @@ jobs:
             --x-feature=test
             --x-manifest-root=.
 
-      - name: Debug - list vcpkg_installed
-        shell: pwsh
-        run: |
-          echo "cache-hit: ${{ steps.cache-restore.outputs.cache-hit }}"
-          echo "GITHUB_WORKSPACE: $env:GITHUB_WORKSPACE"
-          echo "vcpkg_installed contents:"
-          if (Test-Path vcpkg_installed) {
-            Get-ChildItem vcpkg_installed -Recurse -Depth 3 | Select-Object -ExpandProperty FullName | Select-Object -First 50
-          } else {
-            echo "vcpkg_installed directory does not exist!"
-          }
-          echo "argon2 check:"
-          if (Test-Path "vcpkg_installed/x64-windows/share/unofficial-argon2") {
-            echo "argon2 FOUND"
-          } else {
-            echo "argon2 NOT FOUND"
-          }
-
       - name: Configure CMake
         shell: pwsh
         run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,7 +1,6 @@
 name: Windows Build
 permissions:
   contents: read
-  actions: write  # required for vcpkg GHA asset caching (X_VCPKG_ASSET_SOURCES)
 
 on: 
   push:
@@ -11,9 +10,6 @@ on:
 
 env:
   VCPKG_DISABLE_METRICS: "1"
-  # Cache vcpkg downloaded source archives in GitHub Actions cache to avoid
-  # flaky downloads from GNU FTP and Savannah mirrors.
-  X_VCPKG_ASSET_SOURCES: "x-gha,readwrite"
 
 jobs:
   # Pre-warm the vcpkg binary cache for x64-windows triplet.
@@ -26,11 +22,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: microsoft/setup-msbuild@v2
-      - name: Setup vcpkg and install packages
+      - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
-        with:
-          runVcpkgInstall: true
-          runVcpkgFormatString: '[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--triplet`, `x64-windows`, `--x-feature=test`]'
+      - name: Install packages (with retry on download failure)
+        shell: pwsh
+        run: |
+          $maxAttempts = 3
+          for ($i = 1; $i -le $maxAttempts; $i++) {
+            Write-Host "vcpkg install attempt $i/$maxAttempts..."
+            & "$env:VCPKG_ROOT/vcpkg" install `
+              --recurse `
+              --clean-after-build `
+              --x-install-root="$env:VCPKG_INSTALLED_DIR" `
+              --triplet=x64-windows `
+              --x-feature=test
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "vcpkg install succeeded on attempt $i"
+              exit 0
+            }
+            if ($i -lt $maxAttempts) {
+              Write-Host "vcpkg install failed (exit $LASTEXITCODE), retrying in 30s..."
+              Start-Sleep -Seconds 30
+            }
+          }
+          Write-Host "vcpkg install failed after $maxAttempts attempts"
+          exit 1
 
   # Pre-warm the vcpkg binary cache for x64-windows-static-release triplet.
   vcpkg-static:
@@ -41,11 +57,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: microsoft/setup-msbuild@v2
-      - name: Setup vcpkg and install packages
+      - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
-        with:
-          runVcpkgInstall: true
-          runVcpkgFormatString: '[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--triplet`, `x64-windows-static-release`, `--x-feature=test`]'
+      - name: Install packages (with retry on download failure)
+        shell: pwsh
+        run: |
+          $maxAttempts = 3
+          for ($i = 1; $i -le $maxAttempts; $i++) {
+            Write-Host "vcpkg install attempt $i/$maxAttempts..."
+            & "$env:VCPKG_ROOT/vcpkg" install `
+              --recurse `
+              --clean-after-build `
+              --x-install-root="$env:VCPKG_INSTALLED_DIR" `
+              --triplet=x64-windows-static-release `
+              --x-feature=test
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "vcpkg install succeeded on attempt $i"
+              exit 0
+            }
+            if ($i -lt $maxAttempts) {
+              Write-Host "vcpkg install failed (exit $LASTEXITCODE), retrying in 30s..."
+              Start-Sleep -Seconds 30
+            }
+          }
+          Write-Host "vcpkg install failed after $maxAttempts attempts"
+          exit 1
 
   build-windows:
     name: Windows MSVC (${{ matrix.arch }}-windows, ${{ matrix.build_type }}, C++${{ matrix.cxx_standard }})

--- a/ports/shiftmedia-libgnutls/external-libtasn1.patch
+++ b/ports/shiftmedia-libgnutls/external-libtasn1.patch
@@ -1,0 +1,118 @@
+diff --git a/SMP/libgnutls.vcxproj.filters b/SMP/libgnutls.vcxproj.filters
+index ef202f4ac..a397e1574 100644
+--- a/SMP/libgnutls.vcxproj.filters
++++ b/SMP/libgnutls.vcxproj.filters
+@@ -103,9 +103,6 @@
+     <Filter Include="Header Files\lib\inih">
+       <UniqueIdentifier>{ae0c3eeb-53df-4c72-a85a-6b46de35e7ba}</UniqueIdentifier>
+     </Filter>
+-    <Filter Include="Source Files\libtasn1">
+-      <UniqueIdentifier>{32be60b7-8c65-486e-9df5-7e529443cf07}</UniqueIdentifier>
+-    </Filter>
+     <Filter Include="Source Files\lib\nettle\gost">
+       <UniqueIdentifier>{1f3549a8-3c3d-475f-8fd6-20451d336464}</UniqueIdentifier>
+     </Filter>
+@@ -1535,30 +1532,6 @@
+     <ClCompile Include="..\lib\nettle\sysrng-bcrypt.c">
+       <Filter>Source Files\lib\nettle</Filter>
+     </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\coding.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\decoding.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\element.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\errors.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\gstr.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\parser_aux.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\structure.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\version.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+     <ClCompile Include="..\lib\nettle\gost\acpkm.c">
+       <Filter>Source Files\lib\nettle\gost</Filter>
+     </ClCompile>
+diff --git a/SMP/libgnutls_files.props b/SMP/libgnutls_files.props
+index 55049b70b..2bb76e3b0 100644
+--- a/SMP/libgnutls_files.props
++++ b/SMP/libgnutls_files.props
+@@ -175,13 +175,6 @@
+   <ItemGroup>
+     <ClCompile Include="lib\gnutls_asn1_tab.c" />
+     <ClCompile Include="lib\pkix_asn1_tab.c" />
+-    <ClCompile Include="..\devel\libtasn1\lib\coding.c" />
+-    <ClCompile Include="..\devel\libtasn1\lib\decoding.c" />
+-    <ClCompile Include="..\devel\libtasn1\lib\element.c" />
+-    <ClCompile Include="..\devel\libtasn1\lib\gstr.c" />
+-    <ClCompile Include="..\devel\libtasn1\lib\parser_aux.c" />
+-    <ClCompile Include="..\devel\libtasn1\lib\structure.c" />
+-    <ClCompile Include="..\devel\libtasn1\lib\version.c" />
+     <ClCompile Include="..\gnulib\lib\c-strcasecmp.c" />
+     <ClCompile Include="..\gnulib\lib\c-strncasecmp.c" />
+     <ClCompile Include="..\gnulib\lib\cloexec.c" />
+@@ -545,9 +538,6 @@
+     </ClCompile>	
+     <ClCompile Include="..\gnulib\lib\stdio-write.c">
+       <PreprocessorDefinitions>REPLACE_PRINTF_POSIX=1;REPLACE_FPRINTF_POSIX=1;REPLACE_VPRINTF_POSIX=1;REPLACE_VFPRINTF_POSIX=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+-    </ClCompile>	
+-    <ClCompile Include="..\devel\libtasn1\lib\errors.c">
+-      <ObjectFileName>$(IntDir)\tasn1_$(filename).obj</ObjectFileName>
+     </ClCompile>
+     <ClCompile Include="..\lib\algorithms\ecc.c">
+       <ObjectFileName>$(IntDir)\alg_%(Filename).obj</ObjectFileName>
+diff --git a/SMP/libgnutls_winrt.vcxproj.filters b/SMP/libgnutls_winrt.vcxproj.filters
+index f6a355e7e..299749c2a 100644
+--- a/SMP/libgnutls_winrt.vcxproj.filters
++++ b/SMP/libgnutls_winrt.vcxproj.filters
+@@ -103,9 +103,6 @@
+     <Filter Include="Header Files\lib\inih">
+       <UniqueIdentifier>{ae0c3eeb-53df-4c72-a85a-6b46de35e7ba}</UniqueIdentifier>
+     </Filter>
+-    <Filter Include="Source Files\libtasn1">
+-      <UniqueIdentifier>{32be60b7-8c65-486e-9df5-7e529443cf07}</UniqueIdentifier>
+-    </Filter>
+     <Filter Include="Header Files\lib\nettle\gost">
+       <UniqueIdentifier>{4fada990-3138-4089-a6c7-ae722a0e7fe9}</UniqueIdentifier>
+     </Filter>
+@@ -1535,30 +1532,6 @@
+     <ClCompile Include="..\lib\nettle\sysrng-bcrypt.c">
+       <Filter>Source Files\lib\nettle</Filter>
+     </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\coding.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\decoding.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\element.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\errors.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\gstr.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\parser_aux.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\structure.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+-    <ClCompile Include="..\devel\libtasn1\lib\version.c">
+-      <Filter>Source Files\libtasn1</Filter>
+-    </ClCompile>
+     <ClCompile Include="..\lib\accelerated\afalg.c">
+       <Filter>Source Files\lib\accelerated</Filter>
+     </ClCompile>

--- a/ports/shiftmedia-libgnutls/pkgconfig.patch
+++ b/ports/shiftmedia-libgnutls/pkgconfig.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/gnutls.pc.in b/lib/gnutls.pc.in
+index 7cdedda5..11785bcd 100644
+--- a/lib/gnutls.pc.in
++++ b/lib/gnutls.pc.in
+@@ -18,7 +18,7 @@ Name: GnuTLS
+ Description: Transport Security Layer implementation for the GNU system
+ URL: https://www.gnutls.org/
+ Version: @VERSION@
+-Libs: -L${libdir} -lgnutls
++Libs: -L${libdir} @GNUTLS_LIBS@
+ Libs.private: @LIBZ_PC@ @LIBINTL@ @LIBSOCKET@ @INET_PTON_LIB@ @LIBPTHREAD@ @LIB_SELECT@ @TSS_LIBS@ @GMP_LIBS@ @LIBUNISTRING@ @LIBATOMIC_LIBS@ @GNUTLS_LIBS_PRIVATE@
+ @GNUTLS_REQUIRES_PRIVATE@
+ Cflags: -I${includedir}

--- a/ports/shiftmedia-libgnutls/portfile.cmake
+++ b/ports/shiftmedia-libgnutls/portfile.cmake
@@ -1,0 +1,183 @@
+set(GNULIB_REF "3639c57")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ShiftMediaProject/gnutls
+    REF ${VERSION}
+    SHA512 db318ee923d0810484e98342cc395624efc52b7227020fc14b9fa9ae63e4b8bf254cfd90470e051cd992fb167fb839fff340430a223bcc50d1422f1738a5b599
+    HEAD_REF master
+    PATCHES
+        external-libtasn1.patch
+        pkgconfig.patch
+)
+
+file(REMOVE_RECURSE "${SOURCE_PATH}/devel/perlasm")
+
+# Use GitHub mirror of gnulib instead of git.savannah.gnu.org (unreliable on CI)
+vcpkg_from_github(
+    OUT_SOURCE_PATH GNULIB_SOURCE_PATH
+    REPO coreutils/gnulib
+    REF 3639c57a970191e0bf7a9789bd1341786d0255a1
+    SHA512 663781c7d9adb9a7b18decda4a473509e6377d1553aa953cc4876b19ae99a18488dae9652f92661be02ecdd8dfc9f7facb55e0bf3b8a499a00caf2f7223a2823
+    HEAD_REF master
+)
+
+file(REMOVE_RECURSE "${SOURCE_PATH}/gnulib")
+file(RENAME "${GNULIB_SOURCE_PATH}" "${SOURCE_PATH}/gnulib")
+
+include("${CURRENT_HOST_INSTALLED_DIR}/share/yasm-tool-helper/yasm-tool-helper.cmake")
+yasm_tool_helper(OUT_VAR YASM)
+file(TO_NATIVE_PATH "${YASM}" YASM)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(CONFIGURATION_RELEASE ReleaseDLL)
+    set(CONFIGURATION_DEBUG DebugDLL)
+else()
+    set(CONFIGURATION_RELEASE Release)
+    set(CONFIGURATION_DEBUG Debug)
+endif()
+
+if(VCPKG_TARGET_IS_UWP)
+    string(APPEND CONFIGURATION_RELEASE WinRT)
+    string(APPEND CONFIGURATION_DEBUG WinRT)
+endif()
+
+set(_gnutlsproject "${SOURCE_PATH}/SMP/libgnutls.vcxproj")
+file(READ "${_gnutlsproject}" _contents)
+string(REPLACE  [[<Import Project="$(VCTargetsPath)\BuildCustomizations\yasm.props" />]]
+                    "<Import Project=\"${CURRENT_HOST_INSTALLED_DIR}/share/vs-yasm/yasm.props\" />"
+                _contents "${_contents}")
+string(REPLACE  [[<Import Project="$(VCTargetsPath)\BuildCustomizations\yasm.targets" />]]
+                    "<Import Project=\"${CURRENT_HOST_INSTALLED_DIR}/share/vs-yasm/yasm.targets\" />"
+                _contents "${_contents}")
+string(REGEX REPLACE "${VCPKG_ROOT_DIR}/installed/[^/]+/share" "${CURRENT_HOST_INSTALLED_DIR}/share" _contents "${_contents}") # Above already
+file(WRITE "${_gnutlsproject}" "${_contents}")
+
+if(VCPKG_CRT_LINKAGE STREQUAL "static")
+    set(RuntimeLibraryExt "")
+else()
+    set(RuntimeLibraryExt "DLL")
+endif()
+
+# patch output library file path and name
+foreach(PROPS IN ITEMS
+"${SOURCE_PATH}/SMP/smp_deps.props"
+"${SOURCE_PATH}/SMP/smp_winrt_deps.props")
+vcpkg_replace_string(
+    "${PROPS}"
+    [=[_winrt</TargetName>]=]
+    [=[</TargetName>]=]
+    IGNORE_UNCHANGED
+)
+vcpkg_replace_string(
+    "${PROPS}"
+    [=[<TargetName>lib$(RootNamespace)]=]
+    [=[<TargetName>$(RootNamespace)]=]
+)
+endforeach()
+
+# patch hogweed, gpm, nettle, zlib libraries file names; inject RuntimeLibrary property to control CRT linkage 
+foreach(VCXPROJ IN ITEMS
+"${SOURCE_PATH}/SMP/libgnutls.vcxproj"
+"${SOURCE_PATH}/SMP/libgnutls_winrt.vcxproj")
+vcpkg_replace_string(
+    "${VCXPROJ}"
+    "_winrt.lib"
+    ".lib"
+    IGNORE_UNCHANGED
+)
+vcpkg_replace_string(
+    "${VCXPROJ}"
+    "libhogweed"
+    "hogweed"
+)
+vcpkg_replace_string(
+    "${VCXPROJ}"
+    "hogweedd"
+    "hogweed"
+)
+vcpkg_replace_string(
+    "${VCXPROJ}"
+    "libgmp"
+    "gmp"
+)
+vcpkg_replace_string(
+    "${VCXPROJ}"
+    "gmpd"
+    "gmp"
+)
+vcpkg_replace_string(
+    "${VCXPROJ}"
+    "libnettle"
+    "nettle"
+)
+vcpkg_replace_string(
+    "${VCXPROJ}"
+    "nettled"
+    "nettle"
+)
+set(zlib_basename "zlib")
+if(EXISTS "${CURRENT_INSTALLED_DIR}/lib/zs.lib")
+    set(zlib_basename "zs")
+elseif(EXISTS "${CURRENT_INSTALLED_DIR}/lib/z.lib")
+    set(zlib_basename "z")
+endif()
+vcpkg_replace_string(
+    "${VCXPROJ}"
+    "libzlib"
+    "${zlib_basename}"
+)
+vcpkg_replace_string(
+    "${VCXPROJ}"
+    "zlib"
+    "${zlib_basename}"
+)
+vcpkg_replace_string(
+    "${VCXPROJ}"
+    [=[</DisableSpecificWarnings>]=]
+    [=[</DisableSpecificWarnings><RuntimeLibrary>$(RuntimeLibrary)</RuntimeLibrary>]=]
+)
+endforeach()
+
+vcpkg_install_msbuild(
+    USE_VCPKG_INTEGRATION
+    SOURCE_PATH "${SOURCE_PATH}"
+    PROJECT_SUBPATH SMP/libgnutls.sln
+    PLATFORM ${TRIPLET_SYSTEM_ARCH}
+    LICENSE_SUBPATH LICENSE
+    RELEASE_CONFIGURATION ${CONFIGURATION_RELEASE}
+    DEBUG_CONFIGURATION ${CONFIGURATION_DEBUG}
+    SKIP_CLEAN
+    OPTIONS /p:YasmPath="${YASM}" /p:OutDir=..\\msvc
+    OPTIONS_DEBUG /p:RuntimeLibrary=MultiThreadedDebug${RuntimeLibraryExt}
+    OPTIONS_RELEASE /p:RuntimeLibrary=MultiThreaded${RuntimeLibraryExt}
+)
+
+get_filename_component(SOURCE_PATH_SUFFIX "${SOURCE_PATH}" NAME)
+if(VCPKG_TARGET_IS_UWP)
+    set(WINRT_SUBFOLDER libgnutls_winrt)
+endif()
+file(INSTALL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/${SOURCE_PATH_SUFFIX}/msvc/${WINRT_SUBFOLDER}/include" DESTINATION "${CURRENT_PACKAGES_DIR}")
+
+set(GNUTLS_REQUIRES_PRIVATE "Requires.private: gmp, nettle, hogweed, libtasn1, zlib")
+set(GNUTLS_LIBS_PRIVATE "-lcrypt32 -lws2_32 -lkernel32 -lncrypt")
+
+set(prefix "${CURRENT_INSTALLED_DIR}")
+set(exec_prefix "\${prefix}")
+set(libdir "\${prefix}/lib")
+set(includedir "\${prefix}/include")
+set(GNUTLS_LIBS "-lgnutls")
+configure_file("${SOURCE_PATH}/lib/gnutls.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/gnutls.pc" @ONLY)
+
+if(NOT VCPKG_BUILD_TYPE)
+  set(prefix "${CURRENT_INSTALLED_DIR}/debug")
+  set(exec_prefix "\${prefix}")
+  set(libdir "\${prefix}/lib")
+  set(includedir "\${prefix}/../include")
+  set(GNUTLS_LIBS "-lgnutlsd")
+  configure_file("${SOURCE_PATH}/lib/gnutls.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gnutls.pc" @ONLY)
+endif()
+
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+file(COPY "${CURRENT_PORT_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/gnutls")

--- a/ports/shiftmedia-libgnutls/vcpkg-cmake-wrapper.cmake
+++ b/ports/shiftmedia-libgnutls/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,2 @@
+find_library(GNUTLS_LIBRARY NAMES gnutls gnutlsd NAMES_PER_DIR)
+_find_package(${ARGS})

--- a/ports/shiftmedia-libgnutls/vcpkg.json
+++ b/ports/shiftmedia-libgnutls/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "shiftmedia-libgnutls",
+  "version": "3.8.7",
+  "port-version": 3,
+  "description": "Unofficial GnuTLS fork with added custom native Visual Studio project build tools. ",
+  "homepage": "https://github.com/ShiftMediaProject/gnutls",
+  "license": "LGPL-2.1-only",
+  "supports": "windows & !arm & !mingw & !xbox",
+  "dependencies": [
+    "gmp",
+    "libtasn1",
+    "nettle",
+    {
+      "name": "vs-yasm",
+      "host": true
+    },
+    {
+      "name": "yasm-tool-helper",
+      "host": true
+    },
+    "zlib"
+  ]
+}

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -10,5 +10,8 @@
       "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
       "name": "microsoft"
     }
+  ],
+  "overlay-ports": [
+    "ports"
   ]
 }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "66c0373dc7fca549e5803087b9487edfe3aca0a1",
+    "baseline": "56bb2411609227288b70117ead2c47585ba07713",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
## Changes

Replace the manual vcpkg installation/caching approach with [`lukka/run-vcpkg@v11`](https://github.com/marketplace/actions/run-vcpkg).

### Key improvements

- **Removed** `prepare-dependencies` and `prepare-static-dependencies` jobs — no more manual cache key generation or `actions/cache` management
- **`lukka/run-vcpkg@v11`** automatically:
  - Downloads and bootstraps vcpkg using the commit from `vcpkg-configuration.json` baseline (no submodule needed)
  - Sets `VCPKG_ROOT` and `VCPKG_BINARY_SOURCES` to leverage GitHub Actions Binary Caching
  - Handles cache invalidation per package — packages are rebuilt only when their content changes
- CMake triggers `vcpkg install` via the toolchain with `VCPKG_MANIFEST_FEATURES=test`
- Updated action versions to consistent stable releases (`checkout@v4`, `upload-artifact@v4`, `setup-msbuild@v2`)
- Added `fail-fast: false` to matrix strategies so one failing config doesn't cancel others