### PR TITLE
proxy_client: resubscribe when a push is rejected as stale

### DIFF
--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -368,6 +368,14 @@ private:
     std::string pushClientId_;
     std::string pushSessionId_;
 
+    /**
+     * Set when setPushNotificationToken() could not send the subscriptions
+     * because the proxy connection was not established yet. Consumed by
+     * restartListeners() once the connection comes up.
+     * Guarded by lockCurrentProxyInfos_.
+     */
+    bool pushSubscriptionPending_ {false};
+
     mutable std::mutex lockCurrentProxyInfos_;
     NodeStatus statusIpv4_ {NodeStatus::Disconnected};
     NodeStatus statusIpv6_ {NodeStatus::Disconnected};
@@ -439,6 +447,13 @@ private:
      * @param token
      */
     void resubscribe(const InfoHash& key, const size_t token, Listener& listener);
+
+#ifdef OPENDHT_PUSH_NOTIFICATIONS
+    /**
+     * Resubscribe every listener so the server learns the current push session.
+     */
+    void resubscribeAll();
+#endif
 
     /**
      * If we want to use push notifications by default.

--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -1205,6 +1205,25 @@ DhtProxyClient::restartListeners(const asio::error_code& ec)
         }
     }
     if (not deviceKey_.empty()) {
+        bool pending = false;
+        {
+            std::lock_guard l(lockCurrentProxyInfos_);
+            pending = pushSubscriptionPending_;
+            pushSubscriptionPending_ = false;
+        }
+        if (pending) {
+            // setPushNotificationToken() could not send the subscriptions
+            // because the proxy connection was not established yet. Send them
+            // now, so the server learns the session id of this run: healthy
+            // listeners are skipped by the loop below, and would otherwise
+            // never be subscribed for push at all.
+            if (logger_)
+                logger_->debug("[proxy:client] [listeners] sending deferred push subscriptions");
+            for (auto& search : searches_)
+                for (auto& listener : search.second.listeners)
+                    resubscribe(search.first, listener.first, listener.second);
+            return;
+        }
         if (logger_)
             logger_->debug("[proxy:client] [listeners] resubscribe due to a connectivity change");
         // Connectivity changed, refresh all subscribe
@@ -1427,18 +1446,36 @@ DhtProxyClient::setPushNotificationToken([[maybe_unused]] const std::string& tok
         if (deviceKey_ == token)
             return;
         deviceKey_ = token;
-        if (!(statusIpv4_ == NodeStatus::Connected || statusIpv6_ == NodeStatus::Connected))
+        if (!(statusIpv4_ == NodeStatus::Connected || statusIpv6_ == NodeStatus::Connected)) {
+            // The proxy connection is not up yet, so the subscriptions can't be
+            // sent now. Remember that they are owed: clients typically set the
+            // token while the account starts, before the first proxy reply has
+            // been received, and nothing else would ever push the current
+            // session id to the server. The server would then keep notifying
+            // this device with the session of a previous run, and every push
+            // would be discarded as PushNotificationResult::IgnoredWrongSession.
+            pushSubscriptionPending_ = true;
             return;
+        }
+        pushSubscriptionPending_ = false;
     }
+    resubscribeAll();
+#endif
+}
+
+#ifdef OPENDHT_PUSH_NOTIFICATIONS
+void
+DhtProxyClient::resubscribeAll()
+{
     if (logger_)
-        logger_->debug("[proxy:client] [push] token changed, resubscribing");
+        logger_->debug("[proxy:client] [push] resubscribing every listener");
     std::lock_guard lock(searchLock_);
     for (auto& search : searches_) {
         for (auto& listener : search.second.listeners) {
             resubscribe(search.first, listener.first, listener.second);
         }
     }
-#endif
 }
+#endif
 
 } // namespace dht

--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -1281,6 +1281,22 @@ DhtProxyClient::pushNotificationReceived([[maybe_unused]] const std::map<std::st
         if (sessionId != notification.end() and sessionId->second != pushSessionId_) {
             if (logger_)
                 logger_->debug("[proxy:client] [push] ignoring push for other session");
+            // A mismatch proves the server still has a listener registered under a previous
+            // session: it keeps waking this device for notifications that can only be
+            // discarded, and the values they announce are never fetched. Ask for the
+            // subscriptions to be sent again so the server learns the current session,
+            // instead of waiting for an unrelated event to trigger one.
+            //
+            // restartListeners() is rate limited by its own timer: stale listeners notify in
+            // bursts, and rearming the timer on each one simply coalesces them into a single
+            // pass.
+            {
+                std::lock_guard l(lockCurrentProxyInfos_);
+                pushSubscriptionPending_ = true;
+            }
+            listenerRestartTimer_->expires_at(std::chrono::steady_clock::now());
+            listenerRestartTimer_->async_wait(
+                std::bind(&DhtProxyClient::restartListeners, this, std::placeholders::_1));
             return PushNotificationResult::IgnoredWrongSession;
         }
         std::lock_guard lock(searchLock_);


### PR DESCRIPTION
## Problem

`pushNotificationReceived()` drops a notification whose session id does not match, and does nothing else:

```cpp
if (sessionId != notification.end() and sessionId->second != pushSessionId_) {
    logger_->debug("[proxy:client] [push] ignoring push for other session");
    return PushNotificationResult::IgnoredWrongSession;
}
```

Nothing tells the server it is notifying with a session the client no longer knows. It keeps waking the device for notifications that can only be discarded, and the values they announce are never fetched.

## Measured impact

On Android, a call arriving while the account is deactivated in doze:

- the push carrying the `PeerConnectionRequest` is rejected as stale;
- the daemon therefore never learns which value to fetch;
- the call is saved only by the wake-up side effect — the account reconnects and rediscovers the value through the DHT.

That fallback took between **1.7 s and more than 31 s** across the runs measured. A call rings for 30 to 45 seconds, so delivery is left to a race the caller sometimes loses.

Across four calls on two devices (Pixel 5 / Android 14, Galaxy S22+ / Android 16), the push carrying the call was rejected **4 times out of 4**. One device measured 54% of all its pushes discarded this way, another 96%.

## Fix

Treat a session mismatch as evidence that the server holds stale listeners, and ask for the subscriptions to be sent again.

It reuses `listenerRestartTimer_` and the `pushSubscriptionPending_` flag, so recovery follows the same path as a subscription that could not be sent at token time. Stale listeners notify in bursts; rearming the timer cancels the pending wait, so a burst coalesces into a single pass (`restartListeners()` returns early on `operation_aborted`).

## Relationship to #901

Complementary, not a replacement:

| | Role |
|---|---|
| #901 | prevents the mismatch from occurring |
| this | recovers automatically if it occurs anyway |

Either can be merged alone. Together they make push delivery deterministic instead of dependent on a DHT re-discovery race.