### PR TITLE
Fix UnifiedPush not working

### DIFF
--- a/include/opendht/http.h
+++ b/include/opendht/http.h
@@ -344,8 +344,8 @@ private:
 
     dht::crypto::Identity client_identity_;
     std::shared_ptr<dht::crypto::Certificate> server_ca_;
-    std::string service_;
     std::string host_;
+    std::string service_;
 
     unsigned int id_;
     static std::atomic_uint ids_;

--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -36,4 +36,19 @@ base64_decode(std::string_view str)
     return buffer;
 }
 
+std::vector<unsigned char>
+base64_default_or_url_decode(std::string_view str)
+{
+    std::vector<unsigned char> buffer(simdutf::maximal_binary_length_from_base64(str.data(), str.size()));
+    simdutf::result r = simdutf::base64_to_binary(str.data(),
+                                                  str.size(),
+                                                  (char*) buffer.data(),
+                                                  simdutf::base64_options::base64_default_or_url);
+    if (r.error) {
+        throw std::invalid_argument(concat("Invalid base64 input: "sv, simdutf::error_to_string(r.error)));
+    } else {
+        buffer.resize(r.count);
+    }
+    return buffer;
+}
 } // namespace dht

--- a/src/base64.h
+++ b/src/base64.h
@@ -21,5 +21,12 @@ std::string base64_encode(const std::vector<unsigned char>& str);
  * @return a base64-decoded buffer
  */
 std::vector<unsigned char> base64_decode(std::string_view str);
+/**
+ * Decode a buffer in base64 or url style base64 (including '-' '_' ).
+ *
+ * @param str the input buffer
+ * @return a base64-decoded buffer
+ */
+std::vector<unsigned char> base64_default_or_url_decode(std::string_view str);
 
 } // namespace dht

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -1206,8 +1206,9 @@ DhtProxyServer::sendPushNotification(
         std::shared_ptr<http::Request> request;
         if (type == PushType::UnifiedPush) {
             http::Url tokenUrl(token);
+
             request = std::make_shared<http::Request>(io_context(),
-                                                      concat(tokenUrl.protocol, "://"sv, tokenUrl.host),
+                                                      tokenUrl.host,
                                                       tokenUrl.service,
                                                       tokenUrl.protocol.find("https") == 0,
                                                       logger_);
@@ -1231,8 +1232,8 @@ DhtProxyServer::sendPushNotification(
             Blob auth;   ///< Auth secret
             auto delim = topicView.find('|');
             if (delim != std::string_view::npos) {
-                pubKey = base64_decode(topicView.substr(0, delim));
-                auth = base64_decode(topicView.substr(delim + 1));
+                pubKey = base64_default_or_url_decode(topicView.substr(0, delim));
+                auth = base64_default_or_url_decode(topicView.substr(delim + 1));
             }
 
             request->set_header_field(restinio::http_field_t::ttl, "86400");

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -848,9 +848,22 @@ Resolver::Resolver(asio::io_context& ctx,
     , destroyed_(std::make_shared<bool>(false))
     , logger_(logger)
 {
-    url_.host = host;
-    url_.service = service;
-    url_.protocol = (ssl ? "https" : "http");
+    // Reconstruct the valid URL as a safeguard for the future.
+    url_.url = (ssl ? "https" : "http") + std::string {"://"} + std::string {host};
+    if (not service.empty())
+        url_.url += ':' + std::string {service};
+    const std::string_view view {url_.url};
+    std::string_view::size_type p = 0;
+    std::string_view::size_type protocol_size = ssl ? 5 : 4;
+    url_.protocol = view.substr(p, protocol_size);
+    p += protocol_size;
+    p += 3;
+    url_.host = view.substr(p, host.size());
+    p += host.size();
+    if (not service.empty()) {
+        p += 1;
+        url_.service = view.substr(p, service.size());
+    }
     resolve(url_.host, url_.service.empty() ? url_.protocol : url_.service);
 }
 
@@ -1047,9 +1060,11 @@ Request::Request(asio::io_context& ctx,
                  const bool ssl,
                  std::shared_ptr<dht::Logger> logger)
     : logger_(logger)
+    , host_(host)
+    , service_(service)
     , id_(Request::ids_++)
     , ctx_(ctx)
-    , resolver_(std::make_shared<Resolver>(ctx, host, service, ssl, logger))
+    , resolver_(std::make_shared<Resolver>(ctx, host_, service_, ssl, logger))
 {
     init_default_headers();
 }


### PR DESCRIPTION
Two root causes:

1. The topic sent by the Android client is encoded with URL-safe base64. Add a separate auto-decoding function instead of modifying the original one, preserving symmetry between decode and encode.

2. Request's parameter is a string_view; in the low-level async handling it outlives its source and dangles. Make each class that uses the string_view hold its own owning string instead.