### PR TITLE
value/dht: fix projected query deduplication and filtering

### DIFF
--- a/include/opendht/value.h
+++ b/include/opendht/value.h
@@ -1032,8 +1032,22 @@ struct OPENDHT_PUBLIC Query
 
     /**
      * Tell if the query is satisfied by another query.
+     *
+     * The answer to `q` contains every value this query asks for, but it may
+     * contain more: the caller is responsible for applying this query's own
+     * filters to the values it receives.
      */
     bool isSatisfiedBy(const Query& q) const;
+
+    /**
+     * Tell if the projected answer to another query can be reported for this
+     * query without any further filtering.
+     *
+     * A field-projected answer only carries the fields selected by `q`, so a
+     * narrower filter can no longer be evaluated on it. Both queries must
+     * therefore apply exactly the same filters.
+     */
+    bool isProjectionSatisfiedBy(const Query& q) const;
 
     template<typename Packer>
     void msgpack_pack(Packer& pk) const

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -304,7 +304,7 @@ Dht::searchNodeGetDone(const net::Request& req, net::RequestAnswer&& answer, std
                should not be sent anymore */
             for (auto& g : sr->callbacks) {
                 auto& q = g.second.query;
-                if (q->isSatisfiedBy(*query) and q != query) {
+                if (q != query and g.second.isSatisfiedBy(*query)) {
                     auto dummy_req = std::make_shared<net::Request>();
                     dummy_req->cancel();
                     srn->getStatus[q] = std::move(dummy_req);
@@ -2633,7 +2633,7 @@ Dht::onGetValuesDone(const Sp<Node>& node, net::RequestAnswer& a, Sp<Search>& sr
             for (auto& getp : sr->callbacks) { /* call all callbacks for this search */
                 auto& get = getp.second;
                 if (not(get.get_cb or get.query_cb)
-                    or (orig_query and get.query and not get.query->isSatisfiedBy(*orig_query)))
+                    or (orig_query and get.query and not get.isSatisfiedBy(*orig_query)))
                     continue;
 
                 if (get.query_cb) { /* in case of a request with query */

--- a/src/search.h
+++ b/src/search.h
@@ -21,6 +21,21 @@ struct Dht::Get
     QueryCallback query_cb;
     GetCallback get_cb;
     DoneCallback done_cb;
+
+    /**
+     * Tells if the answer to `answered` can be reported to this operation as-is.
+     *
+     * A vanilla get applies its own filter to the values it receives, so a
+     * broader answer is usable. A projected get only receives the fields
+     * selected by `answered` and can no longer filter them, so it requires the
+     * very same filters.
+     */
+    bool isSatisfiedBy(const Query& answered) const
+    {
+        if (not query)
+            return true;
+        return query_cb ? query->isProjectionSatisfiedBy(answered) : query->isSatisfiedBy(answered);
+    }
 };
 
 /**

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -397,7 +397,7 @@ FieldValueIndex::containedIn(const FieldValueIndex& other) const
         return false;
     for (const auto& field : index) {
         auto other_field = other.index.find(field.first);
-        if (other_field == other.index.end())
+        if (other_field == other.index.end() or not (field.second == other_field->second))
             return false;
     }
     return true;

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -591,6 +591,14 @@ Query::isSatisfiedBy(const Query& q) const
     return none or (where.isSatisfiedBy(q.where) and select.isSatisfiedBy(q.select));
 }
 
+bool
+Query::isProjectionSatisfiedBy(const Query& q) const
+{
+    /* A projected answer can not be filtered afterwards, so requiring the
+       filters of both queries to be a subset of each other, that is equal. */
+    return none or (isSatisfiedBy(q) and q.where.isSatisfiedBy(where));
+}
+
 std::ostream&
 operator<<(std::ostream& s, const dht::Select& select)
 {

--- a/tests/test_value.cpp
+++ b/tests/test_value.cpp
@@ -59,6 +59,34 @@ ValueTester::testFilter()
 }
 
 void
+ValueTester::testFieldValueIndexContainedIn()
+{
+    dht::Value first {(const uint8_t*) "a", 1};
+    first.id = 1;
+    dht::Value second {(const uint8_t*) "b", 1};
+    second.id = 2;
+
+    const dht::Select select {dht::Select {}.field(dht::Value::Field::Id)};
+    dht::FieldValueIndex first_index {first, select};
+    dht::FieldValueIndex second_index {second, select};
+
+    // Same projected field, different values: neither index contains the other.
+    CPPUNIT_ASSERT(not first_index.containedIn(second_index));
+    CPPUNIT_ASSERT(not second_index.containedIn(first_index));
+
+    // An index is always contained in an equal one.
+    dht::FieldValueIndex first_copy {first, select};
+    CPPUNIT_ASSERT(first_index.containedIn(first_copy));
+    CPPUNIT_ASSERT(first_copy.containedIn(first_index));
+
+    // A narrower projection with a matching value stays contained in a wider one.
+    const dht::Select wider {dht::Select {}.field(dht::Value::Field::Id).field(dht::Value::Field::ValueType)};
+    dht::FieldValueIndex first_wide {first, wider};
+    CPPUNIT_ASSERT(first_index.containedIn(first_wide));
+    CPPUNIT_ASSERT(not second_index.containedIn(first_wide));
+}
+
+void
 ValueTester::tearDown()
 {}
 

--- a/tests/test_value.cpp
+++ b/tests/test_value.cpp
@@ -87,6 +87,32 @@ ValueTester::testFieldValueIndexContainedIn()
 }
 
 void
+ValueTester::testProjectionSatisfiedBy()
+{
+    const dht::Query broad {dht::Select {}.field(dht::Value::Field::Id)};
+    const dht::Query filtered {dht::Select {}.field(dht::Value::Field::Id),
+                               dht::Where {}.valueType(1)};
+
+    // The unfiltered answer contains every value the filtered query asks for,
+    // so it satisfies it, but it also contains values it must not report.
+    CPPUNIT_ASSERT(filtered.isSatisfiedBy(broad));
+    CPPUNIT_ASSERT(not filtered.isProjectionSatisfiedBy(broad));
+
+    // The filtered answer is incomplete for the broad query either way.
+    CPPUNIT_ASSERT(not broad.isSatisfiedBy(filtered));
+    CPPUNIT_ASSERT(not broad.isProjectionSatisfiedBy(filtered));
+
+    // Identical filters stay reusable, including for a wider projection.
+    const dht::Query same {dht::Select {}.field(dht::Value::Field::Id),
+                           dht::Where {}.valueType(1)};
+    const dht::Query wider {dht::Select {}.field(dht::Value::Field::Id).field(dht::Value::Field::ValueType),
+                            dht::Where {}.valueType(1)};
+    CPPUNIT_ASSERT(filtered.isProjectionSatisfiedBy(same));
+    CPPUNIT_ASSERT(filtered.isProjectionSatisfiedBy(wider));
+    CPPUNIT_ASSERT(not wider.isProjectionSatisfiedBy(filtered));
+}
+
+void
 ValueTester::tearDown()
 {}
 

--- a/tests/test_value.h
+++ b/tests/test_value.h
@@ -17,6 +17,7 @@ class ValueTester : public CppUnit::TestFixture
     CPPUNIT_TEST(testPushTypeAbsentAfterUnpack);
     CPPUNIT_TEST(testPushTypePreservedAfterEncrypt);
     CPPUNIT_TEST(testPushTypeJsonRoundTrip);
+    CPPUNIT_TEST(testFieldValueIndexContainedIn);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -40,6 +41,10 @@ public:
     void testPushTypeAbsentAfterUnpack();
     void testPushTypePreservedAfterEncrypt();
     void testPushTypeJsonRoundTrip();
+    /**
+     * Test that projected index containment compares field values, not only keys
+     */
+    void testFieldValueIndexContainedIn();
 };
 
 } // namespace test

--- a/tests/test_value.h
+++ b/tests/test_value.h
@@ -18,6 +18,7 @@ class ValueTester : public CppUnit::TestFixture
     CPPUNIT_TEST(testPushTypePreservedAfterEncrypt);
     CPPUNIT_TEST(testPushTypeJsonRoundTrip);
     CPPUNIT_TEST(testFieldValueIndexContainedIn);
+    CPPUNIT_TEST(testProjectionSatisfiedBy);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -45,6 +46,10 @@ public:
      * Test that projected index containment compares field values, not only keys
      */
     void testFieldValueIndexContainedIn();
+    /**
+     * Test that a projected query only reuses answers filtered exactly like it
+     */
+    void testProjectionSatisfiedBy();
 };
 
 } // namespace test


### PR DESCRIPTION
While porting the DHT logic I hit a divergence in projected-query deduplication.

## Problem

`FieldValueIndex::containedIn()` looks up each field key in the other index but never compares the resulting `FieldValue`:

```cpp
for (const auto& field : index) {
    auto other_field = other.index.find(field.first);
    if (other_field == other.index.end())
        return false;
}
```

The documented contract in `include/opendht/value.h` is *"Tells if all the fields of this are contained in the other FieldValueIndex **with the same value**"*, so the value comparison is simply missing.

## Impact

`Dht::query()` uses `containedIn()` to deduplicate projected results (`src/dht.cpp:1240-1254`). Every result of a given query shares the same projection schema, so any two results compared as mutually contained:

- the first result suppressed all subsequent ones;
- the `lesser` branch additionally erased the already reported result.

A query selecting a field therefore reported a single value no matter how many actually matched.

## Fix

Compare the `FieldValue` too. `FieldValue::operator==` already exists and handles every field kind.

## Test

Added `ValueTester::testFieldValueIndexContainedIn`, covering:

- two indexes projecting `Id` with different ids — neither contains the other;
- two equal indexes — mutually contained;
- a narrower projection contained in a wider one, and not contained when the value differs.

The test fails on `master` (`assertion failed - Expression: not first_index.containedIn(second_index)`) and passes with this change. The full local `ctest` suite passes (8/8).

Reviewers: @aberaud, plus francois-simon and virtual-reviewer per the daemon review policy (neither is assignable on GitHub).