### PR TITLE
dht: age persisted values by the time the node was really down

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -864,6 +864,8 @@ if (BUILD_TESTING)
         tests/test_dhtrunner.cpp
         tests/test_storage.h
         tests/test_storage.cpp
+        tests/test_persistence.h
+        tests/test_persistence.cpp
         tests/test_threadpool.h
         tests/test_threadpool.cpp
         tests/test_parsedmessage.h

--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -276,6 +276,12 @@ public:
 
     std::vector<ValuesExport> exportValues() const override;
     void importValues(const std::vector<ValuesExport>&) override;
+    /**
+     * Imports values whose timestamps were taken from another run of the
+     * steady clock, shifting them by @p offset so that they mean the same
+     * instant here.
+     */
+    void importValues(const std::vector<ValuesExport>&, clock::duration offset);
 
     void saveState(const std::string& path) const;
     void loadState(const std::string& path);

--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -2386,6 +2386,12 @@ Dht::exportValues() const
 void
 Dht::importValues(const std::vector<ValuesExport>& import)
 {
+    importValues(import, clock::duration::zero());
+}
+
+void
+Dht::importValues(const std::vector<ValuesExport>& import, clock::duration offset)
+{
     const auto& now = scheduler.time();
 
     unsigned imported = 0, ignored = 0;
@@ -2431,7 +2437,9 @@ Dht::importValues(const std::vector<ValuesExport>& import)
                     ignored++;
                     continue;
                 }
-                val_time = std::min(val_time, now);
+                val_time = std::min(val_time + offset, now);
+                if (expiration != time_point::min())
+                    expiration += offset;
                 auto val_size = tmp_val.size();
                 if (storageStore(value.first,
                                  std::make_shared<Value>(std::move(tmp_val)),
@@ -2881,9 +2889,42 @@ struct DhtState
     InfoHash id;
     std::vector<NodeExport> nodes;
     std::vector<ValuesExport> values;
+    /* Value timestamps are steady_clock counts, which are only meaningful for
+       as long as the machine keeps running. Recording when the state was saved,
+       on both clocks, is what lets the next run translate them: the wall clock
+       says how much time really went by, and the steady count says what the
+       timestamps in the file were relative to. Both default to zero, so a state
+       written by an older version is still read the way it used to be. */
+    int64_t saved_steady {0};
+    int64_t saved_wall {0};
 
-    MSGPACK_DEFINE_MAP(v, id, nodes, values)
+    MSGPACK_DEFINE_MAP(v, id, nodes, values, saved_steady, saved_wall)
 };
+
+/**
+ * Returns how much to shift the timestamps of a saved state.
+ *
+ * They were counted on a steady clock, which restarts from zero whenever the
+ * machine does: read back as they are, a value saved before a reboot looks
+ * hours younger than it is and outlives its expiration by exactly the uptime
+ * the machine had reached. The wall clock says how much time really went by
+ * while the node was down, and the difference between the two answers is the
+ * correction to apply.
+ */
+static clock::duration
+savedStateOffset(int64_t savedSteady, int64_t savedWall)
+{
+    if (savedSteady == 0 or savedWall == 0)
+        return clock::duration::zero(); /* saved by a version that did not record them */
+    const auto wallNow = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                             std::chrono::system_clock::now().time_since_epoch())
+                             .count();
+    /* A wall clock that went backwards must not be read as time regained. */
+    const auto elapsed = std::chrono::nanoseconds(std::max<int64_t>(wallNow - savedWall, 0));
+    return clock::now().time_since_epoch()
+           - clock::duration(savedSteady)
+           - std::chrono::duration_cast<clock::duration>(elapsed);
+}
 
 void
 Dht::saveState(const std::string& path) const
@@ -2892,6 +2933,10 @@ Dht::saveState(const std::string& path) const
     state.id = myid;
     state.nodes = exportNodes();
     state.values = exportValues();
+    state.saved_steady = clock::now().time_since_epoch().count();
+    state.saved_wall = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                           std::chrono::system_clock::now().time_since_epoch())
+                           .count();
     std::ofstream file(path);
     msgpack::pack(file, state);
 }
@@ -2928,7 +2973,7 @@ Dht::loadState(const std::string& path)
             tmpNodes.reserve(state.nodes.size());
             for (const auto& node : state.nodes)
                 tmpNodes.emplace_back(network_engine.insertNode(node.id, node.addr));
-            importValues(state.values);
+            importValues(state.values, savedStateOffset(state.saved_steady, state.saved_wall));
         }
     } catch (const std::exception& e) {
         if (logger_)

--- a/tests/test_persistence.cpp
+++ b/tests/test_persistence.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) 2014-2026 Savoir-faire Linux Inc.
+// SPDX-License-Identifier: MIT
+#include "test_persistence.h"
+
+#include <opendht.h>
+
+#include <chrono>
+#include <cstdio>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace test {
+CPPUNIT_TEST_SUITE_REGISTRATION(PersistenceTester);
+
+namespace {
+
+constexpr const char* STATE_PATH = "test_persistence_state";
+
+/** The saved state, as Dht writes it. */
+struct SavedState
+{
+    unsigned v {1};
+    dht::InfoHash id;
+    std::vector<dht::NodeExport> nodes;
+    std::vector<dht::ValuesExport> values;
+    int64_t saved_steady {0};
+    int64_t saved_wall {0};
+
+    MSGPACK_DEFINE_MAP(v, id, nodes, values, saved_steady, saved_wall)
+};
+
+SavedState readState(const std::string& path)
+{
+    std::ifstream file(path, std::ios::binary);
+    CPPUNIT_ASSERT(file.is_open());
+    const std::string data((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    CPPUNIT_ASSERT(not data.empty());
+    msgpack::object_handle oh = msgpack::unpack(data.data(), data.size());
+    return oh.get().as<SavedState>();
+}
+
+void writeState(const std::string& path, const SavedState& state)
+{
+    std::ofstream file(path, std::ios::binary | std::ios::trunc);
+    msgpack::pack(file, state);
+}
+
+/** Saves a node holding one value under @p key, and returns its state. */
+SavedState saveOneValue(const dht::InfoHash& key)
+{
+    std::remove(STATE_PATH);
+    dht::DhtRunner node;
+    dht::DhtRunner::Config config;
+    config.dht_config.node_config.persist_path = STATE_PATH;
+    node.run(0, config);
+    node.put(key, dht::Value(reinterpret_cast<const uint8_t*>("kept"), 4));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    node.shutdown();
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    node.join();
+    return readState(STATE_PATH);
+}
+
+/** Counts the values a node loads back from the saved state. */
+size_t loadValueCount()
+{
+    dht::DhtRunner node;
+    dht::DhtRunner::Config config;
+    config.dht_config.node_config.persist_path = STATE_PATH;
+    node.run(0, config);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    const auto count = node.exportValues().size();
+    node.join();
+    return count;
+}
+
+} // namespace
+
+void
+PersistenceTester::setUp()
+{}
+
+void
+PersistenceTester::tearDown()
+{
+    std::remove(STATE_PATH);
+    std::remove((std::string(STATE_PATH) + "_port.txt").c_str());
+}
+
+void
+PersistenceTester::testRestartKeepsValues()
+{
+    const auto key = dht::InfoHash::get("persisted key");
+    const auto state = saveOneValue(key);
+    CPPUNIT_ASSERT_EQUAL(size_t(1), state.values.size());
+
+    CPPUNIT_ASSERT_EQUAL(size_t(1), loadValueCount());
+}
+
+void
+PersistenceTester::testRebootExpiresValues()
+{
+    const auto key = dht::InfoHash::get("persisted key");
+    auto state = saveOneValue(key);
+    CPPUNIT_ASSERT_EQUAL(size_t(1), state.values.size());
+
+    /* A reboot leaves the steady clock where the saved timestamps point, while
+       the wall clock records the hour the node spent down. The value's ten
+       minute lifetime ran out during that hour. */
+    state.saved_wall -= std::chrono::nanoseconds(std::chrono::hours(1)).count();
+    writeState(STATE_PATH, state);
+
+    CPPUNIT_ASSERT_EQUAL(size_t(0), loadValueCount());
+}
+
+} // namespace test

--- a/tests/test_persistence.h
+++ b/tests/test_persistence.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2014-2026 Savoir-faire Linux Inc.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// cppunit
+#include <cppunit/TestFixture.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include <opendht/dhtrunner.h>
+
+namespace test {
+
+class PersistenceTester : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(PersistenceTester);
+    CPPUNIT_TEST(testRestartKeepsValues);
+    CPPUNIT_TEST(testRebootExpiresValues);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void setUp();
+    void tearDown();
+
+    /**
+     * A node restarted right away keeps the values it had stored.
+     */
+    void testRestartKeepsValues();
+    /**
+     * Values saved before a reboot are dated on a steady clock that starts
+     * over, so they must be aged by the wall-clock time the node was down
+     * instead of surviving it.
+     */
+    void testRebootExpiresValues();
+};
+
+} // namespace test


### PR DESCRIPTION
`Dht::saveState` writes every stored value with its `steady_clock` timestamps. That clock restarts with the machine, so a state saved before a reboot is read back with timestamps pointing into a future that never arrives: the value outlives its expiration by exactly the uptime the machine had reached, and its creation date is clamped to the restart, which also restarts its republication cycle.

The state now also records when it was saved, on both clocks. On load, the wall clock says how much time really elapsed while the node was down and the steady count says what the saved timestamps were relative to; the difference is applied to every imported value. A process restarted without a reboot sees no change, since both clocks then agree, and a state written by an earlier version carries neither field and is read exactly as before.

`tests/test_persistence.cpp` covers both: a node restarted immediately keeps its value, and a state whose save time is moved back an hour — what a reboot looks like — no longer resurrects a value whose ten minute lifetime ran out. The second test fails on master (`expected 0, actual 1`) and passes with this change.