### PR TITLE
value: serialize pushType in JSON

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -202,6 +202,9 @@ Value::Value(const Json::Value& json)
     const auto& jprio = json["prio"];
     if (jprio.isIntegral())
         priority = jprio.asUInt();
+    const auto& jpt = json[VALUE_KEY_PUSHTYPE];
+    if (jpt.isString())
+        pushType = jpt.asString();
 }
 
 Json::Value
@@ -228,6 +231,8 @@ Value::toJson() const
     }
     if (priority)
         val["prio"] = priority;
+    if (not pushType.empty())
+        val[VALUE_KEY_PUSHTYPE] = pushType;
     return val;
 }
 

--- a/tests/test_value.cpp
+++ b/tests/test_value.cpp
@@ -137,4 +137,29 @@ ValueTester::testPushTypePreservedAfterEncrypt()
     CPPUNIT_ASSERT(encrypted.isEncrypted());
 }
 
+void
+ValueTester::testPushTypeJsonRoundTrip()
+{
+#ifdef OPENDHT_JSONCPP
+    dht::Value original {(const uint8_t*) "hello", 5};
+    original.id = 42;
+    original.priority = 1;
+    original.pushType = "videoCall";
+
+    dht::Value restored(original.toJson());
+
+    CPPUNIT_ASSERT_EQUAL(original.id, restored.id);
+    CPPUNIT_ASSERT_EQUAL(original.priority, restored.priority);
+    CPPUNIT_ASSERT_EQUAL(original.pushType, restored.pushType);
+
+    // No pushType: the field must stay absent from the JSON and empty after parse.
+    dht::Value plain {(const uint8_t*) "data", 4};
+    plain.id = 7;
+    auto json = plain.toJson();
+    CPPUNIT_ASSERT(!json.isMember("pt"));
+    dht::Value plainRestored(json);
+    CPPUNIT_ASSERT_EQUAL(std::string(), plainRestored.pushType);
+#endif
+}
+
 } // namespace test

--- a/tests/test_value.h
+++ b/tests/test_value.h
@@ -16,6 +16,7 @@ class ValueTester : public CppUnit::TestFixture
     CPPUNIT_TEST(testPushTypeMsgpackRoundTrip);
     CPPUNIT_TEST(testPushTypeAbsentAfterUnpack);
     CPPUNIT_TEST(testPushTypePreservedAfterEncrypt);
+    CPPUNIT_TEST(testPushTypeJsonRoundTrip);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -38,6 +39,7 @@ public:
     void testPushTypeMsgpackRoundTrip();
     void testPushTypeAbsentAfterUnpack();
     void testPushTypePreservedAfterEncrypt();
+    void testPushTypeJsonRoundTrip();
 };
 
 } // namespace test


### PR DESCRIPTION
## Problem

The `pushType` field (#593e59e0) lets the DHT proxy server tag push notifications with the connection type (`pt` in the FCM/APNs payload), so mobile clients can tell incoming calls apart from background noise.

It was only serialized in msgpack. Clients using `DhtProxyClient` send their puts as JSON (`Value::toJson()`), where the field was silently dropped, and the proxy server parsed the incoming JSON with `Value(const Json::Value&)`, which never read it back.

As a result, any value put through a proxy (e.g. a call request from a mobile device) reached the recipient with an empty `pt`, was classified as noise, and did not wake up the callee: **calls from proxied devices never rang, while the same call from a full DHT node (desktop, msgpack path) did.**

Observed on Jami Android↔Android calls: FCM payloads arrive with `pt=` empty while `prio` survives (it is already JSON-serialized), confirming the asymmetry.

## Fix

Serialize `pushType` as `pt` in `Value::toJson()` when set, and parse it back in the JSON constructor, mirroring the msgpack behavior.

Note: this needs to be deployed on both sides — proxy clients (to emit the field) and proxy servers (to parse it from client puts).

## Tests

- New `testPushTypeJsonRoundTrip`: JSON round-trip preserves `id`/`priority`/`pushType`; field absent from JSON when empty.
- `test_value` 6/6, `test_storage` 5/5, `test_crypto` 10/10 pass.