### PR TITLE
op_cache: fix boundary condition

### DIFF
--- a/src/op_cache.cpp
+++ b/src/op_cache.cpp
@@ -224,7 +224,7 @@ SearchCache::expire(const time_point& now, const std::function<void(size_t)>& on
     auto ret = nextExpiration_;
     for (auto it = ops.begin(); it != ops.end();) {
         auto expiration = it->second->getExpiration();
-        if (expiration < now) {
+        if (expiration <= now) {
             auto cache = std::move(it->second);
             it = ops.erase(it);
             onCancel(cache->searchToken);


### PR DESCRIPTION
In `SearchCache::expire`, if there is an op whose expiration is equal to `now`, then it's not processed and the function returns `now` as the next expiration timepoint. This can lead to the `opExpirationJob` in `Search::cancelListen` getting rescheduled at the same time in an infinite loop.