### PR TITLE
crypto: generate positive certificate serial numbers

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include <argon2.h>
 }
 
+#include <array>
 #include <random>
 #include <sstream>
 #include <fstream>
@@ -1395,9 +1396,19 @@ void
 setRandomSerial(gnutls_x509_crt_t cert)
 {
     std::random_device rdev;
-    std::uniform_int_distribution<int64_t> dist {1};
-    int64_t cert_serial = dist(rdev);
-    gnutls_x509_crt_set_serial(cert, &cert_serial, sizeof(cert_serial));
+    std::uniform_int_distribution<uint64_t> dist {1};
+    /* RFC 5280 section 4.1.2.2 requires the serial number to be a positive
+       integer, and gnutls_x509_crt_set_serial() expects its buffer in network
+       byte order. Handing over the native representation of an integer made
+       the leading DER byte arbitrary, so on little-endian hosts roughly half
+       of the generated certificates carried a negative serial number. */
+    uint64_t cert_serial = dist(rdev) & 0x7fffffffffffffffULL;
+    if (cert_serial == 0)
+        cert_serial = 1;
+    std::array<uint8_t, sizeof(cert_serial)> serial_bytes;
+    for (size_t i = 0; i < serial_bytes.size(); i++)
+        serial_bytes[i] = static_cast<uint8_t>(cert_serial >> (8 * (serial_bytes.size() - 1 - i)));
+    gnutls_x509_crt_set_serial(cert, serial_bytes.data(), serial_bytes.size());
 }
 
 Certificate

--- a/tests/test_crypto.cpp
+++ b/tests/test_crypto.cpp
@@ -301,6 +301,20 @@ CryptoTester::testCertificateSerialNumber()
 }
 
 void
+CryptoTester::testGeneratedSerialNumberIsPositive()
+{
+    /* RFC 5280 section 4.1.2.2: the serial number MUST be a positive integer.
+       A leading byte with its high bit set encodes a negative DER INTEGER. */
+    for (unsigned i = 0; i < 16; i++) {
+        auto id = dht::crypto::generateIdentity("test", {}, 2048, true);
+        auto serial = id.second->getSerialNumber();
+        CPPUNIT_ASSERT(not serial.empty());
+        CPPUNIT_ASSERT_MESSAGE("generated serial number must not be negative",
+                               (serial.front() & 0x80) == 0);
+    }
+}
+
+void
 CryptoTester::testOcsp()
 {
     auto ca = dht::crypto::generateIdentity("Test CA");

--- a/tests/test_crypto.h
+++ b/tests/test_crypto.h
@@ -18,6 +18,7 @@ class CryptoTester : public CppUnit::TestFixture
     CPPUNIT_TEST(testRevocationListPartitionedNumber);
     CPPUNIT_TEST(testCertificateRequest);
     CPPUNIT_TEST(testCertificateSerialNumber);
+    CPPUNIT_TEST(testGeneratedSerialNumberIsPositive);
     CPPUNIT_TEST(testOcsp);
     CPPUNIT_TEST(testAesEncryption);
     CPPUNIT_TEST(testAesEncryptionWithMultipleKeySizes);
@@ -63,6 +64,7 @@ public:
      * Test certificate serial number extraction
      */
     void testCertificateSerialNumber();
+    void testGeneratedSerialNumberIsPositive();
     /**
      * Test OCSP
      */


### PR DESCRIPTION
Roughly half of the certificates generated by OpenDHT carry a **negative** serial number, which RFC 5280 forbids.

### Cause

`setRandomSerial()` draws a positive `int64_t`, then hands the native memory representation of that integer to `gnutls_x509_crt_set_serial()`:

```cpp
std::uniform_int_distribution<int64_t> dist {1};
int64_t cert_serial = dist(rdev);
gnutls_x509_crt_set_serial(cert, &cert_serial, sizeof(cert_serial));
```

GnuTLS expects that buffer in network byte order. On a little-endian host the least significant byte is passed first, so the leading DER byte is an arbitrary byte of the drawn value rather than its most significant one. When that byte has its high bit set, the DER INTEGER encodes a negative number.

Two consequences:

- RFC 5280 §4.1.2.2 states the serial number MUST be a positive integer. Negative serials are flagged by certificate linters and rejected by some X.509 implementations.
- The serial actually stored bears no relation to the number that was drawn, since the byte order is reversed.

### Reproduction

```cpp
int negative = 0;
for (int i = 0; i < 20; i++) {
    auto id = dht::crypto::generateIdentity("T", {}, 2048, true);
    auto serial = id.second->getSerialNumber();
    if (!serial.empty() && (serial[0] & 0x80)) negative++;
}
printf("negative=%d/20\n", negative);   // negative=11/20
```

`openssl x509 -noout -serial -text` on such a certificate reports e.g.
`Serial Number: -2663978395622007703 (-0x24f85a3c885d6397)`.

### Fix

Write the serial most significant byte first and clear the sign bit.

### Test

`CryptoTester::testGeneratedSerialNumberIsPositive` generates 16 identities and asserts the leading byte never has its high bit set. Verified failing before the change (`assertion failed - Expression: (serial.front() & 0x80) == 0`) and passing after it, alongside the 13 pre-existing crypto tests.