### PR TITLE
proxy_client: give subscribe requests a deadline

### DIFF
--- a/include/opendht/proxy.h
+++ b/include/opendht/proxy.h
@@ -10,6 +10,14 @@ namespace proxy {
 constexpr const std::chrono::hours OP_TIMEOUT {24}; // one day
 constexpr const std::chrono::hours OP_MARGIN {2};   // two hours
 
+/**
+ * Deadline for a subscribe request to complete. Unlike a listen, a subscribe is a short
+ * request: the server answers immediately and the device then relies on push notifications.
+ * Nothing else observes it, so without a deadline a subscribe stalled in name resolution,
+ * connection or TLS handshake would never complete nor fail.
+ */
+constexpr const std::chrono::seconds SUBSCRIBE_TIMEOUT {20};
+
 using ListenToken = uint64_t;
 
 } // namespace proxy

--- a/src/dht_proxy_client.cpp
+++ b/src/dht_proxy_client.cpp
@@ -1075,6 +1075,12 @@ DhtProxyClient::sendListen(const restinio::http_request_header_t& header,
         request->set_body(body);
 #endif
         auto rxBuf = std::make_shared<LineSplit>();
+        // Completion flag shared with the subscribe deadline armed below. The request
+        // callbacks replace each other rather than accumulating, so the flag is raised from
+        // the single on_done callback instead of a dedicated one.
+        std::shared_ptr<std::atomic_bool> subscribeDone;
+        if (method != ListenMethod::LISTEN)
+            subscribeDone = std::make_shared<std::atomic_bool>(false);
         request->add_on_body_callback([this, reqid, opstate, rxBuf, cb](const char* at, size_t length) {
             try {
                 auto& b = *rxBuf;
@@ -1113,7 +1119,9 @@ DhtProxyClient::sendListen(const restinio::http_request_header_t& header,
                 opstate->ok.store(false);
             }
         });
-        request->add_on_done_callback([this, opstate, reqid](const http::Response& response) {
+        request->add_on_done_callback([this, opstate, reqid, subscribeDone](const http::Response& response) {
+            if (subscribeDone)
+                subscribeDone->store(true);
             if (response.status_code != 200) {
                 if (logger_)
                     logger_->error("[proxy:client] [listen] send request #{} failed with code={}",
@@ -1138,6 +1146,29 @@ DhtProxyClient::sendListen(const restinio::http_request_header_t& header,
                 request->get_connection()->set_keepalive(seconds);
             }
         });
+        if (subscribeDone) {
+            // Give the subscribe a deadline. Nothing else would ever release it: the
+            // keepalive above is only armed once the server has answered, and no other
+            // request in this client sets a timeout. A subscribe that never completes
+            // leaves the listener registered locally while the server never learns about
+            // it, so the device stops being notified without anything reporting an error.
+            // Cancelling runs the on_done callback, which clears the request, and failing
+            // the operation lets restartListeners() send the subscription again.
+            std::weak_ptr<http::Request> wreq = request;
+            request->timeout(proxy::SUBSCRIBE_TIMEOUT,
+                             [this, reqid, opstate, subscribeDone, wreq](const asio::error_code& ec) {
+                                 if (ec == asio::error::operation_aborted or subscribeDone->load()
+                                     or isDestroying_)
+                                     return;
+                                 if (logger_)
+                                     logger_->error("[proxy:client] [listen] subscribe request #{} timed out",
+                                                    reqid);
+                                 opstate->ok.store(false);
+                                 if (auto req = wreq.lock())
+                                     req->cancel();
+                                 opFailed();
+                             });
+        }
         request->send();
     } catch (const std::exception& e) {
         if (logger_)


### PR DESCRIPTION
## Problem

`DhtProxyClient` never sets a timeout on any request. The API exists in `http.h`:

```cpp
void timeout(const std::chrono::seconds& timeout, HandlerCb cb = {});
```

but `grep -c 'timeout(' src/dht_proxy_client.cpp` returns **0**, and the defaults are `timeout_ {0}` / `timeoutCb_ {}`. In `http.cpp` the deadline is only armed when a callback was registered:

```cpp
if (conn_ && timeoutCb_)
    conn_->timeout(timeout_, std::move(timeoutCb_));
```

So no request in this client is ever under a deadline.

For a streaming listen that is intended: the server holds the connection open. But when push notifications are enabled, `deviceKey_` is non-empty and every listener is sent as a **subscribe** instead, which is a short request the server answers immediately.

Nothing else observes it. The keepalive is only armed once a 200 has been received:

```cpp
request->add_on_status_callback([request, seconds = this->listenKeepIdle()](unsigned status_code) {
    if (status_code == 200) {
        request->get_connection()->set_keepalive(seconds);
    }
});
```

A subscribe that stalls in name resolution, TCP connect or the TLS handshake therefore **never completes and never fails**. The listener stays registered locally while the server never learns about it: the device silently stops being notified, and nothing reports an error. The most likely moment for this is right after a wake-up, when the network stack is still settling.

## Fix

Arm a deadline on subscribe and resubscribe requests only. On expiry, cancel the request and fail the operation, so `restartListeners()` sends the subscription again.

Streaming listens are untouched — they are long lived by design.

Three details worth noting:

- request callbacks **replace** each other rather than accumulating (`add_on_state_change_callback` assigns), so the completion flag is raised from the existing `on_done` callback rather than a second one;
- the request is captured as a `weak_ptr` to avoid a reference cycle with its own callback;
- `cancel()` is called outside `requestLock_`, consistent with the five existing call sites.

## Status of validation

I want to be explicit about what is and is not demonstrated.

**Verified:** the gap is real and visible in the code; the patch compiles for arm64 and runs on a device; under normal use it produces **zero spurious timeouts**, and the account connects and receives pushes as before.

**Not verified:** I have not observed the stall in the wild. Across roughly a dozen forced-doze reproductions the deadline never fired, so I cannot claim this fixes any specific user-visible failure. Forced doze of a few minutes does not appear to degrade the network stack the way an overnight idle does.

The log line it adds is therefore also a detector: if `subscribe request #N timed out` shows up on a device that failed to ring, the stall is confirmed and this patch recovered from it. A build carrying this patch is currently deployed on a test device for that purpose.

I am proposing it on the strength of the code-level gap rather than on a reproduction, and I would rather say so than overstate it.
