### PR TITLE
proxy client: restart listeners on connectivity change

### DIFF
--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -294,6 +294,10 @@ public:
     void connectivityChanged(sa_family_t) override { getProxyInfos(); }
     void connectivityChanged() override
     {
+        // The network path may have changed (e.g. VPN toggled): current listen
+        // connections can be silently dead even if the proxy is still reachable,
+        // so force listeners to restart once the proxy is (re)confirmed.
+        launchConnectedCbs_ = true;
         getProxyInfos();
         loopSignal_();
     }


### PR DESCRIPTION
When the network path changes while the proxy stays reachable (e.g. a VPN is turned on/off and the default route moves to another interface), established listen connections can become silently dead: TCP traffic on the old path is simply dropped.

`connectivityChanged()` triggers `getProxyInfos()`, but since the proxy answers through the new path, the status stays `Connected` and `restartListeners()` is never invoked: every listener stays bound to a dead connection and the node no longer receives any value (connection requests, messages…) until the process is restarted.

This was observed in Jami: after enabling a VPN on a desktop client, the account could still send (puts use fresh requests) but never received anything anymore — invitations/messages stayed pending until Jami was restarted.

Fix: force a listener restart on the next proxy confirmation by raising `launchConnectedCbs_` when a connectivity change is reported. In the push case this only resubscribes listeners marked not-ok; in the no-push case it cancels and re-issues all listen requests on fresh connections.