### PR TITLE
pht: fix the bit arithmetic of Prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -871,6 +871,12 @@ if (BUILD_TESTING)
         tests/test_networkengine.h
         tests/test_networkengine.cpp
     )
+    if (OPENDHT_INDEX)
+        list (APPEND test_FILES
+            tests/test_pht.h
+            tests/test_pht.cpp
+        )
+    endif()
     if (OPENDHT_PROXY_CLIENT)
         list (APPEND test_FILES
             tests/test_dhtproxy_client.h

--- a/include/opendht/indexation/pht.h
+++ b/include/opendht/indexation/pht.h
@@ -123,28 +123,19 @@ ee     *
      */
     static inline unsigned commonBits(const Prefix& p1, const Prefix& p2)
     {
-        unsigned i, j;
-        uint8_t x;
+        /* size_ counts bits, so the comparison walks bits: reading it as a
+           byte count would run past the end of the shorter content. */
         auto longest_prefix_size = std::min(p1.size_, p2.size_);
 
-        for (i = 0; i < longest_prefix_size; i++) {
-            if (p1.content_.data()[i] != p2.content_.data()[i] or not p1.isFlagActive(i) or not p2.isFlagActive(i)) {
+        unsigned common = 0;
+        while (common < longest_prefix_size) {
+            if (not p1.isFlagActive(common) or not p2.isFlagActive(common)
+                or p1.isContentBitActive(common) != p2.isContentBitActive(common))
                 break;
-            }
+            common++;
         }
 
-        if (i == longest_prefix_size)
-            return 8 * longest_prefix_size;
-
-        x = p1.content_.data()[i] ^ p2.content_.data()[i];
-
-        j = 0;
-        while ((x & 0x80) == 0) {
-            x <<= 1;
-            j++;
-        }
-
-        return 8 * i + j;
+        return common;
     }
 
     /**
@@ -242,8 +233,9 @@ private:
         if (bit >= b.size() * 8)
             throw std::out_of_range("bit larger than prefix size.");
 
-        size_t offset_bit = (8 - bit) % 8;
-        b[bit / 8] ^= (1 << offset_bit);
+        /* Bit 0 is the most significant one of the first byte, as
+           isActiveBit reads it. */
+        b[bit / 8] ^= (1 << (7 - (bit % 8)));
     }
 };
 

--- a/tests/test_pht.cpp
+++ b/tests/test_pht.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2014-2026 Savoir-faire Linux Inc.
+// SPDX-License-Identifier: MIT
+
+#include "test_pht.h"
+
+// opendht
+#include "opendht/indexation/pht.h"
+
+namespace test {
+CPPUNIT_TEST_SUITE_REGISTRATION(PhtTester);
+
+using dht::indexation::Prefix;
+
+void
+PhtTester::testCommonBits()
+{
+    // Prefix::size_ counts bits, so two prefixes that agree everywhere have
+    // as many bits in common as they are long, and no more.
+    const Prefix same {dht::Blob(20, 0xAB)};
+    CPPUNIT_ASSERT_EQUAL((unsigned) 160, Prefix::commonBits(same, Prefix {dht::Blob(20, 0xAB)}));
+
+    // A difference in the very last bit leaves every other bit in common.
+    dht::Blob other(20, 0xAB);
+    other[19] = 0xAA;
+    CPPUNIT_ASSERT_EQUAL((unsigned) 159, Prefix::commonBits(same, Prefix {other}));
+
+    // A difference in the very first bit leaves nothing in common.
+    dht::Blob first(20, 0xAB);
+    first[0] = 0x2B;
+    CPPUNIT_ASSERT_EQUAL((unsigned) 0, Prefix::commonBits(same, Prefix {first}));
+
+    // Bits beyond the shorter prefix are not compared, whatever the content
+    // they are cut from holds.
+    const Prefix shorter = same.getPrefix(3);
+    CPPUNIT_ASSERT_EQUAL((size_t) 3, shorter.size_);
+    CPPUNIT_ASSERT_EQUAL((unsigned) 3, Prefix::commonBits(shorter, same));
+    CPPUNIT_ASSERT_EQUAL((unsigned) 3, Prefix::commonBits(same, shorter));
+}
+
+void
+PhtTester::testSibling()
+{
+    // The sibling of a node in the trie is the prefix that differs from it in
+    // its last bit, and in that bit only.
+    for (size_t length : {1, 7, 8, 9, 15, 16, 159}) {
+        const Prefix prefix = Prefix {dht::Blob(20, 0xAB)}.getPrefix(length);
+        const Prefix sibling = prefix.getSibling();
+
+        CPPUNIT_ASSERT_EQUAL(prefix.size_, sibling.size_);
+        CPPUNIT_ASSERT_EQUAL((unsigned) (length - 1), Prefix::commonBits(prefix, sibling));
+        CPPUNIT_ASSERT(prefix.isContentBitActive(length - 1) != sibling.isContentBitActive(length - 1));
+
+        // Being siblings is symmetric.
+        CPPUNIT_ASSERT(sibling.getSibling().content_ == prefix.content_);
+    }
+}
+
+} // namespace test

--- a/tests/test_pht.h
+++ b/tests/test_pht.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2014-2026 Savoir-faire Linux Inc.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// cppunit
+#include <cppunit/TestFixture.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+namespace test {
+
+class PhtTester : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(PhtTester);
+    CPPUNIT_TEST(testCommonBits);
+    CPPUNIT_TEST(testSibling);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    /**
+     * Test how many bits two prefixes have in common
+     */
+    void testCommonBits();
+    /**
+     * Test the prefix of the sibling node in the trie
+     */
+    void testSibling();
+};
+
+} // namespace test


### PR DESCRIPTION
Prefix mixes up bit and byte positions in two places.

**`commonBits` reads past the end of the prefix.** `size_` counts bits, but the loop walks `content_` a byte at a time up to it. Two prefixes agreeing over their whole common length are read well past their end, and the count returned is eight times too large. Compiled with AddressSanitizer:

```
==230705==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6dca151e13d4
READ of size 1 at 0x6dca151e13d4 thread T0
    #0 dht::indexation::Prefix::commonBits(...)
0x6dca151e13d4 is located 0 bytes after 20-byte region
```

`Pht::lookupStep` calls it as `Prefix::commonBits(p, entry.prefix)` during an inexact lookup, and `entry.prefix` comes straight off the network, so this is reachable as soon as an index entry matches the key being looked for. The flags were indexed the same way, so a partially known prefix was tested at the wrong position too.

**`swapBit` flips the wrong bit.** It uses `(8 - bit) % 8`, while `isActiveBit` reads `7 - (bit % 8)`. `getSibling` flips the last bit of a prefix to name the sibling node in the trie, so it returned a prefix that differs in some other bit and still shares the last one. Splitting a full leaf (`pht.cpp:326`), the binary search over the trie (`pht.cpp:171`) and the canary lookup (`pht.cpp:505`) all rely on it.

`InfoHash::commonBits` is the correct version of the same idea; the one in `Prefix` looks like a copy that was never adapted to a prefix whose length is not a whole number of bytes.

## Testing

New `tests/test_pht.cpp`, built when `OPENDHT_INDEX` is on. Both tests fail before the fix:

```
1) test: test::PhtTester::testCommonBits
- Expected: 160
- Actual  : 193

2) test: test::PhtTester::testSibling
- Expected: 0
- Actual  : 7
```

and pass after it.