### PR TITLE
dht: let a node that lost the network try to rejoin it

### DIFF
--- a/src/dht.cpp
+++ b/src/dht.cpp
@@ -2270,8 +2270,16 @@ Dht::onDisconnected()
 void
 Dht::bootstrap()
 {
-    if (dht4.status != NodeStatus::Disconnected || dht6.status != NodeStatus::Disconnected)
+    if (dht4.status != NodeStatus::Disconnected || dht6.status != NodeStatus::Disconnected) {
+        // The job that led here has already run, and the scheduler does not
+        // clear the handle to a job it has executed. onDisconnected() reads a
+        // set handle as "a bootstrap is already scheduled" and does nothing,
+        // so leaving it set here means the node never tries to rejoin the
+        // network once it has lost it. Clearing it is what says that no
+        // bootstrap is pending any more.
+        bootstrapJob.reset();
         return;
+    }
     if (logger_)
         logger_->debug("[{}] Bootstraping", myid.to_view());
     bootstrap_pending = false;


### PR DESCRIPTION
`Dht::onDisconnected()` only starts a bootstrap when `bootstrapJob` is unset:

```cpp
void
Dht::onDisconnected()
{
    if (not bootstrapJob)
        bootstrap();
}
```

It reads a set handle as *a bootstrap is already scheduled*. That reading does
not hold. `Scheduler::run()` erases the job from its timers and calls it, but
never clears the `Sp<Job>` the caller holds, and `Scheduler::cancel()` also
leaves the handle alone once the job is no longer in the timers:

```cpp
auto job = std::move(timer->second);
timers.erase(timer);
if (job->do_)
    job->do_();
```

A short program against the public `Scheduler` shows it:

```
before run: handle set = 1
job ran     = 1
after run: handle set = 1
cancel() after run    = 0
after cancel: handle set = 1
```

So `bootstrapJob` stays set for the life of the `Dht` as soon as one bootstrap
job has run.

That is harmless while `bootstrap()` reschedules itself, which it does for as
long as the node is disconnected. It is not harmless on the early return:

```cpp
void
Dht::bootstrap()
{
    if (dht4.status != NodeStatus::Disconnected || dht6.status != NodeStatus::Disconnected)
        return;
```

`Kad::getStatus()` returns `Connecting` when there is a dubious contact or a
ping in flight, and the transition to `Connecting` fires neither `onConnected()`
nor `onDisconnected()`, so nothing cancels the job. A bootstrap job that fires
in that window returns without rescheduling, and the retry chain is dead. When
the node then loses its last contact and goes to `Disconnected`,
`onDisconnected()` sees the stale handle and does nothing.

From that point the node stays disconnected for good. `startBootstrap()` is
only reachable from `addBootstrap()` and `connectivityChanged()`, and a node
whose network simply went away — a laptop that suspends, a phone that changes
cell — gets neither.

Clearing the handle on the early return restores the meaning `onDisconnected()`
relies on, and costs nothing elsewhere: `stopBootstrap()` still resets the
period, and `cancel()` on an already-cleared handle is a no-op.
