### PR TITLE
proxy_client: send push subscriptions deferred at token time

### DIFF
--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -368,6 +368,14 @@ private:
     std::string pushClientId_;
     std::string pushSessionId_;
 
+    /**
+     * Set when setPushNotificationToken() could not send the subscriptions
+     * because the proxy connection was not established yet. Consumed by
+     * restartListeners() once the connection comes up.
+     * Guarded by lockCurrentProxyInfos_.
+     */
+    bool pushSubscriptionPending_ {false};
+
     mutable std::mutex lockCurrentProxyInfos_;
     NodeStatus statusIpv4_ {NodeStatus::Disconnected};
     NodeStatus statusIpv6_ {NodeStatus::Disconnected};
@@ -439,6 +447,13 @@ private:
      * @param token
      */
     void resubscribe(const InfoHash& key, const size_t token, Listener& listener);
+
+#ifdef OPENDHT_PUSH_NOTIFICATIONS
+    /**
+     * Resubscribe every listener so the server learns the current push session.
+     */
+    void resubscribeAll();
+#endif
 
     /**
      * If we want to use push notifications by default.

--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -1205,6 +1205,25 @@ DhtProxyClient::restartListeners(const asio::error_code& ec)
         }
     }
     if (not deviceKey_.empty()) {
+        bool pending = false;
+        {
+            std::lock_guard l(lockCurrentProxyInfos_);
+            pending = pushSubscriptionPending_;
+            pushSubscriptionPending_ = false;
+        }
+        if (pending) {
+            // setPushNotificationToken() could not send the subscriptions
+            // because the proxy connection was not established yet. Send them
+            // now, so the server learns the session id of this run: healthy
+            // listeners are skipped by the loop below, and would otherwise
+            // never be subscribed for push at all.
+            if (logger_)
+                logger_->debug("[proxy:client] [listeners] sending deferred push subscriptions");
+            for (auto& search : searches_)
+                for (auto& listener : search.second.listeners)
+                    resubscribe(search.first, listener.first, listener.second);
+            return;
+        }
         if (logger_)
             logger_->debug("[proxy:client] [listeners] resubscribe due to a connectivity change");
         // Connectivity changed, refresh all subscribe
@@ -1427,18 +1446,36 @@ DhtProxyClient::setPushNotificationToken([[maybe_unused]] const std::string& tok
         if (deviceKey_ == token)
             return;
         deviceKey_ = token;
-        if (!(statusIpv4_ == NodeStatus::Connected || statusIpv6_ == NodeStatus::Connected))
+        if (!(statusIpv4_ == NodeStatus::Connected || statusIpv6_ == NodeStatus::Connected)) {
+            // The proxy connection is not up yet, so the subscriptions can't be
+            // sent now. Remember that they are owed: clients typically set the
+            // token while the account starts, before the first proxy reply has
+            // been received, and nothing else would ever push the current
+            // session id to the server. The server would then keep notifying
+            // this device with the session of a previous run, and every push
+            // would be discarded as PushNotificationResult::IgnoredWrongSession.
+            pushSubscriptionPending_ = true;
             return;
+        }
+        pushSubscriptionPending_ = false;
     }
+    resubscribeAll();
+#endif
+}
+
+#ifdef OPENDHT_PUSH_NOTIFICATIONS
+void
+DhtProxyClient::resubscribeAll()
+{
     if (logger_)
-        logger_->debug("[proxy:client] [push] token changed, resubscribing");
+        logger_->debug("[proxy:client] [push] resubscribing every listener");
     std::lock_guard lock(searchLock_);
     for (auto& search : searches_) {
         for (auto& listener : search.second.listeners) {
             resubscribe(search.first, listener.first, listener.second);
         }
     }
-#endif
 }
+#endif
 
 } // namespace dht


### PR DESCRIPTION
## Problem

`setPushNotificationToken()` stores the token and returns early when the proxy connection is not established yet, without ever scheduling the subscriptions it skipped:

```cpp
deviceKey_ = token;
if (!(statusIpv4_ == NodeStatus::Connected || statusIpv6_ == NodeStatus::Connected))
    return;                       // subscriptions are owed, and forgotten
```

Nothing retries them afterwards. `restartListeners()` only resubscribes listeners whose `opstate` is not `ok`, so healthy listeners keep the subscription they were created with and the server is never told the session id of the current run:

```cpp
for (auto& search : searches_)
    for (auto& listener : search.second.listeners)
        if (!listener.second.opstate->ok)
            resubscribe(search.first, listener.first, listener.second);
```

Clients set the push token while the account is starting, before the first proxy reply arrives, so this is the common path rather than a corner case.

## Consequence

The server keeps the listener registered under the session of a previous run and stamps every notification with that stale id. The client compares it against `pushSessionId_`, which is drawn once per `DhtProxyClient`, and discards the notification:

```cpp
if (sessionId != notification.end() and sessionId->second != pushSessionId_)
    return PushNotificationResult::IgnoredWrongSession;
```

The device silently stops receiving anything that depends on push: incoming calls, messages, and the diagnostic ping.

## Evidence

Measured on an Android device (Jami 20260807-01, OpenDHT 4.3.1 client, 4.2.0 proxy):

- **83 of 83** push notifications received were rejected with `IgnoredWrongSession`.
- Reproduced with the app in foreground and in background, screen locked and unlocked, battery optimised and whitelisted, and across full application restarts.
- The DHT side was verified healthy throughout: the device announcement was published, the caller's `PeerConnectionRequest` was present on the DHT at the expected key, and the push was delivered by the correct proxy at high priority.
- Restarting the proxy instance cleared the stale listeners. After that the device received **no push at all**, confirming it never subscribes for push with its current session.

## Fix

Remember the skipped subscriptions in `pushSubscriptionPending_` and send them from `restartListeners()` once the connection comes up.

`searchLock_` is already held at that point, so the loop is inlined rather than calling `resubscribeAll()`, which would deadlock. In `setPushNotificationToken()`, `lockCurrentProxyInfos_` is released before `searchLock_` is acquired, keeping the lock order consistent with `restartListeners()`.

Behaviour is unchanged when the connection is already established.
