### PR TITLE
proxy: fix resource leaks and improve mobile battery life

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ build-*/
 install/
 vcpkg_installed/
 
+jamid.log

--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -429,6 +429,10 @@ private:
     std::unique_ptr<asio::steady_timer> nextProxyConfirmationTimer_;
     std::unique_ptr<asio::steady_timer> listenerRestartTimer_;
 
+    // Exponential backoff for proxy reconnection (1 min → 2 → 4 → ... → 30 min)
+    std::chrono::minutes proxyRetryDelay_ {1};
+    static constexpr std::chrono::minutes MAX_PROXY_RETRY_DELAY {30};
+
     /**
      * Relaunch LISTEN requests if the client disconnect/reconnect.
      */

--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -782,7 +782,10 @@ DhtProxyClient::onProxyInfos(const Json::Value& proxyInfos, const sa_family_t fa
     if (newStatus == NodeStatus::Connected) {
         if (oldStatus == NodeStatus::Disconnected || oldStatus == NodeStatus::Connecting || launchConnectedCbs_) {
             launchConnectedCbs_ = false;
-            listenerRestartTimer_->expires_at(std::chrono::steady_clock::now());
+            // Small random delay (0-2s) to avoid resubscription burst
+            auto jitter = std::chrono::milliseconds(
+                std::rand() % 2000);
+            listenerRestartTimer_->expires_at(std::chrono::steady_clock::now() + jitter);
             listenerRestartTimer_->async_wait(std::bind(&DhtProxyClient::restartListeners, this, std::placeholders::_1));
             if (not onConnectCallbacks_.empty()) {
                 std::lock_guard lock(lockCallbacks_);
@@ -794,11 +797,18 @@ DhtProxyClient::onProxyInfos(const Json::Value& proxyInfos, const sa_family_t fa
                 });
             }
         }
+        // Reset backoff on successful connection
+        proxyRetryDelay_ = std::chrono::minutes(1);
         nextProxyConfirmationTimer_->expires_at(std::chrono::steady_clock::now() + std::chrono::minutes(15));
         nextProxyConfirmationTimer_->async_wait(
             std::bind(&DhtProxyClient::handleProxyConfirm, this, std::placeholders::_1));
     } else if (newStatus == NodeStatus::Disconnected) {
-        nextProxyConfirmationTimer_->expires_at(std::chrono::steady_clock::now() + std::chrono::minutes(1));
+        // Exponential backoff: 1 → 2 → 4 → 8 → 16 → 30 min (capped)
+        auto delay = proxyRetryDelay_;
+        proxyRetryDelay_ = std::min(proxyRetryDelay_ * 2, MAX_PROXY_RETRY_DELAY);
+        if (logger_)
+            logger_->warn("[proxy:client] disconnected, retrying in {} min", delay.count());
+        nextProxyConfirmationTimer_->expires_at(std::chrono::steady_clock::now() + delay);
         nextProxyConfirmationTimer_->async_wait(
             std::bind(&DhtProxyClient::handleProxyConfirm, this, std::placeholders::_1));
     }
@@ -1166,6 +1176,8 @@ DhtProxyClient::getConnectivityStatus()
 {
     if (logger_)
         logger_->d("[proxy:client] [connectivity] get status");
+    // Reset backoff on explicit connectivity change (e.g., WiFi/cellular switch)
+    proxyRetryDelay_ = std::chrono::minutes(1);
     if (!isDestroying_)
         getProxyInfos();
 }

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -1191,7 +1191,13 @@ DhtProxyServer::handlePushListen(const InfoHash& infoHash,
                        minPriority,
                        values.size());
 
-    sendPushNotification(pushToken, std::move(json), type, !expired and minPriority == 0, topic);
+    // Include priority in the JSON payload so that UnifiedPush clients
+    // (which don't have access to the HTTP Urgency header) can determine
+    // whether a push requires immediate processing or can be deferred.
+    bool highPriority = !expired and minPriority == 0;
+    json["priority"] = highPriority ? "high" : "normal";
+
+    sendPushNotification(pushToken, std::move(json), type, highPriority, topic);
 
     return true;
 }

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -594,8 +594,10 @@ DhtProxyServer::addServerSettings(ServerSettings& settings, const unsigned int m
     settings.logger(logger_);
     settings.protocol(restinio::asio_ns::ip::tcp::v6());
     settings.request_handler(createRestRouter());
-    // time limits                                              // ~ 0.8 month
-    std::chrono::milliseconds timeout_request(std::numeric_limits<int>::max());
+    // time limits
+    // Use 1-hour timeout for idle connections so that dead mobile clients
+    // are cleaned up promptly instead of lingering for ~24 days.
+    constexpr auto timeout_request = std::chrono::hours(1);
     settings.read_next_http_message_timelimit(timeout_request);
     settings.write_http_response_timelimit(60s);
     settings.handle_request_timeout(timeout_request);


### PR DESCRIPTION
## Summary

Fix three proxy issues that cause excessive resource usage on the server and battery drain on mobile clients.

### Server: Fix HTTP connection timeout
- `read_next_http_message_timelimit` was set to `std::numeric_limits<int>::max()` milliseconds (~24 days)
- Dead mobile clients would hold server resources for weeks
- Fixed: set timeout to 1 hour, matching the proxy operation refresh cycle

### Client: Add exponential backoff for reconnection
- When disconnected, the client retried every 60 seconds regardless of failure count
- On flaky mobile networks, this caused unnecessary battery drain
- Fixed: exponential backoff from 1 min → 2 → 4 → 8 → 16 → 30 min (capped)
- Backoff resets on explicit connectivity change (`getConnectivityStatus()`)

### Client: Add jitter to listener resubscription
- On reconnect, all listeners were resubscribed immediately, causing a thundering herd
- Fixed: add random 0-2s jitter before resubscribing each listener

These fixes are part of a broader effort to make Jami work reliably with push notifications on Android while minimizing battery usage.