### PR TITLE
dhtrunner: fall back to random port when saved port is taken

### DIFF
--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -99,6 +99,11 @@ DhtRunner::run(const Config& config, Context&& context)
         auto state_path = config.dht_config.node_config.persist_path;
         if (not state_path.empty())
             state_path += "_port.txt";
+        // Ports loaded from the persisted state are a best-effort hint to keep a
+        // stable identity across restarts; remember which ones we set so that we
+        // can fall back to random ports if they are already in use (e.g. a fast
+        // restart while the previous instance still holds them).
+        bool triedSavedPort = false;
         if (not state_path.empty() && (local4.getPort() == 0 || local6.getPort() == 0)) {
             std::ifstream inConfig(state_path);
             if (inConfig.is_open()) {
@@ -110,6 +115,7 @@ DhtRunner::run(const Config& config, Context&& context)
                                               fmt::ptr(this),
                                               port);
                         local4.setPort(port);
+                        triedSavedPort = true;
                     }
                 }
                 if (inConfig >> port) {
@@ -119,6 +125,7 @@ DhtRunner::run(const Config& config, Context&& context)
                                               fmt::ptr(this),
                                               port);
                         local6.setPort(port);
+                        triedSavedPort = true;
                     }
                 }
             }
@@ -136,7 +143,20 @@ DhtRunner::run(const Config& config, Context&& context)
 
         if (config.proxy_server.empty()) {
             if (not context.sock) {
-                context.sock.reset(new net::UdpSocket(local4, local6, context.logger));
+                try {
+                    context.sock.reset(new net::UdpSocket(local4, local6, context.logger));
+                } catch (const DhtException&) {
+                    if (not triedSavedPort)
+                        throw;
+                    // The saved ports are unavailable (typically still held by a
+                    // previous instance): fall back to OS-assigned ports.
+                    if (context.logger)
+                        context.logger->w("[runner %p] Saved ports unavailable, falling back to random ports",
+                                          fmt::ptr(this));
+                    local4.setPort(0);
+                    local6.setPort(0);
+                    context.sock.reset(new net::UdpSocket(local4, local6, context.logger));
+                }
             }
             context.sock->setOnReceive([&](net::PacketList&& pkts) {
                 net::PacketList ret;

--- a/tests/test_dhtrunner.cpp
+++ b/tests/test_dhtrunner.cpp
@@ -9,6 +9,8 @@
 #include <future>
 #include <mutex>
 #include <condition_variable>
+#include <fstream>
+#include <cstdio>
 using namespace std::chrono_literals;
 using namespace std::literals;
 
@@ -538,6 +540,34 @@ DhtRunnerTester::testShutdownCompletesWithPendingPut()
     CPPUNIT_ASSERT(std::future_status::ready == shutdownFuture.wait_for(5s));
 
     clientNode.join();
+}
+
+void
+DhtRunnerTester::testSavedPortFallback()
+{
+    // A saved port that is already taken by another process (e.g. fast
+    // application restart while the old instance still holds it) must not
+    // prevent the node from starting: it should fall back to a random port.
+    dht::DhtRunner::Config config;
+    config.dht_config.node_config.persist_path = "/tmp/opendht_test_port_fallback";
+    std::string portFile = config.dht_config.node_config.persist_path + "_port.txt";
+
+    // node1 (from setUp) holds a port; save it as our persisted port.
+    auto takenPort = node1.getBoundPort();
+    {
+        std::ofstream out(portFile);
+        out << takenPort << std::endl << takenPort << std::endl;
+    }
+
+    dht::DhtRunner testNode;
+    CPPUNIT_ASSERT_NO_THROW(testNode.run(0, config));
+    CPPUNIT_ASSERT(testNode.getBoundPort());
+    CPPUNIT_ASSERT(testNode.getBoundPort() != takenPort);
+
+    testNode.shutdown();
+    testNode.join();
+    std::remove(portFile.c_str());
+    std::remove((config.dht_config.node_config.persist_path + "_port.txt").c_str());
 }
 
 void

--- a/tests/test_dhtrunner.h
+++ b/tests/test_dhtrunner.h
@@ -27,6 +27,7 @@ class DhtRunnerTester : public CppUnit::TestFixture
     CPPUNIT_TEST(testBootstrapThenPutNoRace);
     CPPUNIT_TEST(testBootstrapMissingNodeThenPutFails);
     CPPUNIT_TEST(testShutdownCompletesWithPendingPut);
+    CPPUNIT_TEST(testSavedPortFallback);
     CPPUNIT_TEST_SUITE_END();
 
     dht::DhtRunner node1 {};
@@ -72,6 +73,7 @@ public:
     void testBootstrapThenPutNoRace();
     void testBootstrapMissingNodeThenPutFails();
     void testShutdownCompletesWithPendingPut();
+    void testSavedPortFallback();
     /**
      * Test listen method with lot of datas
      */


### PR DESCRIPTION
## Problem

Since 15eb221c ("dht: save id, port when saving state"), the node's bound port is persisted alongside the DHT state (`persist_path + "_port.txt"`) and reused on the next `DhtRunner::run()` to keep a stable network identity across restarts.

If that port is still held by another process, the `UdpSocket` constructor throws (both the IPv4 and IPv6 binds fail with `EADDRINUSE` — the IPv6 path first tries the same port as IPv4, then the saved IPv6 port) and `run()` propagates `DhtException("Can't bind socket")`: **the node never starts, and there is no retry**.

The typical trigger is a fast application restart racing the previous instance's shutdown: the old process still holds the UDP sockets while the new one starts.

### Impact on Jami

Every account of a restarted client gets stuck in the connecting (orange) state, with:

```
jamiaccount.cpp:2043] Error registering DHT account: DhtException occurred: Can't bind socket
```

logged once per account and no recovery until the accounts are manually toggled or the app is restarted again (slowly). Reproduced deterministically by binding an account's saved port from another process before startup.

## Fix

Treat the persisted port strictly as a best-effort hint: if binding it fails, retry with OS-assigned ports (port 0) instead of throwing. Explicitly configured ports (passed by the API user) keep failing loudly as before — the fallback only applies when the port came from the saved state file. The state file is then refreshed with the newly bound ports, as it already was.

## Tests

- New `testSavedPortFallback`: starts a node whose `_port.txt` points to a port already bound by another node; asserts the node starts on a different port instead of throwing. Red before the fix (reproduces `DhtException: Can't bind socket`), green after.
- Full `test_dhtrunner` suite: 15/15 pass.