### PR TITLE
proxy client: resubscribe on push for another session

### DIFF
--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -1260,6 +1260,28 @@ DhtProxyClient::pushNotificationReceived([[maybe_unused]] const std::map<std::st
     try {
         auto sessionId = notification.find("s");
         if (sessionId != notification.end() and sessionId->second != pushSessionId_) {
+            // The push was requested by another client instance sharing this
+            // push token and client id (e.g. the iOS notification extension
+            // subscribing while the app was suspended): the proxy now tags
+            // pushes with that other session. The notification still means
+            // that values are available for the given key, so if we listen
+            // on it, resubscribe (with refresh) to retrieve pending values
+            // immediately and re-associate the proxy-side subscription with
+            // this session, instead of dropping the notification.
+            auto keyIt = notification.find("key");
+            if (keyIt != notification.end()) {
+                std::lock_guard lock(searchLock_);
+                auto search = searches_.find(InfoHash(keyIt->second));
+                if (search != searches_.end() and not search->second.listeners.empty()) {
+                    if (logger_)
+                        logger_->debug("[proxy:client] [push] wrong session for [search {}], resubscribing",
+                                       search->first);
+                    for (auto& list : search->second.listeners)
+                        resubscribe(search->first, list.first, list.second);
+                    loopSignal_();
+                    return PushNotificationResult::ListenRefresh;
+                }
+            }
             if (logger_)
                 logger_->debug("[proxy:client] [push] ignoring push for other session");
             return PushNotificationResult::IgnoredWrongSession;


### PR DESCRIPTION
## Problem

On iOS, the main app and the notification service extension (NSE) each run their own `DhtProxyClient` sharing the **same push token and `client_id`**, but each instance generates a **random `pushSessionId_`**. Whenever one instance subscribes a key on the proxy, the proxy re-associates the push subscription with that instance's session id.

Typical failure scenario (observed with Jami on a locked iPad receiving a call):

1. A message push wakes the NSE, which runs a short-lived daemon; its proxy client subscribes with a new random session id. The proxy now tags all pushes with the **NSE's** session id.
2. An incoming call arrives; CallKit wakes the main app.
3. All queued push notifications fed to `pushNotificationReceived()` are rejected with `IgnoredWrongSession` (`s=` doesn't match the app's session), losing the *push → immediate `get()`* fast path.
4. The app only discovers the pending `PeerConnectionRequest` after an unrelated internal resubscription — measured at **~3.5 s later**.

Consequences for calls: the caller stays in "searching" state for several extra seconds while the callee already rings, and answering too early fails because the ICE answer hasn't been sent yet.

Measured timeline (Mac → locked iPad, before / after this patch on the callee):

| Step | Before | After (expected) |
|---|---|---|
| Pushes accepted at app wake-up | all rejected (128) | resubscribe → values |
| PeerConnectionRequest delivered to app | +3.4 s after wake | ~0.3 s after wake |
| Caller sees RINGING | +8.7 s | ~+5 s |

## Fix

A push tagged with another session still carries a valid piece of information: *values are available for this key*. On session mismatch, if the key is one we currently listen on, **resubscribe the listeners** (with `refresh=true`, which both retrieves pending values immediately and re-associates the proxy-side subscription with this session) instead of dropping the notification, and return `ListenRefresh`.

Pushes for keys we do not listen on (e.g. leftovers addressed to a previous install) are still ignored with `IgnoredWrongSession` as before.

This is bounded and loop-free: a resubscription only happens when an actual push is delivered for a listened key, and APNs throttles push delivery. In the common single-instance case the behavior is unchanged.
