### PR TITLE
dht: bound the listeners a remote node may register

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -460,7 +460,13 @@ private:
     void reportedAddr(const SockAddr&);
 
     // Storage
-    void storageAddListener(const InfoHash& id, const Sp<Node>& node, size_t tid, Query&& = {}, int version = 0);
+    /**
+     * Registers or refreshes a remote listening socket.
+     *
+     * @return false when the listener quota of the node or of the key is
+     *         reached, in which case nothing is stored.
+     */
+    bool storageAddListener(const InfoHash& id, const Sp<Node>& node, size_t tid, Query&& = {}, int version = 0);
     bool storageStore(const InfoHash& id,
                       const Sp<Value>& value,
                       time_point created,

--- a/include/opendht/network_engine.h
+++ b/include/opendht/network_engine.h
@@ -46,6 +46,7 @@ public:
     static const constexpr uint16_t NON_AUTHORITATIVE_INFORMATION {203}; /* incomplete request packet. */
     static const constexpr uint16_t UNAUTHORIZED {401};                  /* incorrect tokens. */
     static const constexpr uint16_t NOT_FOUND {404};                     /* storage not found */
+    static const constexpr uint16_t TOO_MANY_REQUESTS {429};             /* resource quota reached. */
     // for internal use (custom).
     static const constexpr uint16_t INVALID_TID_SIZE {421};        /* id was truncated. */
     static const constexpr uint16_t UNKNOWN_TID {422};             /* unknown tid */
@@ -54,6 +55,7 @@ public:
     static const std::string GET_NO_INFOHASH;    /* received "get" request with no infohash */
     static const std::string LISTEN_NO_INFOHASH; /* got "listen" request without infohash */
     static const std::string LISTEN_WRONG_TOKEN; /* incorrect token in "listen" request */
+    static const std::string LISTEN_TOO_MANY;    /* too many listeners registered by the node */
     static const std::string PUT_NO_INFOHASH;    /* no infohash in "put" request */
     static const std::string PUT_WRONG_TOKEN;    /* got "put" request with incorrect token */
     static const std::string STORAGE_NOT_FOUND;  /* got access request for an unknown storage */

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -1487,35 +1487,47 @@ Dht::storageStore(const InfoHash& id,
     return std::get<0>(store);
 }
 
-void
+bool
 Dht::storageAddListener(const InfoHash& id, const Sp<Node>& node, size_t socket_id, Query&& query, int version)
 {
     const auto& now = scheduler.time();
     auto st = store.find(id);
     if (st == store.end()) {
         if (store.size() >= max_store_keys)
-            return;
+            return false;
         st = store.emplace(id, now).first;
     }
-    auto& node_listeners = st->second.listeners[node];
-    auto l = node_listeners.find(socket_id);
-    if (l == node_listeners.end()) {
-        auto vals = st->second.get(query.where.getFilter());
-        if (not vals.empty()) {
-            network_engine.tellListener(node,
-                                        socket_id,
-                                        id,
-                                        WANT4 | WANT6,
-                                        makeToken(node->getAddr(), false),
-                                        dht4.buckets.findClosestNodes(id, now, TARGET_NODES),
-                                        dht6.buckets.findClosestNodes(id, now, TARGET_NODES),
-                                        std::move(vals),
-                                        query,
-                                        version);
+    auto& storage = st->second;
+    auto nl = storage.listeners.find(node);
+    if (nl != storage.listeners.end()) {
+        auto l = nl->second.find(socket_id);
+        if (l != nl->second.end()) {
+            l->second.refresh(now, std::forward<Query>(query));
+            return true;
         }
-        node_listeners.emplace(socket_id, Listener {now, std::forward<Query>(query), version});
-    } else
-        l->second.refresh(now, std::forward<Query>(query));
+    }
+    /* Look the quota up before touching the listener maps, so that a refused
+       subscription never creates an entry of its own. */
+    if (not storage.canAddListener(node)) {
+        if (logger_)
+            logger_->warn("[node {}] Listener quota reached for {}", node->toString(), id.to_view());
+        return false;
+    }
+    auto vals = storage.get(query.where.getFilter());
+    if (not vals.empty()) {
+        network_engine.tellListener(node,
+                                    socket_id,
+                                    id,
+                                    WANT4 | WANT6,
+                                    makeToken(node->getAddr(), false),
+                                    dht4.buckets.findClosestNodes(id, now, TARGET_NODES),
+                                    dht6.buckets.findClosestNodes(id, now, TARGET_NODES),
+                                    std::move(vals),
+                                    query,
+                                    version);
+    }
+    storage.listeners[node].emplace(socket_id, Listener {now, std::forward<Query>(query), version});
+    return true;
 }
 
 void
@@ -2704,7 +2716,10 @@ Dht::onListen(Sp<Node> node, const InfoHash& hash, const Blob& token, size_t soc
                                          net::DhtProtocolException::LISTEN_WRONG_TOKEN};
     }
     Query q = query;
-    storageAddListener(hash, node, socket_id, std::move(q), version);
+    if (not storageAddListener(hash, node, socket_id, std::move(q), version)) {
+        throw net::DhtProtocolException {net::DhtProtocolException::TOO_MANY_REQUESTS,
+                                         net::DhtProtocolException::LISTEN_TOO_MANY};
+    }
     net::RequestAnswer answer {};
     answer.ntoken = makeToken(node->getAddr(), false);
     return answer;

--- a/src/network_engine.cpp
+++ b/src/network_engine.cpp
@@ -18,6 +18,7 @@ using namespace std::chrono_literals;
 const std::string DhtProtocolException::GET_NO_INFOHASH {"Get_values with no info_hash"};
 const std::string DhtProtocolException::LISTEN_NO_INFOHASH {"Listen with no info_hash"};
 const std::string DhtProtocolException::LISTEN_WRONG_TOKEN {"Listen with incorrect token"};
+const std::string DhtProtocolException::LISTEN_TOO_MANY {"Too many listeners for this node"};
 const std::string DhtProtocolException::PUT_NO_INFOHASH {"Put with no info_hash"};
 const std::string DhtProtocolException::PUT_WRONG_TOKEN {"Put with incorrect token"};
 const std::string DhtProtocolException::PUT_INVALID_ID {"Put with invalid ID"};

--- a/src/storage.h
+++ b/src/storage.h
@@ -96,6 +96,28 @@ struct Storage
     /* The maximum number of values we store for a given hash. */
     static constexpr unsigned MAX_VALUES {64 * 1024};
 
+    /* The maximum number of listening sockets a remote node may register for a given hash. */
+    static constexpr unsigned MAX_LISTENERS_PER_NODE {32};
+
+    /* The maximum number of remote nodes listening to a given hash. */
+    static constexpr unsigned MAX_LISTENING_NODES {512};
+
+    /**
+     * Tells whether a new listening socket may be registered for this node.
+     *
+     * Remote listeners are entirely attacker-controlled: a peer picks its own
+     * socket identifiers, and may claim any number of node identifiers from a
+     * single address. Without a quota, the retained subscriptions and the
+     * queries they carry grow without bound.
+     */
+    bool canAddListener(const Sp<Node>& node) const
+    {
+        auto nl = listeners.find(node);
+        if (nl == listeners.end())
+            return listeners.size() < MAX_LISTENING_NODES;
+        return nl->second.size() < MAX_LISTENERS_PER_NODE;
+    }
+
     /**
      * Changes caused by an operation on the storage.
      */

--- a/tests/test_networkengine.cpp
+++ b/tests/test_networkengine.cpp
@@ -546,6 +546,42 @@ NetworkEngineTester::testUnauthorizedListenFlushClearsListenState()
     CPPUNIT_ASSERT(!listenStatusIt->second.refresh);
 }
 
+void
+NetworkEngineTester::testRemoteListenerQuota()
+{
+    std::mt19937_64 rd(11);
+    Storage storage {clock::now()};
+    auto node = std::make_shared<Node>(InfoHash::getRandom(rd), makeIPv4("127.0.0.3", 5100), rd);
+
+    // A remote node picks its own socket identifiers, so its subscriptions must
+    // be capped instead of growing with every request.
+    for (unsigned i = 0; i < Storage::MAX_LISTENERS_PER_NODE; ++i) {
+        CPPUNIT_ASSERT(storage.canAddListener(node));
+        storage.listeners[node].emplace(i, Listener {clock::now(), Query {}, 0});
+    }
+    CPPUNIT_ASSERT(not storage.canAddListener(node));
+    CPPUNIT_ASSERT_EQUAL((size_t) Storage::MAX_LISTENERS_PER_NODE, storage.listeners[node].size());
+
+    // A different node keeps its own quota.
+    auto other = std::make_shared<Node>(InfoHash::getRandom(rd), makeIPv4("127.0.0.4", 5101), rd);
+    CPPUNIT_ASSERT(storage.canAddListener(other));
+
+    // A node claims its own identifier, so the number of listening nodes is
+    // capped as well.
+    Storage crowded {clock::now()};
+    for (unsigned i = 0; i < Storage::MAX_LISTENING_NODES; ++i) {
+        auto n = std::make_shared<Node>(InfoHash::getRandom(rd), makeIPv4("127.0.0.5", 5200), rd);
+        CPPUNIT_ASSERT(crowded.canAddListener(n));
+        crowded.listeners[n].emplace(0u, Listener {clock::now(), Query {}, 0});
+    }
+    auto extra = std::make_shared<Node>(InfoHash::getRandom(rd), makeIPv4("127.0.0.5", 5200), rd);
+    CPPUNIT_ASSERT(not crowded.canAddListener(extra));
+    CPPUNIT_ASSERT_EQUAL((size_t) Storage::MAX_LISTENING_NODES, crowded.listeners.size());
+
+    // An already registered socket is still refreshable at quota.
+    CPPUNIT_ASSERT(storage.listeners[node].find(0) != storage.listeners[node].end());
+}
+
 } // namespace test
 
 #endif

--- a/tests/test_networkengine.h
+++ b/tests/test_networkengine.h
@@ -20,6 +20,7 @@ class NetworkEngineTester : public CppUnit::TestFixture
     CPPUNIT_TEST(testListenConfirmationUpdatesSearchNodeToken);
     CPPUNIT_TEST(testListenReopensSocketAfterNodeExpiration);
     CPPUNIT_TEST(testUnauthorizedListenFlushClearsListenState);
+    CPPUNIT_TEST(testRemoteListenerQuota);
 #endif
     CPPUNIT_TEST_SUITE_END();
 
@@ -37,6 +38,7 @@ public:
     void testListenConfirmationUpdatesSearchNodeToken();
     void testListenReopensSocketAfterNodeExpiration();
     void testUnauthorizedListenFlushClearsListenState();
+    void testRemoteListenerQuota();
 #endif
 };
 


### PR DESCRIPTION
Follow-up to the network hardening in #888, on a different subsystem.

## Problem

`Dht::storageAddListener()` (`src/dht.cpp:1491`) registers a `Listener` unconditionally:

```cpp
auto& node_listeners = st->second.listeners[node];
auto l = node_listeners.find(socket_id);
if (l == node_listeners.end()) {
    ...
    node_listeners.emplace(socket_id, Listener {now, std::forward<Query>(query), version});
}
```

Both the socket identifier and the node identifier are chosen by the peer, and the token only binds to a source address. A single address can therefore register an unbounded number of subscriptions, each retaining a copy of the attacker-supplied `Query`.

Nothing bounds this:

- listener bookkeeping is independent of `Storage::MAX_VALUES` and of the storage size quota;
- `max_store_keys` bounds the number of keys, not the listeners on a key;
- the ten-minute expiration in `Storage::expire()` bounds their *lifetime*, not their *intake* — traffic well within the default request rate limit keeps memory pressure up indefinitely.

Trigger: `get`/`find_node` to obtain the freely issued token, then repeated valid `listen` requests with distinct socket ids.

## Fix

- `Storage::MAX_LISTENERS_PER_NODE` (32) and `Storage::MAX_LISTENING_NODES` (512), alongside the existing `MAX_VALUES`.
- `Storage::canAddListener()` is consulted *before* touching the listener maps, so a refused subscription never creates an entry of its own (`listeners[node]` used to default-construct one).
- `storageAddListener()` now returns whether the listener was registered; `onListen()` reports a refusal with a new `TOO_MANY_REQUESTS` (429) protocol error instead of silently pretending the listen succeeded.
- Refreshing an already registered socket keeps working at quota.

The 429 code is only special-cased for `UNAUTHORIZED` in `Dht::onError()`, so older peers simply see the request fail — no interop break.

I am happy to adjust the two limits if you prefer different defaults, or to make them configurable through `Config`.

## Test

`NetworkEngineTester::testRemoteListenerQuota` covers the per-node cap, the independence of two nodes, the per-key node cap, and that a registered socket survives at quota. Full local `ctest` passes (8/8).

Reviewers: @aberaud, plus francois-simon and virtual-reviewer per the daemon review policy (neither is assignable on GitHub).