### PR TITLE
proxy: fix listener restart on connectivity change

### DIFF
--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -291,9 +291,14 @@ public:
     virtual size_t getStorageLimit() const override { return 0; }
     void setLocalStorageLimit(size_t) override {}
     virtual size_t getLocalStorageLimit() const override { return STORAGE_LIMIT_UNLIMITED; }
-    void connectivityChanged(sa_family_t) override { getProxyInfos(); }
+    void connectivityChanged(sa_family_t) override
+    {
+        launchConnectedCbs_ = true;
+        getProxyInfos();
+    }
     void connectivityChanged() override
     {
+        launchConnectedCbs_ = true;
         getProxyInfos();
         loopSignal_();
     }


### PR DESCRIPTION
When a device wakes up from Doze mode or switches networks (e.g. WiFi to 4G), old TCP sockets may become silently dead. When `connectivityChanged()` is called, the proxy client triggers a new HTTP request (`getProxyInfos`) which succeeds since it uses a fresh socket, leading the client to believe the connection is still UP.

Because the status doesn't change (`Connected` -> `Connected`), `launchConnectedCbs_` was not set, and `restartListeners()` was never invoked. Consequently, push subscriptions and permanent puts were not renewed on the proxy, causing the device to appear offline on the DHT.

This patch forces `launchConnectedCbs_` to true on `connectivityChanged`, ensuring that listeners and subscriptions are properly restarted.