### PR TITLE
net: harden network message parsing and reassembly

### DIFF
--- a/include/opendht/network_engine.h
+++ b/include/opendht/network_engine.h
@@ -489,6 +489,8 @@ private:
     static constexpr size_t MTU {1280};
     static constexpr size_t MAX_PACKET_VALUE_SIZE {600};
     static constexpr size_t MAX_MESSAGE_VALUE_SIZE {56 * 1024};
+    static constexpr size_t RX_MAX_EARLY_BYTES {MAX_MESSAGE_VALUE_SIZE + MAX_VALUE_SIZE + 32};
+    static constexpr size_t RX_MAX_EARLY_PARTS {RX_MAX_EARLY_BYTES / MTU + 2};
 
     void process(std::unique_ptr<ParsedMessage>&&, const SockAddr& from);
 
@@ -527,7 +529,8 @@ private:
     {
         return packValueHeader(buf, values.begin(), values.end());
     }
-    void maintainRxBuffer(Tid tid);
+    using PartialMessageKey = std::pair<SockAddr, Tid>;
+    void maintainRxBuffer(const PartialMessageKey& key);
 
     /*************
      *  Answers  *
@@ -573,7 +576,7 @@ private:
 
     // requests handling
     std::map<Tid, Sp<Request>> requests {};
-    std::map<Tid, PartialMessage> partial_messages;
+    std::map<PartialMessageKey, PartialMessage> partial_messages;
 
     MessageStats in_stats {}, out_stats {};
     std::set<SockAddr> blacklist {};

--- a/src/network_engine.cpp
+++ b/src/network_engine.cpp
@@ -40,6 +40,9 @@ struct NetworkEngine::PartialMessage
     time_point start;
     time_point last_part;
     std::unique_ptr<ParsedMessage> msg;
+    std::vector<std::unique_ptr<ParsedMessage>> early_parts;
+    size_t early_bytes {};
+    bool request_quota_consumed {};
 };
 
 std::vector<Blob>
@@ -466,35 +469,66 @@ NetworkEngine::processMessage(const uint8_t* buf, size_t buflen, SockAddr f)
 
     // partial value data
     if (msg->type == MessageType::ValueData) {
-        auto pmsg_it = partial_messages.find(msg->tid);
-        if (pmsg_it == partial_messages.end()) {
-            if (logIncoming_)
-                if (logger_)
-                    logger_->debug("Unable to find partial message");
+        if (msg->fragment_parts.empty()
+            || std::any_of(msg->fragment_parts.begin(), msg->fragment_parts.end(), [](const auto& fragment) {
+                   return fragment.second.second.empty();
+               })) {
             rateLimit(from);
             return;
         }
-        if (!pmsg_it->second.from.equals(from)) {
-            if (logger_)
-                logger_->debug("Received partial message data from unexpected IP address");
-            rateLimit(from);
+        PartialMessageKey key {from, msg->tid};
+        auto pmsg_it = partial_messages.find(key);
+        if (pmsg_it == partial_messages.end()) {
+            if (!rateLimit(from))
+                return;
+            auto inserted = partial_messages.emplace(key, PartialMessage {});
+            pmsg_it = inserted.first;
+            pmsg_it->second.from = from;
+            pmsg_it->second.start = now;
+            pmsg_it->second.last_part = now;
+            pmsg_it->second.request_quota_consumed = true;
+            scheduler.add(now + RX_MAX_PACKET_TIME, std::bind(&NetworkEngine::maintainRxBuffer, this, key));
+        }
+        auto& pmsg = pmsg_it->second;
+        if (!pmsg.msg) {
+            if (pmsg.early_parts.size() >= RX_MAX_EARLY_PARTS) {
+                partial_messages.erase(pmsg_it);
+                return;
+            }
+            size_t fragment_bytes {};
+            for (const auto& [index, fragment] : msg->fragment_parts) {
+                (void) index;
+                if (fragment.second.size() > RX_MAX_EARLY_BYTES - fragment_bytes) {
+                    partial_messages.erase(pmsg_it);
+                    return;
+                }
+                fragment_bytes += fragment.second.size();
+            }
+            if (fragment_bytes > RX_MAX_EARLY_BYTES - pmsg.early_bytes) {
+                partial_messages.erase(pmsg_it);
+                return;
+            }
+            pmsg.early_bytes += fragment_bytes;
+            pmsg.early_parts.emplace_back(std::move(msg));
+            pmsg.last_part = now;
+            scheduler.add(now + RX_TIMEOUT, std::bind(&NetworkEngine::maintainRxBuffer, this, key));
             return;
         }
         // append data block
-        if (pmsg_it->second.msg->append(*msg)) {
-            pmsg_it->second.last_part = now;
+        if (pmsg.msg->append(*msg)) {
+            pmsg.last_part = now;
             // check data completion
-            if (pmsg_it->second.msg->complete()) {
+            if (pmsg.msg->complete()) {
                 try {
                     // process the full message
-                    process(std::move(pmsg_it->second.msg), from);
+                    process(std::move(pmsg.msg), from);
                 } catch (const std::exception& e) {
                     if (logger_)
                         logger_->warn("Error while processing partial message: {}", e.what());
                 }
                 partial_messages.erase(pmsg_it);
             } else
-                scheduler.add(now + RX_TIMEOUT, std::bind(&NetworkEngine::maintainRxBuffer, this, msg->tid));
+                scheduler.add(now + RX_TIMEOUT, std::bind(&NetworkEngine::maintainRxBuffer, this, key));
         }
         return;
     }
@@ -505,7 +539,11 @@ NetworkEngine::processMessage(const uint8_t* buf, size_t buflen, SockAddr f)
         return;
     }
 
-    if (msg->type > MessageType::Reply) {
+    PartialMessageKey partial_key {from, msg->tid};
+    const auto partial = partial_messages.find(partial_key);
+    const bool request_quota_consumed = !msg->value_parts.empty() && partial != partial_messages.end()
+                                        && !partial->second.msg && partial->second.request_quota_consumed;
+    if (msg->type > MessageType::Reply && !request_quota_consumed) {
         /* Rate limit requests. */
         if (!rateLimit(from)) {
             if (logger_)
@@ -524,17 +562,34 @@ NetworkEngine::processMessage(const uint8_t* buf, size_t buflen, SockAddr f)
         }
     } else {
         // starting partial message session
-        auto k = msg->tid;
-        auto& pmsg = partial_messages[k];
+        auto inserted = partial_messages.emplace(partial_key, PartialMessage {});
+        auto& pmsg = inserted.first->second;
         if (not pmsg.msg) {
-            pmsg.from = from;
+            if (inserted.second) {
+                pmsg.from = from;
+                pmsg.start = now;
+                scheduler.add(now + RX_MAX_PACKET_TIME,
+                              std::bind(&NetworkEngine::maintainRxBuffer, this, partial_key));
+            }
             pmsg.msg = std::move(msg);
-            pmsg.start = now;
             pmsg.last_part = now;
-            scheduler.add(now + RX_MAX_PACKET_TIME, std::bind(&NetworkEngine::maintainRxBuffer, this, k));
-            scheduler.add(now + RX_TIMEOUT, std::bind(&NetworkEngine::maintainRxBuffer, this, k));
+            for (const auto& part : pmsg.early_parts)
+                pmsg.msg->append(*part);
+            pmsg.early_parts.clear();
+            pmsg.early_bytes = 0;
+            if (pmsg.msg->complete()) {
+                try {
+                    process(std::move(pmsg.msg), from);
+                } catch (const std::exception& e) {
+                    if (logger_)
+                        logger_->warn("Error while processing partial message: {}", e.what());
+                }
+                partial_messages.erase(inserted.first);
+            } else {
+                scheduler.add(now + RX_TIMEOUT, std::bind(&NetworkEngine::maintainRxBuffer, this, partial_key));
+            }
         } else if (logger_)
-            logger_->error("Partial message with given TID {} already exists", k);
+            logger_->error("Partial message from {} with given TID {} already exists", from.toString(), msg->tid);
     }
 }
 
@@ -1614,9 +1669,9 @@ NetworkEngine::sendError(const SockAddr& addr, Tid tid, uint16_t code, const std
 }
 
 void
-NetworkEngine::maintainRxBuffer(Tid tid)
+NetworkEngine::maintainRxBuffer(const PartialMessageKey& key)
 {
-    auto msg = partial_messages.find(tid);
+    auto msg = partial_messages.find(key);
     if (msg != partial_messages.end()) {
         const auto& now = scheduler.time();
         if (msg->second.start + RX_MAX_PACKET_TIME < now || msg->second.last_part + RX_TIMEOUT < now) {

--- a/src/parsed_message.h
+++ b/src/parsed_message.h
@@ -274,13 +274,20 @@ ParsedMessage::msgpack_unpack(const msgpack::object& msg)
 
     if (!parsed.a && !parsed.r && !parsed.e && !parsed.u)
         throw msgpack::type_error();
-    auto& req = parsed.a ? *parsed.a : (parsed.r ? *parsed.r : (parsed.u ? *parsed.u : *parsed.e));
 
     if (parsed.e) {
-        if (parsed.e->type != msgpack::type::ARRAY)
+        if (parsed.e->type != msgpack::type::ARRAY or parsed.e->via.array.size < 1)
             throw msgpack::type_error();
         error_code = parsed.e->via.array.ptr[0].as<uint16_t>();
     }
+
+    /* An error-only message carries no request map. The error array must never
+       be reached through the map view of the msgpack object union, and a
+       request field that is not a map must be rejected rather than
+       reinterpreted. */
+    const msgpack::object* req = parsed.a ? parsed.a : (parsed.r ? parsed.r : parsed.u);
+    if (req and req->type != msgpack::type::MAP)
+        throw msgpack::type_error();
 
     struct ParsedReq
     {
@@ -290,8 +297,9 @@ ParsedMessage::msgpack_unpack(const msgpack::object& msg)
         msgpack::object* want;
     } parsedReq {};
 
-    for (unsigned i = 0; i < req.via.map.size; i++) {
-        auto& o = req.via.map.ptr[i];
+    const uint32_t req_size = req ? req->via.map.size : 0;
+    for (unsigned i = 0; i < req_size; i++) {
+        auto& o = req->via.map.ptr[i];
         if (o.key.type != msgpack::type::STR)
             continue;
         auto key = o.key.as<std::string_view>();

--- a/src/parsed_message.h
+++ b/src/parsed_message.h
@@ -370,6 +370,8 @@ ParsedMessage::msgpack_unpack(const msgpack::object& msg)
     } else if (parsedReq.fields) {
         if (auto rfields = findMapValue(*parsedReq.fields, "f"sv)) {
             auto vfields = rfields->as<std::set<Value::Field>>();
+            if (vfields.empty())
+                throw msgpack::type_error();
             if (auto rvalues = findMapValue(*parsedReq.fields, "v"sv)) {
                 if (rvalues->type != msgpack::type::ARRAY)
                     throw msgpack::type_error();

--- a/tests/test_networkengine.cpp
+++ b/tests/test_networkengine.cpp
@@ -214,9 +214,12 @@ makeEngine(std::unique_ptr<TestDatagramSocket>&& socket,
            std::mt19937_64& rd,
            int& onNewNodeCalls)
 {
+    net::NetworkConfig config {};
+    config.max_req_per_sec = -1;
+    config.max_peer_req_per_sec = -1;
     return net::NetworkEngine(
         myid,
-        {},
+        config,
         std::move(socket),
         {},
         rd,
@@ -243,18 +246,68 @@ NetworkEngineTester::tearDown()
 {}
 
 void
-NetworkEngineTester::testIgnoresUnknownPartialData()
+NetworkEngineTester::testCompletesPartialSessionWithDataBeforeHeader()
 {
     Scheduler scheduler;
     std::mt19937_64 rd(0);
     InfoHash myid = InfoHash::getRandom(rd);
+    InfoHash remoteId = InfoHash::getRandom(rd);
     int onNewNodeCalls = 0;
     auto engine = makeEngine(std::make_unique<TestDatagramSocket>(), scheduler, myid, rd, onNewNodeCalls);
 
-    Blob fragment = {1, 2, 3};
-    auto packet = makeValueDataPacketBlob(99, 0, 0, fragment);
+    auto serialized = serializeValue("fragment before header");
     auto from = makeIPv4("127.0.0.2", 5000);
+    auto fragment = makeValueDataPacketBlob(99, 0, 0, serialized);
+    auto header = makeReplyHeaderPacketBlob(remoteId, 99, {serialized.size()});
 
+    engine.processMessage(fragment.data(), fragment.size(), from);
+    CPPUNIT_ASSERT_EQUAL((size_t) 1, engine.getPartialCount());
+    CPPUNIT_ASSERT_EQUAL(0, onNewNodeCalls);
+
+    engine.processMessage(header.data(), header.size(), from);
+
+    CPPUNIT_ASSERT_EQUAL((size_t) 0, engine.getPartialCount());
+    CPPUNIT_ASSERT(onNewNodeCalls > 0);
+}
+
+void
+NetworkEngineTester::testBuffersLargeValueBeforeHeader()
+{
+    Scheduler scheduler;
+    std::mt19937_64 rd(8);
+    InfoHash myid = InfoHash::getRandom(rd);
+    InfoHash remoteId = InfoHash::getRandom(rd);
+    int onNewNodeCalls = 0;
+    auto engine = makeEngine(std::make_unique<TestDatagramSocket>(), scheduler, myid, rd, onNewNodeCalls);
+
+    auto serialized = serializeValue(std::string(57 * 1024, 'l'));
+    auto from = makeIPv4("127.0.0.2", 5008);
+    for (size_t offset = 0; offset < serialized.size(); offset += TEST_MTU) {
+        auto end = std::min(offset + TEST_MTU, serialized.size());
+        Blob data(serialized.begin() + offset, serialized.begin() + end);
+        auto fragment = makeValueDataPacketBlob(101, 0, offset, data);
+        engine.processMessage(fragment.data(), fragment.size(), from);
+    }
+    CPPUNIT_ASSERT_EQUAL((size_t) 1, engine.getPartialCount());
+
+    auto header = makeReplyHeaderPacketBlob(remoteId, 101, {serialized.size()});
+    engine.processMessage(header.data(), header.size(), from);
+
+    CPPUNIT_ASSERT_EQUAL((size_t) 0, engine.getPartialCount());
+    CPPUNIT_ASSERT(onNewNodeCalls > 0);
+}
+
+void
+NetworkEngineTester::testIgnoresEmptyPartialData()
+{
+    Scheduler scheduler;
+    std::mt19937_64 rd(7);
+    InfoHash myid = InfoHash::getRandom(rd);
+    int onNewNodeCalls = 0;
+    auto engine = makeEngine(std::make_unique<TestDatagramSocket>(), scheduler, myid, rd, onNewNodeCalls);
+
+    auto packet = makeValueDataPacketBlob(100, 0, 0, {});
+    auto from = makeIPv4("127.0.0.2", 5007);
     engine.processMessage(packet.data(), packet.size(), from);
 
     CPPUNIT_ASSERT_EQUAL((size_t) 0, engine.getPartialCount());
@@ -291,38 +344,30 @@ NetworkEngineTester::testCompletesPartialSessionFromSameSource()
 }
 
 void
-NetworkEngineTester::testKeepsSessionForWrongSourceFragment()
+NetworkEngineTester::testSeparatesPartialSessionsBySource()
 {
     Scheduler scheduler;
     std::mt19937_64 rd(2);
     InfoHash myid = InfoHash::getRandom(rd);
-    InfoHash remoteId = InfoHash::getRandom(rd);
+    InfoHash firstRemoteId = InfoHash::getRandom(rd);
+    InfoHash secondRemoteId = InfoHash::getRandom(rd);
     int onNewNodeCalls = 0;
     auto engine = makeEngine(std::make_unique<TestDatagramSocket>(), scheduler, myid, rd, onNewNodeCalls);
 
-    std::string data(TEST_MTU + 32, 'w');
-    auto serialized = serializeValue(data);
-    auto goodFrom = makeIPv4("127.0.0.2", 5002);
-    auto badFrom = makeIPv4("127.0.0.3", 5002);
-    auto header = makeReplyHeaderPacketBlob(remoteId, 11, {serialized.size()});
+    auto serialized = serializeValue("same transaction, different peers");
+    auto firstFrom = makeIPv4("127.0.0.2", 5002);
+    auto secondFrom = makeIPv4("127.0.0.3", 5002);
+    auto firstHeader = makeReplyHeaderPacketBlob(firstRemoteId, 11, {serialized.size()});
+    auto secondHeader = makeReplyHeaderPacketBlob(secondRemoteId, 11, {serialized.size()});
 
-    engine.processMessage(header.data(), header.size(), goodFrom);
+    engine.processMessage(firstHeader.data(), firstHeader.size(), firstFrom);
+    engine.processMessage(secondHeader.data(), secondHeader.size(), secondFrom);
+    CPPUNIT_ASSERT_EQUAL((size_t) 2, engine.getPartialCount());
+
+    auto fragment = makeValueDataPacketBlob(11, 0, 0, serialized);
+    engine.processMessage(fragment.data(), fragment.size(), firstFrom);
     CPPUNIT_ASSERT_EQUAL((size_t) 1, engine.getPartialCount());
-
-    auto firstEnd = std::min(TEST_MTU, serialized.size());
-    Blob firstFragment(serialized.begin(), serialized.begin() + firstEnd);
-    auto firstPacket = makeValueDataPacketBlob(11, 0, 0, firstFragment);
-    engine.processMessage(firstPacket.data(), firstPacket.size(), badFrom);
-
-    CPPUNIT_ASSERT_EQUAL((size_t) 1, engine.getPartialCount());
-    CPPUNIT_ASSERT_EQUAL(0, onNewNodeCalls);
-
-    engine.processMessage(firstPacket.data(), firstPacket.size(), goodFrom);
-    if (firstEnd < serialized.size()) {
-        Blob tail(serialized.begin() + firstEnd, serialized.end());
-        auto tailPacket = makeValueDataPacketBlob(11, 0, firstEnd, tail);
-        engine.processMessage(tailPacket.data(), tailPacket.size(), goodFrom);
-    }
+    engine.processMessage(fragment.data(), fragment.size(), secondFrom);
 
     CPPUNIT_ASSERT_EQUAL((size_t) 0, engine.getPartialCount());
     CPPUNIT_ASSERT(onNewNodeCalls > 0);

--- a/tests/test_networkengine.h
+++ b/tests/test_networkengine.h
@@ -13,9 +13,11 @@ class NetworkEngineTester : public CppUnit::TestFixture
 #ifdef _MSC_VER
     CPPUNIT_TEST(testDisabledOnMsvc);
 #else
-    CPPUNIT_TEST(testIgnoresUnknownPartialData);
+    CPPUNIT_TEST(testCompletesPartialSessionWithDataBeforeHeader);
+    CPPUNIT_TEST(testBuffersLargeValueBeforeHeader);
+    CPPUNIT_TEST(testIgnoresEmptyPartialData);
     CPPUNIT_TEST(testCompletesPartialSessionFromSameSource);
-    CPPUNIT_TEST(testKeepsSessionForWrongSourceFragment);
+    CPPUNIT_TEST(testSeparatesPartialSessionsBySource);
     CPPUNIT_TEST(testListenConfirmationCarriesToken);
     CPPUNIT_TEST(testListenConfirmationUpdatesSearchNodeToken);
     CPPUNIT_TEST(testListenReopensSocketAfterNodeExpiration);
@@ -30,9 +32,11 @@ public:
 #ifdef _MSC_VER
     void testDisabledOnMsvc();
 #else
-    void testIgnoresUnknownPartialData();
+    void testCompletesPartialSessionWithDataBeforeHeader();
+    void testBuffersLargeValueBeforeHeader();
+    void testIgnoresEmptyPartialData();
     void testCompletesPartialSessionFromSameSource();
-    void testKeepsSessionForWrongSourceFragment();
+    void testSeparatesPartialSessionsBySource();
     void testListenConfirmationCarriesToken();
     void testListenConfirmationUpdatesSearchNodeToken();
     void testListenReopensSocketAfterNodeExpiration();

--- a/tests/test_parsedmessage.cpp
+++ b/tests/test_parsedmessage.cpp
@@ -329,6 +329,31 @@ ParsedMessageTester::testParseRejectsInvalidValuesField()
 }
 
 void
+ParsedMessageTester::testParseRejectsEmptyFieldSelection()
+{
+    msgpack::sbuffer buffer;
+    msgpack::packer<msgpack::sbuffer> pk(&buffer);
+
+    pk.pack_map(3);
+    pk.pack(KEY_R);
+    pk.pack_map(1);
+    pk.pack(KEY_REQ_FIELDS);
+    pk.pack_map(2);
+    pk.pack("f");
+    pk.pack_array(0);
+    pk.pack("v");
+    pk.pack_array(0);
+    pk.pack(KEY_TID);
+    pk.pack(1u);
+    pk.pack(KEY_Y);
+    pk.pack(KEY_R);
+
+    auto msg = msgpack::unpack(buffer.data(), buffer.size());
+    ParsedMessage parsed;
+    CPPUNIT_ASSERT_THROW(parsed.msgpack_unpack(msg.get()), msgpack::type_error);
+}
+
+void
 ParsedMessageTester::testParseIgnoresIncompleteValueDataEntry()
 {
     msgpack::sbuffer buffer;

--- a/tests/test_parsedmessage.cpp
+++ b/tests/test_parsedmessage.cpp
@@ -354,6 +354,79 @@ ParsedMessageTester::testParseRejectsEmptyFieldSelection()
 }
 
 void
+ParsedMessageTester::testParseRejectsEmptyErrorArray()
+{
+    msgpack::sbuffer buffer;
+    msgpack::packer<msgpack::sbuffer> pk(&buffer);
+
+    pk.pack_map(3);
+    pk.pack(KEY_E);
+    pk.pack_array(0);
+    pk.pack(KEY_TID);
+    pk.pack(1u);
+    pk.pack(KEY_Y);
+    pk.pack(KEY_E);
+
+    auto msg = msgpack::unpack(buffer.data(), buffer.size());
+    ParsedMessage parsed;
+    CPPUNIT_ASSERT_THROW(parsed.msgpack_unpack(msg.get()), msgpack::type_error);
+}
+
+void
+ParsedMessageTester::testParseRejectsNonMapRequest()
+{
+    msgpack::sbuffer buffer;
+    msgpack::packer<msgpack::sbuffer> pk(&buffer);
+
+    pk.pack_map(4);
+    pk.pack(KEY_A);
+    pk.pack_array(2);
+    pk.pack(1u);
+    pk.pack(2u);
+    pk.pack(KEY_Q);
+    pk.pack(QUERY_PING);
+    pk.pack(KEY_TID);
+    pk.pack(1u);
+    pk.pack(KEY_Y);
+    pk.pack("q");
+
+    auto msg = msgpack::unpack(buffer.data(), buffer.size());
+    ParsedMessage parsed;
+    CPPUNIT_ASSERT_THROW(parsed.msgpack_unpack(msg.get()), msgpack::type_error);
+}
+
+void
+ParsedMessageTester::testParseErrorOnlyMessageKeepsRequestFieldsEmpty()
+{
+    msgpack::sbuffer buffer;
+    msgpack::packer<msgpack::sbuffer> pk(&buffer);
+
+    // An error message with no request map: the error array must not be walked
+    // as if it were a sequence of key/value pairs.
+    pk.pack_map(3);
+    pk.pack(KEY_E);
+    pk.pack_array(2);
+    pk.pack(401u);
+    pk.pack("unauthorized");
+    pk.pack(KEY_TID);
+    pk.pack(9u);
+    pk.pack(KEY_Y);
+    pk.pack(KEY_E);
+
+    auto msg = msgpack::unpack(buffer.data(), buffer.size());
+    ParsedMessage parsed;
+    parsed.msgpack_unpack(msg.get());
+
+    CPPUNIT_ASSERT(parsed.type == MessageType::Error);
+    CPPUNIT_ASSERT_EQUAL((uint16_t) 401, parsed.error_code);
+    CPPUNIT_ASSERT(not parsed.id);
+    CPPUNIT_ASSERT(parsed.token.empty());
+    CPPUNIT_ASSERT(parsed.values.empty());
+    CPPUNIT_ASSERT(parsed.nodes4_raw.empty());
+    CPPUNIT_ASSERT(parsed.nodes6_raw.empty());
+}
+
+void
 ParsedMessageTester::testParseIgnoresIncompleteValueDataEntry()
 {
     msgpack::sbuffer buffer;

--- a/tests/test_parsedmessage.h
+++ b/tests/test_parsedmessage.h
@@ -25,6 +25,9 @@ class ParsedMessageTester : public CppUnit::TestFixture
     CPPUNIT_TEST(testParseRejectsInvalidValueDataPayload);
     CPPUNIT_TEST(testParseRejectsInvalidValuesField);
     CPPUNIT_TEST(testParseRejectsEmptyFieldSelection);
+    CPPUNIT_TEST(testParseRejectsEmptyErrorArray);
+    CPPUNIT_TEST(testParseRejectsNonMapRequest);
+    CPPUNIT_TEST(testParseErrorOnlyMessageKeepsRequestFieldsEmpty);
     CPPUNIT_TEST(testParseIgnoresIncompleteValueDataEntry);
     CPPUNIT_TEST(testCompleteEmpty);
     CPPUNIT_TEST(testCompleteIncomplete);
@@ -55,6 +58,9 @@ public:
     void testParseRejectsInvalidValueDataPayload();
     void testParseRejectsInvalidValuesField();
     void testParseRejectsEmptyFieldSelection();
+    void testParseRejectsEmptyErrorArray();
+    void testParseRejectsNonMapRequest();
+    void testParseErrorOnlyMessageKeepsRequestFieldsEmpty();
     void testParseIgnoresIncompleteValueDataEntry();
     void testCompleteEmpty();
     void testCompleteIncomplete();

--- a/tests/test_parsedmessage.h
+++ b/tests/test_parsedmessage.h
@@ -24,6 +24,7 @@ class ParsedMessageTester : public CppUnit::TestFixture
     CPPUNIT_TEST(testParseRejectsNonMapPacket);
     CPPUNIT_TEST(testParseRejectsInvalidValueDataPayload);
     CPPUNIT_TEST(testParseRejectsInvalidValuesField);
+    CPPUNIT_TEST(testParseRejectsEmptyFieldSelection);
     CPPUNIT_TEST(testParseIgnoresIncompleteValueDataEntry);
     CPPUNIT_TEST(testCompleteEmpty);
     CPPUNIT_TEST(testCompleteIncomplete);
@@ -53,6 +54,7 @@ public:
     void testParseRejectsNonMapPacket();
     void testParseRejectsInvalidValueDataPayload();
     void testParseRejectsInvalidValuesField();
+    void testParseRejectsEmptyFieldSelection();
     void testParseIgnoresIncompleteValueDataEntry();
     void testCompleteEmpty();
     void testCompleteIncomplete();


### PR DESCRIPTION
## Problem

Malformed field-compressed responses can trigger a division by zero when their field selection is empty. Fragmented values also assume that the header arrives first and track in-progress messages only by transaction ID, so UDP reordering drops data and equal transaction IDs from different peers collide.

## Change

- reject empty field selections before computing the value count
- key partial messages by source address and transaction ID
- buffer fragments that arrive before their header
- bound pre-header bytes and packet count
- preserve rate limiting without charging reordered requests twice
- add regressions for malformed fields, reordered fragments, source collisions, empty fragment data and large values

## Tests

```
cmake --build build --target test_parsedmessage test_networkengine -j2
ctest --test-dir build --output-on-failure -R "test_(parsedmessage|networkengine)"
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>