### PR TITLE
proxy server: only send call pushes at high priority

### DIFF
--- a/include/opendht/dht_proxy_server.h
+++ b/include/opendht/dht_proxy_server.h
@@ -146,6 +146,26 @@ public:
 
     std::shared_ptr<DhtRunner> getNode() const { return dht_; }
 
+#ifdef OPENDHT_PUSH_NOTIFICATIONS
+    /**
+     * Decide whether a batch of values notified to a push listener must be
+     * delivered as a high (urgent) priority push notification.
+     *
+     * Only real-time call signaling — values whose pushType is "audioCall" or
+     * "videoCall", published at high priority (priority == 0) — warrants an
+     * urgent push. Every other notification (presence/connection-request
+     * refreshes carrying an empty pushType, value expirations, etc.) is sent at
+     * normal priority so it does not saturate the mobile platform's adaptive
+     * high-priority quota; once that quota is tripped, the platform silently
+     * drops genuine call pushes.
+     *
+     * @param values the values being notified to the listener.
+     * @param expired whether this notification is for expired (removed) values.
+     * @return true if the notification must be sent at high priority.
+     */
+    static bool isHighPriorityPush(const std::vector<std::shared_ptr<Value>>& values, bool expired) noexcept;
+#endif // OPENDHT_PUSH_NOTIFICATIONS
+
 private:
     class ConnectionListener;
     struct RestRouterTraitsTls;

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -1135,6 +1135,25 @@ DhtProxyServer::handleCancelPushListen(const asio::error_code& ec,
 }
 
 bool
+DhtProxyServer::isHighPriorityPush(const std::vector<std::shared_ptr<Value>>& values, bool expired) noexcept
+{
+    // Expired-value notifications (de-registration) are never time-critical.
+    if (expired)
+        return false;
+    // Promote to high (urgent) push priority only for real-time call signaling.
+    // Background traffic — most notably connection-request refreshes, which
+    // carry an empty pushType — stays at normal priority so it does not trip the
+    // mobile platform's adaptive high-priority quota, which would otherwise
+    // silently drop genuine call pushes once the high-priority noise ratio gets
+    // too high.
+    for (const auto& v : values) {
+        if (v->priority == 0 and (v->pushType == "videoCall" or v->pushType == "audioCall"))
+            return true;
+    }
+    return false;
+}
+
+bool
 DhtProxyServer::handlePushListen(const InfoHash& infoHash,
                                  const std::string& pushToken,
                                  PushType type,

--- a/src/dht_proxy_server.cpp
+++ b/src/dht_proxy_server.cpp
@@ -1195,20 +1195,23 @@ DhtProxyServer::handlePushListen(const InfoHash& infoHash,
         json["exp"] = json["ids"];
     }
 
-    auto minPriority = 1000u;
-    for (const auto& v : values)
-        minPriority = std::min(minPriority, v->priority);
+    const bool highPriority = isHighPriorityPush(values, expired);
 
-    if (logger_)
-        logger_->debug("[proxy:server] [listen {}] [client {}] [session {}] [expired {}] [priority {}] [values {}]",
+    if (logger_) {
+        auto minPriority = 1000u;
+        for (const auto& v : values)
+            minPriority = std::min(minPriority, v->priority);
+        logger_->debug("[proxy:server] [listen {}] [client {}] [session {}] [expired {}] [priority {}] [high {}] [values {}]",
                        infoHash,
                        clientId,
                        sessionCtx->sessionId,
                        expired,
                        minPriority,
+                       highPriority,
                        values.size());
+    }
 
-    sendPushNotification(pushToken, std::move(json), type, !expired and minPriority == 0, topic);
+    sendPushNotification(pushToken, std::move(json), type, highPriority, topic);
 
     return true;
 }

--- a/tests/test_dhtproxy.cpp
+++ b/tests/test_dhtproxy.cpp
@@ -327,4 +327,39 @@ DhtProxyTester::testShutdownStop()
     CPPUNIT_ASSERT_EQUAL(2 * C, callback_count.load());
 }
 
+#ifdef OPENDHT_PUSH_NOTIFICATIONS
+void
+DhtProxyTester::testPushNotificationPriority()
+{
+    auto mkValue = [](unsigned priority, const std::string& pushType) {
+        auto v = std::make_shared<dht::Value>();
+        v->priority = priority;
+        v->pushType = pushType;
+        return v;
+    };
+
+    // Real-time call signaling at high priority => urgent push.
+    CPPUNIT_ASSERT(dht::DhtProxyServer::isHighPriorityPush({mkValue(0, "videoCall")}, false));
+    CPPUNIT_ASSERT(dht::DhtProxyServer::isHighPriorityPush({mkValue(0, "audioCall")}, false));
+
+    // Connection-request refresh (empty pushType) is noise => normal push.
+    CPPUNIT_ASSERT(!dht::DhtProxyServer::isHighPriorityPush({mkValue(0, "")}, false));
+
+    // Any other pushType is not a call => normal push.
+    CPPUNIT_ASSERT(!dht::DhtProxyServer::isHighPriorityPush({mkValue(0, "message")}, false));
+
+    // Expired (de-registration) notifications are never urgent, even for calls.
+    CPPUNIT_ASSERT(!dht::DhtProxyServer::isHighPriorityPush({mkValue(0, "videoCall")}, true));
+
+    // A call value explicitly published at normal priority stays normal.
+    CPPUNIT_ASSERT(!dht::DhtProxyServer::isHighPriorityPush({mkValue(1, "videoCall")}, false));
+
+    // Mixed batch: a single high-priority call value is enough to make it urgent.
+    CPPUNIT_ASSERT(dht::DhtProxyServer::isHighPriorityPush({mkValue(0, ""), mkValue(0, "videoCall")}, false));
+
+    // Empty batch => normal.
+    CPPUNIT_ASSERT(!dht::DhtProxyServer::isHighPriorityPush({}, false));
+}
+#endif // OPENDHT_PUSH_NOTIFICATIONS
+
 } // namespace test

--- a/tests/test_dhtproxy.h
+++ b/tests/test_dhtproxy.h
@@ -21,6 +21,9 @@ class DhtProxyTester : public CppUnit::TestFixture
     CPPUNIT_TEST(testPutGet40KChars);
     CPPUNIT_TEST(testFuzzy);
     CPPUNIT_TEST(testShutdownStop);
+#ifdef OPENDHT_PUSH_NOTIFICATIONS
+    CPPUNIT_TEST(testPushNotificationPriority);
+#endif
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -54,6 +57,15 @@ public:
     void testFuzzy();
 
     void testShutdownStop();
+
+#ifdef OPENDHT_PUSH_NOTIFICATIONS
+    /**
+     * The proxy must only request a high-priority push for real-time call
+     * signaling (audioCall/videoCall at priority 0); everything else stays at
+     * normal priority.
+     */
+    void testPushNotificationPriority();
+#endif
 
 private:
     dht::DhtRunner::Config clientConfig {};


### PR DESCRIPTION
## Problem

`DhtProxyServer::handlePushListen` promotes a push notification to **high (urgent)** FCM/APNs priority whenever any notified value has the default `priority == 0`:

```cpp
sendPushNotification(..., !expired and minPriority == 0, ...);
```

In practice almost everything is published at priority 0 — including the frequent **connection-request refreshes** that carry an **empty `pushType`**. On mobile, this floods the platform's *adaptive high-priority quota*. Once that quota is tripped (high-priority noise ratio too high), the platform **silently drops** subsequent high-priority pushes — including genuine `videoCall`/`audioCall` ones. The observable symptom (Jami / `cx.ring`): **incoming calls don't ring while the device is in the background**, even though the proxy "successfully" sent the push.

## Change

Decide high priority from the **pushType** instead of the raw value priority: only real-time call signaling (`audioCall` / `videoCall`, published at priority 0) is sent at high priority. Presence/connection-request refreshes (empty `pushType`), other non-call types and expirations are sent at **normal** priority.

This is a **strict subset** of the previous high-priority set: no notification that was normal before becomes high — it only stops over-prioritizing background noise, leaving the quota headroom for real calls.

The decision is extracted into a pure, static `DhtProxyServer::isHighPriorityPush(values, expired)` so it can be unit-tested without a push gateway.

## Behavior note

Non-call push types (e.g. message syncs) now go out at **normal** priority. On Android the wakeup is classified by the `pt` payload rather than FCM priority, so this is fine; reviewers targeting iOS may want to confirm message-notification latency expectations.

## Tests

New `testPushNotificationPriority` in `tests/test_dhtproxy.cpp` covers call / non-call / empty / expired / normal-priority / mixed-batch / empty-batch cases.

```
$ ninja -C build test_dhtproxy && ./build/test_dhtproxy
OK (7 tests)
```

Both commits build and pass in isolation (bisectable).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>