### PR TITLE
crypto: strip the terminating null byte from an exported public key

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -571,6 +571,12 @@ PublicKey::toString() const
     }
     if (err != GNUTLS_E_SUCCESS)
         throw CryptoException(std::string("Could not print public key: ") + gnutls_strerror(err));
+    // GnuTLS reports the PEM size including the terminating null byte, which
+    // does not belong to the text and would end up embedded in whatever the
+    // string is copied into, such as the "owner" field of a serialized value.
+    ret.resize(sz);
+    if (not ret.empty() and ret.back() == '\0')
+        ret.pop_back();
     return ret;
 }
 

--- a/tests/test_crypto.cpp
+++ b/tests/test_crypto.cpp
@@ -60,6 +60,24 @@ CryptoTester::testSignatureEncryption()
 }
 
 void
+CryptoTester::testPublicKeyPemIsPlainText()
+{
+    auto key = dht::crypto::PrivateKey::generate();
+    auto pem = key.getPublicKey().toString();
+
+    // The exported key is PEM text: it must not carry the terminating null
+    // byte GnuTLS counts in the exported size, which would otherwise be
+    // embedded in anything the string is serialized into.
+    CPPUNIT_ASSERT(not pem.empty());
+    CPPUNIT_ASSERT_EQUAL(std::string::npos, pem.find('\0'));
+    CPPUNIT_ASSERT_EQUAL('\n', pem.back());
+
+    // The exported text still reads back as the same key.
+    dht::crypto::PublicKey reloaded(dht::Blob(pem.begin(), pem.end()));
+    CPPUNIT_ASSERT_EQUAL(key.getPublicKey().getId(), reloaded.getId());
+}
+
+void
 CryptoTester::testCertificateRevocation()
 {
     auto ca1 = dht::crypto::generateIdentity("ca1");

--- a/tests/test_crypto.h
+++ b/tests/test_crypto.h
@@ -12,6 +12,7 @@ class CryptoTester : public CppUnit::TestFixture
 {
     CPPUNIT_TEST_SUITE(CryptoTester);
     CPPUNIT_TEST(testSignatureEncryption);
+    CPPUNIT_TEST(testPublicKeyPemIsPlainText);
     CPPUNIT_TEST(testCertificateRevocation);
     CPPUNIT_TEST(testRevocationListNumber);
     CPPUNIT_TEST(testRevocationListExplicitNumber);
@@ -39,6 +40,10 @@ public:
      * Test data signature, encryption and decryption
      */
     void testSignatureEncryption();
+    /**
+     * Test that an exported public key is text only, with no embedded null byte
+     */
+    void testPublicKeyPemIsPlainText();
     /**
      * Test certificate generation, validation and revocation
      */


### PR DESCRIPTION
`gnutls_pubkey_export` reports the size of the exported PEM **including** its terminating null byte, and `PublicKey::toString` hands that size straight back to the caller. The returned string therefore ends with a byte that is not part of the PEM text.

`Certificate::toString` does not have the problem, because `gnutls_x509_crt_export` excludes the terminator. The two exports disagree on what a PEM string is.

The stray byte travels. `Value::toJson` stores `owner->toString()` in the `owner` field, so a signed value served by the proxy looks like this:

```json
{"data":"c2ln","id":"9","owner":"-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n\u0000","seq":0,"sig":"..."}
```

That is valid JSON, but a null byte inside a text field is a surprise for any consumer that treats it as a string.

The fix resizes to the reported size and drops the terminator when present.

A regression test asserts the exported key contains no null byte, ends with a newline, and still reloads to the same key identifier. Without the change it fails, reporting the null byte at offset 800:

```
1) test: test::CryptoTester::testPublicKeyPemIsPlainText (F) line: 72 tests/test_crypto.cpp
equality assertion failed
- Expected: 18446744073709551615
- Actual  : 800
```

With the change the suite passes (14 tests).